### PR TITLE
Added Python and Javascript linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: lint
+
+on: pull_request
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Lint with Flake8
+        run: |
+          pip install flake8
+          flake8 --ignore=E501,E731 server
+
+  javascipt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up Node 12.x
+        uses: actions/setup-node@v1
+        with:
+            node-version: 12.x
+      - name: Lint with ESLint
+        run: |
+          npm install eslint
+          npx eslint src

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## TransitMatters Data Dashboard
+![](https://github.com/transitmatters/t-performance-dash/workflows/lint/badge.svg)
 
 This is the repository for the TransitMatters data dashboard. Client code is written in JavaScript with React, and the backend is written in Python with Flask.
 


### PR DESCRIPTION
- Added GitHub Actions workflow for linting Python files in `server/` and JS files in `src/` (note this will only run on Pull Requests)
- Added lint status badge to `README.md`