### PR TITLE
Make points colorblind-friendly and add purple for >100%

### DIFF
--- a/src/Legend.js
+++ b/src/Legend.js
@@ -3,9 +3,10 @@ import React from 'react';
 export default function legend() {
     return (
       <div className="legend">
-        <p><span className="legend-dot" style={{"backgroundColor": "#75c400"}}></span> On time</p>
-        <p><span className="legend-dot" style={{"backgroundColor": "#e5a70b"}}></span> >25% longer than benchmark</p>
-        <p><span className="legend-dot" style={{"backgroundColor": "#e53a0b"}}></span> >50% longer than benchmark</p>
+        <p><span className="legend-dot" style={{"backgroundColor": "#64b96a"}}></span> On time</p>
+        <p><span className="legend-dot" style={{"backgroundColor": "#f5ed00"}}></span> >25% longer than benchmark</p>
+        <p><span className="legend-dot" style={{"backgroundColor": "#c33149"}}></span> >50% longer than benchmark</p>
+        <p><span className="legend-dot" style={{"backgroundColor": "#bb5cc1"}}></span> >100% longer than benchmark</p>
         <p><span className="legend-line"></span> MBTA benchmark</p>
       </div>
     );

--- a/src/line.js
+++ b/src/line.js
@@ -25,10 +25,12 @@ const departure_from_normal_string = (metric, benchmark) => {
   else if (ratio <= 1.5) {
     return '>25% longer than normal';
   }
-  else if (ratio > 1.5) {
+  else if (ratio <= 2.0) {
     return '>50% longer than normal';
   }
-
+  else if (ratio > 2.0) {
+    return '>100% longer than normal';
+  }
 };
 
 const point_colors = (data, metric_field, benchmark_field) => {
@@ -38,13 +40,16 @@ const point_colors = (data, metric_field, benchmark_field) => {
       return '#1c1c1c'; //grey
     }
     else if (ratio <= 1.25) {
-      return '#75c400'; //green
+      return '#64b96a'; //green
     }
     else if (ratio <= 1.5) {
-      return '#e5a70b'; //yellow
+      return '#f5ed00'; //yellow
     }
-    else if (ratio > 1.5) {
-      return '#e53a0b'; //red
+    else if (ratio <= 2.0) {
+      return '#c33149'; //red
+    }
+    else if (ratio > 2.0) {
+      return '#bb5cc1'; //purple
     }
 
     return '#1c1c1c'; //whatever


### PR DESCRIPTION
Addresses #28 

![image](https://user-images.githubusercontent.com/8498946/108011491-2dad9580-6fd5-11eb-981b-9fa3ff48a141.png)


I'm opening this against main for public release, I think. lmk if I should be trialing this in the beta server first. (also, which branch is the beta version using?)