### PR TITLE
Add support for dashboard-beta.transitmatters.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TM_BACKEND_CERT_ARN: ${{ secrets.TM_BACKEND_CERT_ARN }}
+      TM_BACKEND_CERT_ARN_BETA: ${{ secrets.TM_BACKEND_CERT_ARN_BETA }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,7 @@ export AWS_PAGER=""
 
 [[ "$1" = "beta" ]] && ENV_SUFFIX="-beta" || ENV_SUFFIX=""
 [[ "$1" = "beta" ]] && CHALICE_STAGE="beta" || CHALICE_STAGE="production"
+[[ "$1" = "beta" ]] && FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN_BETA" || FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN"
 [[ "$1" = "beta" ]] && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN_BETA" || BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN"
 
 BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
@@ -26,7 +27,7 @@ npm run build
 pushd server/ > /dev/null
 pipenv run chalice package --stage $CHALICE_STAGE --merge-template frontend-cfn.json cfn/
 aws cloudformation package --template-file cfn/sam.json --s3-bucket $BACKEND_BUCKET --output-template-file cfn/packaged.yaml
-aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides TMFrontendHostname=$FRONTEND_HOSTNAME TMBackendCertArn=$BACKEND_CERT_ARN
+aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides TMFrontendHostname=$FRONTEND_HOSTNAME TMFrontendCertArn=$FRONTEND_CERT_ARN TMBackendCertArn=$BACKEND_CERT_ARN
 popd > /dev/null
 aws s3 sync build/ s3://$FRONTEND_HOSTNAME
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,17 +5,31 @@ export AWS_PROFILE=transitmatters
 export AWS_REGION=us-east-1
 export AWS_PAGER=""
 
+# Setup environment stuff
+# By default deploy to production, otherwise "./deploy.sh beta" deploys to beta stage
+[[ "$1" = "beta" ]] && ENV_SUFFIX="-beta" || ENV_SUFFIX=""
+[[ "$1" = "beta" ]] && CHALICE_STAGE="beta" || CHALICE_STAGE="production"
+
+BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
+FRONTEND_HOSTNAME=dashboard$ENV_SUFFIX.transitmatters.org # Must match in .chalice/config.json!
+CF_STACK_NAME=datadashboard$ENV_SUFFIX
+
+echo "Starting $CHALICE_STAGE deployment"
+echo "Backend bucket: $BACKEND_BUCKET"
+echo "Hostname: $FRONTEND_HOSTNAME"
+echo "CloudFormation stack name: $CF_STACK_NAME"
+
 npm run build
 
 pushd server/ > /dev/null
-pipenv run chalice package --merge-template frontend-cfn.json cfn/
-aws cloudformation package --template-file cfn/sam.json --s3-bucket datadashboard-backend --output-template-file cfn/packaged.yaml
-aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name datadashboard --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset
+pipenv run chalice package --stage $CHALICE_STAGE --merge-template frontend-cfn.json cfn/
+aws cloudformation package --template-file cfn/sam.json --s3-bucket $BACKEND_BUCKET --output-template-file cfn/packaged.yaml
+aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides TMFrontendHostname=$FRONTEND_HOSTNAME
 popd > /dev/null
-aws s3 sync build/ s3://dashboard.transitmatters.org
+aws s3 sync build/ s3://$FRONTEND_HOSTNAME
 
 # Grab the cloudfront ID and invalidate its cache
-CLOUDFRONT_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items!=null] | [?contains(Aliases.Items, 'dashboard.transitmatters.org')].Id | [0]" --output text)
+CLOUDFRONT_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items!=null] | [?contains(Aliases.Items, '$FRONTEND_HOSTNAME')].Id | [0]" --output text)
 aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/*"
 
 echo

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,8 +7,10 @@ export AWS_PAGER=""
 
 # Setup environment stuff
 # By default deploy to production, otherwise "./deploy.sh beta" deploys to beta stage
+
 [[ "$1" = "beta" ]] && ENV_SUFFIX="-beta" || ENV_SUFFIX=""
 [[ "$1" = "beta" ]] && CHALICE_STAGE="beta" || CHALICE_STAGE="production"
+[[ "$1" = "beta" ]] && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN_BETA" || BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN"
 
 BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
 FRONTEND_HOSTNAME=dashboard$ENV_SUFFIX.transitmatters.org # Must match in .chalice/config.json!
@@ -24,7 +26,7 @@ npm run build
 pushd server/ > /dev/null
 pipenv run chalice package --stage $CHALICE_STAGE --merge-template frontend-cfn.json cfn/
 aws cloudformation package --template-file cfn/sam.json --s3-bucket $BACKEND_BUCKET --output-template-file cfn/packaged.yaml
-aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides TMFrontendHostname=$FRONTEND_HOSTNAME
+aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides TMFrontendHostname=$FRONTEND_HOSTNAME TMBackendCertArn=$BACKEND_CERT_ARN
 popd > /dev/null
 aws s3 sync build/ s3://$FRONTEND_HOSTNAME
 

--- a/server/.chalice/config.json
+++ b/server/.chalice/config.json
@@ -1,12 +1,34 @@
 {
   "version": "2.0",
   "app_name": "data-dashboard",
+  "api_gateway_endpoint_type": "EDGE",
   "minimum_compression_size": 1000,
   "stages": {
-    "dev": {
+    "production": {
       "api_gateway_stage": "api",
       "autogen_policy": false,
-      "iam_policy_file": "policy.json"
+      "iam_policy_file": "policy.json",
+      "environment_variables": {
+        "TM_FRONTEND_HOST": "dashboard.transitmatters.org"
+      },
+      "api_gateway_custom_domain": {
+        "domain_name": "dashboard-api.transitmatters.org",
+        "tls_version": "TLS_1_2",
+        "certificate_arn": ""
+      }
+    },
+    "beta": {
+      "api_gateway_stage": "beta",
+      "autogen_policy": false,
+      "iam_policy_file": "policy.json",
+      "environment_variables": {
+        "TM_FRONTEND_HOST": "dashboard-beta.transitmatters.org"
+      },
+      "api_gateway_custom_domain": {
+        "domain_name": "dashboard-api-beta.transitmatters.org",
+        "tls_version": "TLS_1_2",
+        "certificate_arn": ""
+      }
     }
   }
 }

--- a/server/.chalice/config.json
+++ b/server/.chalice/config.json
@@ -5,7 +5,7 @@
   "minimum_compression_size": 1000,
   "stages": {
     "production": {
-      "api_gateway_stage": "api",
+      "api_gateway_stage": "production",
       "autogen_policy": false,
       "iam_policy_file": "policy.json",
       "environment_variables": {

--- a/server/.chalice/config.json
+++ b/server/.chalice/config.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0",
   "app_name": "data-dashboard",
-  "api_gateway_endpoint_type": "EDGE",
+  "api_gateway_endpoint_type": "REGIONAL",
   "minimum_compression_size": 1000,
   "stages": {
     "production": {

--- a/server/.chalice/config.json
+++ b/server/.chalice/config.json
@@ -12,7 +12,7 @@
         "TM_FRONTEND_HOST": "dashboard.transitmatters.org"
       },
       "api_gateway_custom_domain": {
-        "domain_name": "dashboard-api.transitmatters.org",
+        "domain_name": "dashboard-api2.transitmatters.org",
         "tls_version": "TLS_1_2",
         "certificate_arn": ""
       }

--- a/server/app.py
+++ b/server/app.py
@@ -1,11 +1,14 @@
+import os
 from chalice import Chalice, CORSConfig
 from datetime import date
 from chalicelib import data_funcs, s3_historical
 
 app = Chalice(app_name="data-dashboard")
 
+TM_FRONTEND_HOST = os.environ["TM_FRONTEND_HOST"]
+
 cors_config = CORSConfig(
-    allow_origin="https://dashboard.transitmatters.org", max_age=3600
+    allow_origin=f"https://{TM_FRONTEND_HOST}", max_age=3600
 )
 
 

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -1,13 +1,22 @@
 {
   "Parameters" : {
-    "TMFrontendHostname" : {
-      "Type" : "String",
-      "Default" : "dashboard.transitmatters.org",
-      "AllowedValues" : ["dashboard-beta.transitmatters.org", "dashboard.transitmatters.org"],
-      "Description" : "The frontend hostname for the data dashboard."
+    "TMFrontendHostname": {
+      "Type": "String",
+      "Default": "dashboard.transitmatters.org",
+      "AllowedValues": ["dashboard-beta.transitmatters.org", "dashboard.transitmatters.org"],
+      "Description": "The frontend hostname for the data dashboard."
+    },
+    "TMBackendCertArn": {
+      "Type": "String",
+      "Description": "The ACM ARN of the backend certificate."
     }
   },
   "Resources": {
+    "ApiGatewayCustomDomain": {
+      "Properties": {
+        "RegionalCertificateArn": { "Ref": "TMBackendCertArn" }
+      }
+    },
     "FrontendCert": {
       "Type": "AWS::CertificateManager::Certificate",
       "Properties": {

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -1,23 +1,20 @@
 {
+  "Parameters" : {
+    "TMFrontendHostname" : {
+      "Type" : "String",
+      "Default" : "dashboard.transitmatters.org",
+      "AllowedValues" : ["dashboard-beta.transitmatters.org", "dashboard.transitmatters.org"],
+      "Description" : "The frontend hostname for the data dashboard."
+    }
+  },
   "Resources": {
     "FrontendCert": {
       "Type": "AWS::CertificateManager::Certificate",
       "Properties": {
-        "DomainName": "dashboard.transitmatters.org",
+        "DomainName": { "Ref": "TMFrontendHostname" },
         "DomainValidationOptions": [{
-          "DomainName": "dashboard.transitmatters.org",
-          "ValidationDomain": "dashboard.transitmatters.org"
-        }],
-        "ValidationMethod": "DNS"
-      }
-    },
-    "BackendCert": {
-      "Type": "AWS::CertificateManager::Certificate",
-      "Properties": {
-        "DomainName": "dashboard-api.transitmatters.org",
-        "DomainValidationOptions": [{
-          "DomainName": "dashboard-api.transitmatters.org",
-          "ValidationDomain": "dashboard-api.transitmatters.org"
+          "DomainName": { "Ref": "TMFrontendHostname" },
+          "ValidationDomain": { "Ref": "TMFrontendHostname" }
         }],
         "ValidationMethod": "DNS"
       }
@@ -25,7 +22,7 @@
     "FrontendBucket": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "BucketName": "dashboard.transitmatters.org",
+        "BucketName": { "Ref": "TMFrontendHostname" },
         "AccessControl": "PublicRead",
         "WebsiteConfiguration": {
           "IndexDocument": "index.html",
@@ -36,7 +33,7 @@
     "FrontendBucketPolicy": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
-        "Bucket": "dashboard.transitmatters.org",
+        "Bucket": { "Ref": "FrontendBucket" },
         "PolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -45,9 +42,7 @@
               "Effect": "Allow",
               "Principal": "*",
               "Action": "s3:GetObject",
-              "Resource": [
-                "arn:aws:s3:::dashboard.transitmatters.org/*"
-              ]
+              "Resource": { "Fn::Join" : [ "", [ { "Fn::GetAtt" : [ "FrontendBucket", "Arn" ] }, "/*" ] ] }
             }
           ]
         }
@@ -58,7 +53,7 @@
       "Properties": {
         "DistributionConfig": {
           "Aliases": [
-            "dashboard.transitmatters.org"
+            { "Ref": "TMFrontendHostname" }
           ],
           "Enabled": "true",
           "DefaultCacheBehavior": {
@@ -77,7 +72,7 @@
                 "HTTPSPort": "443",
                 "OriginProtocolPolicy": "http-only"
               },
-              "DomainName": "dashboard.transitmatters.org.s3.amazonaws.com",
+              "DomainName": { "Fn::GetAtt" : [ "FrontendBucket", "DomainName" ] },
               "Id": "only-origin"
             }
           ],

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -6,6 +6,10 @@
       "AllowedValues": ["dashboard-beta.transitmatters.org", "dashboard.transitmatters.org"],
       "Description": "The frontend hostname for the data dashboard."
     },
+    "TMFrontendCertArn": {
+      "Type": "String",
+      "Description": "The ACM ARN of the frontend certificate."
+    },
     "TMBackendCertArn": {
       "Type": "String",
       "Description": "The ACM ARN of the backend certificate."
@@ -15,17 +19,6 @@
     "ApiGatewayCustomDomain": {
       "Properties": {
         "RegionalCertificateArn": { "Ref": "TMBackendCertArn" }
-      }
-    },
-    "FrontendCert": {
-      "Type": "AWS::CertificateManager::Certificate",
-      "Properties": {
-        "DomainName": { "Ref": "TMFrontendHostname" },
-        "DomainValidationOptions": [{
-          "DomainName": { "Ref": "TMFrontendHostname" },
-          "ValidationDomain": { "Ref": "TMFrontendHostname" }
-        }],
-        "ValidationMethod": "DNS"
       }
     },
     "FrontendBucket": {
@@ -96,9 +89,7 @@
           "PriceClass": "PriceClass_100",
           "ViewerCertificate": {
             "MinimumProtocolVersion": "TLSv1.2_2018",
-            "AcmCertificateArn": {
-              "Ref": "FrontendCert"
-            },
+            "AcmCertificateArn": { "Ref": "TMFrontendCertArn" },
             "SslSupportMethod": "sni-only"
           }
         }

--- a/src/App.js
+++ b/src/App.js
@@ -10,9 +10,13 @@ import './App.css';
 import Select from './Select';
 import { configPresets } from './constants';
 
-const APP_DATA_BASE_PATH = (window.location.hostname === "localhost" ||
-  window.location.hostname === "127.0.0.1") ?
-  '' : 'https://dashboard-api.transitmatters.org';
+const FRONTEND_TO_BACKEND_MAP = new Map([
+  ["localhost", ""], // this becomes a relative path that is proxied through CRA:3000 to python on :5000
+  ["127.0.0.1", ""],
+  ["dashboard.transitmatters.org", "https://dashboard-api.transitmatters.org"],
+  ["dashboard-beta.transitmatters.org", "https://dashboard-api-beta.transitmatters.org"]
+]);
+const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname);
 
 const stateFromURL = (config) => {
   const [line, from_id, to_id, date] = config.split(",");

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import { configPresets } from './constants';
 const FRONTEND_TO_BACKEND_MAP = new Map([
   ["localhost", ""], // this becomes a relative path that is proxied through CRA:3000 to python on :5000
   ["127.0.0.1", ""],
-  ["dashboard.transitmatters.org", "https://dashboard-api.transitmatters.org"],
+  ["dashboard.transitmatters.org", "https://dashboard-api2.transitmatters.org"],
   ["dashboard-beta.transitmatters.org", "https://dashboard-api-beta.transitmatters.org"]
 ]);
 const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname);


### PR DESCRIPTION
This PR evolves the dashboard to take advantage of the chalice package's built-in stages (aka environments) in order to get dashboard-beta.transitmatters.org working.

`./deploy.sh` still works, but now `./deploy.sh beta` is an option too.