### PR TITLE
Add color to station names in chart titles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -177,15 +177,18 @@ class App extends React.Component {
     }
   }
 
-  graphTitle(prefix, showDirection, showTo) {
+  locationDescription(bothStops) {
     const { from, to, line } = this.state.configuration;
+    var result = {};
+
     if (from && to) {
-      const direction = showDirection ? ` ${station_direction(from, to, line)}` : ""
-      const preposition = showTo ? "from" : "at";
-      const suffix = showTo ? `to ${to.stop_name}` : "";
-      return `${prefix} ${preposition} ${from.stop_name}${direction} ${suffix}`;
+      result['bothStops'] = bothStops;
+      result['to'] = to.stop_name;
+      result['from'] = from.stop_name;
+      result['direction'] = station_direction(from, to, line);
+      result['line'] = line;
     }
-    return prefix;
+    return result;
   }
 
   chartTimeframe() {
@@ -233,7 +236,8 @@ class App extends React.Component {
   renderCharts() {
     return <div className='charts main-column'>
       <Line
-        title={this.graphTitle('Travel times', false, true)}
+        title={"Travel times"}
+        location={this.locationDescription(true)}
         tooltipUnit={"travel time"}
         seriesName={'traveltimes'}
         isLoading={this.getIsLoadingDataset('traveltimes')}
@@ -246,7 +250,8 @@ class App extends React.Component {
         legend={true}
       />
       <Line
-        title={this.graphTitle('Time between trains (headways)', true, false)}
+        title={'Time between trains (headways)'}
+        location={this.locationDescription(false)}
         tooltipUnit={"headway"}
         seriesName={'headways'}
         isLoading={this.getIsLoadingDataset('headways')}
@@ -259,7 +264,8 @@ class App extends React.Component {
         legend={true}
       />
       <Line
-        title={this.graphTitle('Time spent at station (dwells)', true, false)}
+        title={'Time spent at station (dwells)'}
+        location={this.locationDescription(false)}
         tooltipUnit={"dwell time"}
         seriesName={'dwells'}
         isLoading={this.getIsLoadingDataset('dwells')}

--- a/src/App.js
+++ b/src/App.js
@@ -179,16 +179,17 @@ class App extends React.Component {
 
   locationDescription(bothStops) {
     const { from, to, line } = this.state.configuration;
-    var result = {};
 
     if (from && to) {
-      result['bothStops'] = bothStops;
-      result['to'] = to.stop_name;
-      result['from'] = from.stop_name;
-      result['direction'] = station_direction(from, to, line);
-      result['line'] = line;
+      return {
+	bothStops: bothStops,
+	to: to.stop_name,
+	from: from.stop_name,
+	direction: station_direction(from, to, line),
+	line: line,
+      };
     }
-    return result;
+    return {};
   }
 
   chartTimeframe() {

--- a/src/App.js
+++ b/src/App.js
@@ -182,11 +182,11 @@ class App extends React.Component {
 
     if (from && to) {
       return {
-	bothStops: bothStops,
-	to: to.stop_name,
-	from: from.stop_name,
-	direction: station_direction(from, to, line),
-	line: line,
+        bothStops: bothStops,
+        to: to.stop_name,
+        from: from.stop_name,
+        direction: station_direction(from, to, line),
+        line: line,
       };
     }
     return {};

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,5 +1,5 @@
 const get_line_color = (line) => {
-  var line_color = 'grey';
+  let line_color = 'grey';
 
   switch(line) {
     case 'Red':
@@ -26,13 +26,13 @@ const parse_location_description = (location) => {
 
   var line_color = get_line_color(location['line']);
 
-  result.push([location['from'], line_color])
+  result.push([location['from'], line_color]);
 
   if (location['bothStops']) {
-    result.push([' to ', 'grey'])
-    result.push([location['to'], line_color])
+    result.push([' to ', 'grey']);
+    result.push([location['to'], line_color]);
   } else {
-    result.push([` ${location['direction']}`, 'grey'])
+    result.push([` ${location['direction']}`, 'grey']);
   }
   return result;
 };
@@ -42,27 +42,32 @@ const drawTitle = (title, location, chart) => {
   ctx.save();
 
   const left_buffer = 50;
+  const midspace = 10;
   const vpos_row1 = 25;
   const vpos_row2 = 50;
 
-  var title_width = ctx.measureText(title).width
-  var location_width = parse_location_description(location).map(x => ctx.measureText(x[0]).width).reduce((a,b) => {return a+b;}, 0)
+  var position;
 
-  if ((title_width + location_width + left_buffer) > chart.chart.width) {
+  var title_width = ctx.measureText(title).width;
+  var location_width = parse_location_description(location)
+      .map(x => ctx.measureText(x[0]).width)
+      .reduce((a,b) => a + b, 0);
+
+  if ((left_buffer + title_width + midspace + location_width) > chart.chart.width) {
     // small screen: centered title stacks vertically
     ctx.textAlign = 'center';
     ctx.fillStyle = 'grey';
     ctx.fillText(title, chart.chart.width/2, vpos_row1);
 
     ctx.textAlign = 'left';
-    var position = chart.chart.width/2 - location_width/2;
-    parse_location_description(location).forEach(
-      tuple => {
-        ctx.fillStyle = tuple[1];
-        ctx.fillText(tuple[0], position, vpos_row2);
-        position += ctx.measureText(tuple[0]).width;
-      }
-    )
+    position = chart.chart.width/2 - location_width/2;
+
+    for (const [word, color] of parse_location_description(location)) {
+      ctx.fillStyle = color;
+      ctx.fillText(word, position, vpos_row2);
+      position += ctx.measureText(word).width;
+    }
+
   } else {
     // larger screen
     // Primary chart title, grey and left
@@ -72,14 +77,12 @@ const drawTitle = (title, location, chart) => {
 
     // location components are aligned right
     ctx.textAlign = 'right';
-    var position = chart.chart.width;
-    parse_location_description(location).reverse().forEach(
-      tuple => {
-        ctx.fillStyle = tuple[1];
-        ctx.fillText(tuple[0], position, vpos_row2);
-        position -= ctx.measureText(tuple[0]).width;
-      }
-    )
+    position = chart.chart.width;
+    for (const [word, color] of parse_location_description(location).reverse()) {
+      ctx.fillStyle = color;
+      ctx.fillText(word, position, vpos_row2);
+      position -= ctx.measureText(word).width;
+    }
   }
   ctx.restore();
 }

--- a/src/Title.js
+++ b/src/Title.js
@@ -4,9 +4,9 @@ const getLineColor = (lineName) => colorsForLine[lineName] || 'black';
 const titleColor = 'gray';
 
 const parse_location_description = (location) => {
-  var result = [];
+  let result = [];
 
-  var lineColor = getLineColor(location['line']);
+  const lineColor = getLineColor(location['line']);
 
   result.push([location['from'], lineColor]);
 
@@ -20,7 +20,7 @@ const parse_location_description = (location) => {
 };
 
 const drawTitle = (title, location, chart) => {
-  var ctx = chart.chart.ctx;
+  let ctx = chart.chart.ctx;
   ctx.save();
 
   const leftMargin = 50;
@@ -28,12 +28,12 @@ const drawTitle = (title, location, chart) => {
   const vpos_row1 = 25;
   const vpos_row2 = 50;
 
-  var position;
+  let position;
 
-  var titleWidth = ctx.measureText(title).width;
-  var locationWidth = parse_location_description(location)
-      .map(x => ctx.measureText(x[0]).width)
-      .reduce((a,b) => a + b, 0);
+  const titleWidth = ctx.measureText(title).width;
+  const locationWidth = parse_location_description(location)
+	.map(x => ctx.measureText(x[0]).width)
+	.reduce((a,b) => a + b, 0);
 
   if ((leftMargin + titleWidth + minGap + locationWidth) > chart.chart.width) {
     // small screen: centered title stacks vertically

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,0 +1,87 @@
+const get_line_color = (line) => {
+  var line_color = 'grey';
+
+  switch(line) {
+    case 'Red':
+      line_color = '#d13434';
+      break;
+    case 'Orange':
+      line_color = '#e66f00';
+      break;
+    case 'Blue':
+      line_color = '#0e3d8c';
+      break;
+    case 'Green':
+      line_color = '#159765';
+      break;
+    default:
+      break;
+    }
+
+  return line_color;
+}
+
+const parse_location_description = (location) => {
+  var result = [];
+
+  var line_color = get_line_color(location['line']);
+
+  result.push([location['from'], line_color])
+
+  if (location['bothStops']) {
+    result.push([' to ', 'grey'])
+    result.push([location['to'], line_color])
+  } else {
+    result.push([` ${location['direction']}`, 'grey'])
+  }
+  return result;
+};
+
+const drawTitle = (title, location, chart) => {
+  var ctx = chart.chart.ctx;
+  ctx.save();
+
+  const left_buffer = 50;
+  const vpos_row1 = 25;
+  const vpos_row2 = 50;
+
+  var title_width = ctx.measureText(title).width
+  var location_width = parse_location_description(location).map(x => ctx.measureText(x[0]).width).reduce((a,b) => {return a+b;}, 0)
+
+  if ((title_width + location_width + left_buffer) > chart.chart.width) {
+    // small screen: centered title stacks vertically
+    ctx.textAlign = 'center';
+    ctx.fillStyle = 'grey';
+    ctx.fillText(title, chart.chart.width/2, vpos_row1);
+
+    ctx.textAlign = 'left';
+    var position = chart.chart.width/2 - location_width/2;
+    parse_location_description(location).forEach(
+      tuple => {
+        ctx.fillStyle = tuple[1];
+        ctx.fillText(tuple[0], position, vpos_row2);
+        position += ctx.measureText(tuple[0]).width;
+      }
+    )
+  } else {
+    // larger screen
+    // Primary chart title, grey and left
+    ctx.textAlign = 'left';
+    ctx.fillStyle = 'gray';
+    ctx.fillText(title, left_buffer, vpos_row2);
+
+    // location components are aligned right
+    ctx.textAlign = 'right';
+    var position = chart.chart.width;
+    parse_location_description(location).reverse().forEach(
+      tuple => {
+        ctx.fillStyle = tuple[1];
+        ctx.fillText(tuple[0], position, vpos_row2);
+        position -= ctx.measureText(tuple[0]).width;
+      }
+    )
+  }
+  ctx.restore();
+}
+
+export default drawTitle;

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,38 +1,20 @@
-const get_line_color = (line) => {
-  let line_color = 'grey';
+import { colorsForLine } from './constants.js';
 
-  switch(line) {
-    case 'Red':
-      line_color = '#d13434';
-      break;
-    case 'Orange':
-      line_color = '#e66f00';
-      break;
-    case 'Blue':
-      line_color = '#0e3d8c';
-      break;
-    case 'Green':
-      line_color = '#159765';
-      break;
-    default:
-      break;
-    }
-
-  return line_color;
-}
+const getLineColor = (lineName) => colorsForLine[lineName] || 'black';
+const titleColor = 'gray';
 
 const parse_location_description = (location) => {
   var result = [];
 
-  var line_color = get_line_color(location['line']);
+  var lineColor = getLineColor(location['line']);
 
-  result.push([location['from'], line_color]);
+  result.push([location['from'], lineColor]);
 
   if (location['bothStops']) {
-    result.push([' to ', 'grey']);
-    result.push([location['to'], line_color]);
+    result.push([' to ', titleColor]);
+    result.push([location['to'], lineColor]);
   } else {
-    result.push([` ${location['direction']}`, 'grey']);
+    result.push([` ${location['direction']}`, titleColor]);
   }
   return result;
 };
@@ -41,26 +23,26 @@ const drawTitle = (title, location, chart) => {
   var ctx = chart.chart.ctx;
   ctx.save();
 
-  const left_buffer = 50;
-  const midspace = 10;
+  const leftMargin = 50;
+  const minGap = 10;
   const vpos_row1 = 25;
   const vpos_row2 = 50;
 
   var position;
 
-  var title_width = ctx.measureText(title).width;
-  var location_width = parse_location_description(location)
+  var titleWidth = ctx.measureText(title).width;
+  var locationWidth = parse_location_description(location)
       .map(x => ctx.measureText(x[0]).width)
       .reduce((a,b) => a + b, 0);
 
-  if ((left_buffer + title_width + midspace + location_width) > chart.chart.width) {
+  if ((leftMargin + titleWidth + minGap + locationWidth) > chart.chart.width) {
     // small screen: centered title stacks vertically
     ctx.textAlign = 'center';
-    ctx.fillStyle = 'grey';
+    ctx.fillStyle = titleColor;
     ctx.fillText(title, chart.chart.width/2, vpos_row1);
 
     ctx.textAlign = 'left';
-    position = chart.chart.width/2 - location_width/2;
+    position = chart.chart.width/2 - locationWidth/2;
 
     for (const [word, color] of parse_location_description(location)) {
       ctx.fillStyle = color;
@@ -70,10 +52,10 @@ const drawTitle = (title, location, chart) => {
 
   } else {
     // larger screen
-    // Primary chart title, grey and left
+    // Primary chart title goes left left
     ctx.textAlign = 'left';
-    ctx.fillStyle = 'gray';
-    ctx.fillText(title, left_buffer, vpos_row2);
+    ctx.fillStyle = titleColor;
+    ctx.fillText(title, leftMargin, vpos_row2);
 
     // location components are aligned right
     ctx.textAlign = 'right';
@@ -85,6 +67,6 @@ const drawTitle = (title, location, chart) => {
     }
   }
   ctx.restore();
-}
+};
 
 export default drawTitle;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,10 @@
+export const colorsForLine = {
+  Red: '#d13434',
+  Orange: '#e66f00',
+  Blue: '#0e3d8c',
+  Green: '#159765',
+};
+
 export const stations = {
 	"Red": [{
 		"stop_name": "Alewife",
@@ -1096,7 +1103,7 @@ const createConfigPresetValue = (line, fromStationName, toStationName, date) => 
 		from: fromStation,
 		to: toStation,
 	}
-}
+};
 
 export const configPresets = [
 	{

--- a/src/line.js
+++ b/src/line.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Line } from 'react-chartjs-2';
 import Legend from './Legend';
+import drawTitle from './Title';
 
 const departure_from_normal_string = (metric, benchmark) => {
   const ratio = metric / benchmark;
@@ -36,39 +37,6 @@ const point_colors = (data, metric_field, benchmark_field) => {
     return '#1c1c1c'; //whatever
   });
 }
-
-const parse_location_description = (location) => {
-  var result = [];
-
-  var line_color = 'grey';
-
-  switch(location['line']) {
-    case 'Red':
-      line_color = '#d13434';
-      break;
-    case 'Orange':
-      line_color = '#e66f00';
-      break;
-    case 'Blue':
-      line_color = '#0e3d8c';
-      break;
-    case 'Green':
-      line_color = '#159765';
-      break;
-    default:
-      break;
-    }
-
-  result.push([location['from'], line_color])
-
-  if (location['bothStops']) {
-    result.push([' to ', 'grey'])
-    result.push([location['to'], line_color])
-  } else {
-    result.push([` ${location['direction']}`, 'grey'])
-  }
-  return result;
-};
 
 class LineClass extends React.Component {
 
@@ -135,8 +103,13 @@ class LineClass extends React.Component {
               //   annotations: alert_annotations
               // },
               maintainAspectRatio: false,
+              layout: {
+                padding: {
+                  top: 25
+                }
+              },
               title: {
-		// empty title here to leave space and set font for the title process in afterDraw
+                // empty title here to leave space and set font for the drawTitle process
                 display: true,
                 text: "",
                 fontSize: 16
@@ -187,28 +160,8 @@ class LineClass extends React.Component {
               }
             }}
             plugins={{
-              afterDraw: (chart, easing) => {
-		var ctx = chart.chart.ctx;
-		ctx.save();
-
-		// Primary chart title, grey and left
-		ctx.textAlign = 'left';
-		ctx.fillStyle = 'gray';
-		ctx.fillText(this.props.title, 50, 25);
-
-		// location components are aligned right
-		ctx.textAlign = 'right';
-		var position = chart.chart.width;
-		parse_location_description(this.props.location).reverse().forEach(
-		  tuple => {
-		    ctx.fillStyle = tuple[1];
-		    ctx.fillText(tuple[0], position, 25);
-		    position -= ctx.measureText(tuple[0]).width;
-		  }
-		)
-		ctx.restore();
-	      }
-	    }}
+              afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
+            }}
           />
         </div>
         {this.props.legend && <Legend />}

--- a/src/line.js
+++ b/src/line.js
@@ -37,6 +37,39 @@ const point_colors = (data, metric_field, benchmark_field) => {
   });
 }
 
+const parse_location_description = (location) => {
+  var result = [];
+
+  var line_color = 'grey';
+
+  switch(location['line']) {
+    case 'Red':
+      line_color = '#d13434';
+      break;
+    case 'Orange':
+      line_color = '#e66f00';
+      break;
+    case 'Blue':
+      line_color = '#0e3d8c';
+      break;
+    case 'Green':
+      line_color = '#159765';
+      break;
+    default:
+      break;
+    }
+
+  result.push([location['from'], line_color])
+
+  if (location['bothStops']) {
+    result.push([' to ', 'grey'])
+    result.push([location['to'], line_color])
+  } else {
+    result.push([` ${location['direction']}`, 'grey'])
+  }
+  return result;
+};
+
 class LineClass extends React.Component {
 
   render() {
@@ -103,8 +136,9 @@ class LineClass extends React.Component {
               // },
               maintainAspectRatio: false,
               title: {
+		// empty title here to leave space and set font for the title process in afterDraw
                 display: true,
-                text: this.props.title,
+                text: "",
                 fontSize: 16
               },
               tooltips: {
@@ -152,6 +186,29 @@ class LineClass extends React.Component {
                 ]
               }
             }}
+            plugins={{
+              afterDraw: (chart, easing) => {
+		var ctx = chart.chart.ctx;
+		ctx.save();
+
+		// Primary chart title, grey and left
+		ctx.textAlign = 'left';
+		ctx.fillStyle = 'gray';
+		ctx.fillText(this.props.title, 50, 25);
+
+		// location components are aligned right
+		ctx.textAlign = 'right';
+		var position = chart.chart.width;
+		parse_location_description(this.props.location).reverse().forEach(
+		  tuple => {
+		    ctx.fillStyle = tuple[1];
+		    ctx.fillText(tuple[0], position, 25);
+		    position -= ctx.measureText(tuple[0]).width;
+		  }
+		)
+		ctx.restore();
+	      }
+	    }}
           />
         </div>
         {this.props.legend && <Legend />}


### PR DESCRIPTION
I've had a go at implementing one of the improved designs for the chart titles. I think the splitting it into smaller chunks helps readability, and I'm a fan of the added color for orientation. (My preferred option with a highlighted background is substantially more difficult to do in HTML canvas, since you have to draw the background color rectangles separately...)

I'm in no way a front-end dev, so let me know your thoughts, esp. if I've done something totally funky.  There are some issues with words overlapping on very small windows- resolving this might make things complicated at best, and infeasible at worst.

Anyway, I'm curious to hear others' thoughts on this approach...


![Blue Line - 2020-10-07 - TransitMatters Data Dashboard - Mozilla Firefox 2020-11-19 5_56_19 PM](https://user-images.githubusercontent.com/8498946/99734356-b11c2100-2a90-11eb-9a9a-3312b5dc551f.png)

![red_demo](https://user-images.githubusercontent.com/8498946/99735713-14a74e00-2a93-11eb-85cd-56781c886868.png)


![overlap_issue](https://user-images.githubusercontent.com/8498946/99735540-c5611d80-2a92-11eb-84a2-42f0698d734c.png)
