### PR TITLE
Multiday mbta api

### DIFF
--- a/server/chalicelib/MbtaPerformanceAPI.py
+++ b/server/chalicelib/MbtaPerformanceAPI.py
@@ -9,7 +9,7 @@ import itertools
 from .secrets import MBTA_V2_API_KEY
 
 
-def get_datetimes(day):
+def get_timestamps(day):
     # has to start after 3:30am, east coast time
     bos_tz = pytz.timezone("America/New_York")
     start_time = datetime.time(3, 30, 1)
@@ -25,12 +25,23 @@ def get_datetimes(day):
     return dt_str
 
 
-def get_single_url(day, module, params):
+def get_timestamp_range(start_day, end_day=None):
+    if end_day:
+        a = get_timestamps(start_day)
+        z = get_timestamps(end_day)
+        dt_str = {}
+        dt_str["from_dt_str"] = a["from_dt_str"]
+        dt_str["to_dt_str"] = z["to_dt_str"]
+        return dt_str
+    else:
+        return get_timestamps(start_day)
+
+def get_single_url(start_day, module, params, end_day=None):
     # import api key & set base url
     base_url_v2 = "http://realtime.mbta.com/developer/api/v2.1/{command}?{parameters}"
 
     # get datetimes
-    dt_str = get_datetimes(day)
+    dt_str = get_timestamp_range(start_day, end_day)
 
     # format parameters
     params["format"] = "json"
@@ -57,14 +68,14 @@ def get_product_of_list_dict_values(dict_of_lists):
         yield dict(zip(keys, combination))
 
 
-def get_many_urls(day, module, params):
+def get_many_urls(start_day, module, params, end_day=None):
     exploded_params = list(
         get_product_of_list_dict_values(params)
     )  # get all possible parameter combinations
     url_list = []
     # get url for each pair, add to list
     for single_param in exploded_params:
-        url_list.append(get_single_url(day, module, single_param))
+        url_list.append(get_single_url(start_day, module, single_param, end_day))
     return url_list
 
 
@@ -76,8 +87,8 @@ def get_single_api_data(url):
     return data
 
 
-def get_api_data(day, module, params):
-    url_list = get_many_urls(day, module, params)
+def get_api_data(start_day, module, params, end_day=None):
+    url_list = get_many_urls(start_day, module, params, end_day)
     all_data = []
     for url in url_list:
         data = get_single_api_data(url=url)

--- a/server/chalicelib/MbtaPerformanceAPI.py
+++ b/server/chalicelib/MbtaPerformanceAPI.py
@@ -36,6 +36,7 @@ def get_timestamp_range(start_day, end_day=None):
     else:
         return get_timestamps(start_day)
 
+
 def get_single_url(start_day, module, params, end_day=None):
     # import api key & set base url
     base_url_v2 = "http://realtime.mbta.com/developer/api/v2.1/{command}?{parameters}"

--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -7,6 +7,7 @@ import numpy as np
 # This matches the cutoff used in MbtaPerformanceApi.py
 SERVICE_HR_OFFSET = datetime.timedelta(hours=3, minutes=30)
 
+
 def train_peak_status(df):
     cal = USFederalHolidayCalendar()
     holidays = cal.holidays(start=df['dep_dt'].min(), end=df['dep_dt'].max())
@@ -23,7 +24,7 @@ def train_peak_status(df):
 
 def travel_times_over_time(sdate, edate, from_stop, to_stop):
     all_data = data_funcs.travel_times(sdate, [from_stop], [to_stop], edate)
-        
+
     # convert to pandas
     df = pd.DataFrame.from_records(all_data)
     df['dep_dt'] = pd.to_datetime(df['dep_dt'])
@@ -45,6 +46,7 @@ def travel_times_over_time(sdate, edate, from_stop, to_stop):
     # convert to dictionary
     summary_stats_dict = summary_stats_final.to_dict('records')
     return list(filter(lambda x: x['peak'] == 'all', summary_stats_dict))
+
 
 def headways_over_time(sdate, edate, stop):
     all_data = data_funcs.headways(sdate, [stop], edate)

--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -4,6 +4,8 @@ import pandas as pd
 from pandas.tseries.holiday import USFederalHolidayCalendar
 import numpy as np
 
+# This matches the cutoff used in MbtaPerformanceApi.py
+SERVICE_HR_OFFSET = datetime.timedelta(hours=3, minutes=30)
 
 def train_peak_status(df):
     cal = USFederalHolidayCalendar()
@@ -20,21 +22,13 @@ def train_peak_status(df):
 
 
 def travel_times_over_time(sdate, edate, from_stop, to_stop):
-    all_data = []
-    delta = edate - sdate       # as timedelta
-
-    # get a range of dates
-    for i in range(delta.days + 1):
-        day = sdate + datetime.timedelta(days=i)
-        data = data_funcs.travel_times(day, [from_stop], [to_stop])
-        for data_dict in data:
-            data_dict['service_date'] = day
-        all_data.extend(data)
-
+    all_data = data_funcs.travel_times(sdate, [from_stop], [to_stop], edate)
+        
     # convert to pandas
     df = pd.DataFrame.from_records(all_data)
     df['dep_dt'] = pd.to_datetime(df['dep_dt'])
     df['dep_time'] = pd.to_datetime(df['dep_dt']).dt.time
+    df['service_date'] = (df['dep_dt'] - SERVICE_HR_OFFSET).map(lambda x: x.date())
     df = train_peak_status(df)
 
     # get summary stats
@@ -52,23 +46,15 @@ def travel_times_over_time(sdate, edate, from_stop, to_stop):
     summary_stats_dict = summary_stats_final.to_dict('records')
     return list(filter(lambda x: x['peak'] == 'all', summary_stats_dict))
 
-
 def headways_over_time(sdate, edate, stop):
-    all_data = []
-    delta = edate - sdate       # as timedelta
-
-    # get a range of dates
-    for i in range(delta.days + 1):
-        day = sdate + datetime.timedelta(days=i)
-        data = data_funcs.headways(day, [stop])
-        for data_dict in data:
-            data_dict['service_date'] = day
-        all_data.extend(data)
+    all_data = data_funcs.headways(sdate, [stop], edate)
 
     # convert to pandas
     df = pd.DataFrame.from_records(all_data)
+
     df['dep_dt'] = pd.to_datetime(df['current_dep_dt'])
     df['dep_time'] = pd.to_datetime(df['current_dep_dt']).dt.time
+    df['service_date'] = (df['dep_dt'] - SERVICE_HR_OFFSET).map(lambda x: x.date())
     df = train_peak_status(df)
 
     # get summary stats
@@ -88,21 +74,13 @@ def headways_over_time(sdate, edate, stop):
 
 
 def dwells_over_time(sdate, edate, stop):
-    all_data = []
-    delta = edate - sdate       # as timedelta
-
-    # get a range of dates
-    for i in range(delta.days + 1):
-        day = sdate + datetime.timedelta(days=i)
-        data = data_funcs.dwells(day, [stop])
-        for data_dict in data:
-            data_dict['service_date'] = day
-        all_data.extend(data)
+    all_data = data_funcs.dwells(sdate, [stop], edate)
 
     # convert to pandas
     df = pd.DataFrame.from_records(all_data)
     df['dep_dt'] = pd.to_datetime(df['dep_dt'])
     df['dep_time'] = pd.to_datetime(df['dep_dt']).dt.time
+    df['service_date'] = (df['dep_dt'] - SERVICE_HR_OFFSET).map(lambda x: x.date())
     df = train_peak_status(df)
 
     # get summary stats

--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -12,6 +12,25 @@ def stamp_to_dt(stamp):
 def use_S3(date):
     return (date.today() - date).days >= 90
 
+def partition_S3_dates(start_date, end_date):
+    CUTOFF = datetime.date.today() - datetime.timedelta(days=90)
+
+    s3_dates = None
+    api_dates = None
+
+    if end_date < CUTOFF:
+        s3_dates = (start_date, end_date)
+    elif CUTOFF <= start_date:
+        api_dates = (start_date, end_date)
+    else:
+        s3_dates = (start_date, CUTOFF - datetime.timedelta(days=1))
+        api_dates = (CUTOFF, end_date)
+
+    return {
+        's3_interval': s3_dates,
+        'mbta_api_interval': api_dates
+    }
+
 
 def headways(date, stops):
     if use_S3(date):

--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -6,8 +6,9 @@ DATE_FORMAT = "%Y/%m/%d %H:%M:%S"
 
 
 def stamp_to_dt(stamp):
-    return datetime.datetime.fromtimestamp(stamp, pytz.timezone("America/New_York"))
-
+    stamp = int(stamp)
+    dt = datetime.datetime.fromtimestamp(stamp, pytz.timezone("America/New_York"))
+    return dt.strftime(DATE_FORMAT)
 
 def use_S3(date):
     return (date.today() - date).days >= 90
@@ -26,19 +27,43 @@ def partition_S3_dates(start_date, end_date):
         s3_dates = (start_date, CUTOFF - datetime.timedelta(days=1))
         api_dates = (CUTOFF, end_date)
 
-    return {
-        's3_interval': s3_dates,
-        'mbta_api_interval': api_dates
-    }
+    return (s3_dates, api_dates)
+        
+def headways(sdate, stops, edate=None):
+    if edate is None:
+        if use_S3(sdate):
+            return s3_historical.headways(stops, sdate)
+        else:
+            return process_mbta_headways(sdate, stops)
 
+    s3_interval, api_interval = partition_S3_dates(sdate, edate)
+    all_data = []
+    if s3_interval:
+        start, end = s3_interval
+        delta = (end - start).days + 1
+        for i in range(delta):
+            all_data.extend(s3_historical.headways(stops, start + datetime.timedelta(days=i)))
 
-def headways(date, stops):
-    if use_S3(date):
-        return s3_historical.headways(stops, date.year, date.month, date.day)
+    if api_interval:
+        start, end = api_interval
+        delta = (end - start).days + 1 # to make it pythonic: we want to include the end date
+        # MBTA api won't accept queries > 7 days.
+        # We could move this logic inside the api (since it generates multiple requests), or leave it here.
+        cur = start
+        while delta != 0:
+            inc = min(delta, 7)
+            all_data.extend(process_mbta_headways(cur, stops, cur + datetime.timedelta(days=inc - 1)))
+            delta -= inc
+            cur += datetime.timedelta(days=inc)
+
+    return all_data
+        
+
+def process_mbta_headways(sdate, stops, edate=None):
     # get data
-    api_data = MbtaPerformanceAPI.get_api_data(date, "headways", {
+    api_data = MbtaPerformanceAPI.get_api_data(sdate, "headways", {
         "stop": stops
-    })
+    }, end_day=edate)
 
     # combine all headways data
     headways = []
@@ -49,11 +74,9 @@ def headways(date, stops):
     for headway_dict in headways:
         # convert to datetime
         headway_dict["current_dep_dt"] = stamp_to_dt(
-            int(headway_dict.get("current_dep_dt"))
-        ).strftime(DATE_FORMAT)
+            headway_dict.get("current_dep_dt"))
         headway_dict["previous_dep_dt"] = stamp_to_dt(
-            int(headway_dict.get("previous_dep_dt"))
-        ).strftime(DATE_FORMAT)
+            headway_dict.get("previous_dep_dt"))
         # convert to int
         headway_dict["benchmark_headway_time_sec"] = int(
             headway_dict.get("benchmark_headway_time_sec")
@@ -63,16 +86,43 @@ def headways(date, stops):
 
     return headways
 
+def travel_times(sdate, from_stops, to_stops, edate=None):
+    if edate is None:
+        if use_S3(sdate):
+            return s3_historical.travel_times(from_stops, to_stops, sdate)
+        else:
+            return process_mbta_travel_times(sdate, from_stops, to_stops)
 
-def travel_times(date, from_stops, to_stops):
-    if use_S3(date):
-        return s3_historical.travel_times(from_stops[0], to_stops[0], date.year, date.month, date.day)
+    s3_interval, api_interval = partition_S3_dates(sdate, edate)
+    all_data = []
+    if s3_interval:
+        start, end = s3_interval
+        delta = (end - start).days + 1
+        for i in range(delta):
+            all_data.extend(s3_historical.travel_times(from_stops, to_stops, start + datetime.timedelta(days=i)))
 
+    if api_interval:
+        start, end = api_interval
+        delta = (end - start).days + 1 # to make it pythonic: we want to include the end date
+        # MBTA api won't accept queries > 7 days.
+        # We could move this logic inside the api (since it generates multiple requests), or leave it here.
+        cur = start
+        while delta != 0:
+            inc = min(delta, 7)
+            all_data.extend(process_mbta_travel_times(cur, from_stops, to_stops,
+                                                      cur + datetime.timedelta(days=inc - 1)))
+            delta -= inc
+            cur += datetime.timedelta(days=inc)
+
+    return all_data
+
+def process_mbta_travel_times(sdate, from_stops, to_stops, edate=None):
     # get data
-    api_data = MbtaPerformanceAPI.get_api_data(date, "traveltimes", {
+    api_data = MbtaPerformanceAPI.get_api_data(sdate, "traveltimes", {
         "from_stop": from_stops,
         "to_stop": to_stops
-    })
+    },
+    edate)
 
     # combine all travel times data
     travel = []
@@ -83,11 +133,9 @@ def travel_times(date, from_stops, to_stops):
     for travel_dict in travel:
         # convert to datetime
         travel_dict["arr_dt"] = stamp_to_dt(
-            int(travel_dict.get("arr_dt"))
-        ).strftime(DATE_FORMAT)
+            travel_dict.get("arr_dt"))
         travel_dict["dep_dt"] = stamp_to_dt(
-            int(travel_dict.get("dep_dt"))
-        ).strftime(DATE_FORMAT)
+            travel_dict.get("dep_dt"))
         # convert to int
         travel_dict["benchmark_travel_time_sec"] = int(
             travel_dict.get("benchmark_travel_time_sec")
@@ -97,15 +145,41 @@ def travel_times(date, from_stops, to_stops):
 
     return travel
 
+def dwells(sdate, stops, edate=None):
+    if edate is None:
+        if use_S3(sdate):
+            return s3_historical.dwells(stops, sdate)
+        else:
+            return process_mbta_dwells(sdate, stops)
 
-def dwells(date, stops):
-    if use_S3(date):
-        return s3_historical.dwells(stops, date.year, date.month, date.day)
+    s3_interval, api_interval = partition_S3_dates(sdate, edate)
+    all_data = []
+    if s3_interval:
+        start, end = s3_interval
+        delta = (end - start).days + 1
+        for i in range(delta):
+            all_data.extend(s3_historical.dwells(stops, start + datetime.timedelta(days=i)))
 
+    if api_interval:
+        start, end = api_interval
+        delta = (end - start).days + 1 # to make it pythonic: we want to include the end date
+        # MBTA api won't accept queries > 7 days.
+        # We could move this logic inside the api (since it generates multiple requests), or leave it here.
+        cur = start
+        while delta != 0:
+            inc = min(delta, 7)
+            all_data.extend(process_mbta_dwells(cur, stops, cur + datetime.timedelta(days=inc - 1)))
+            delta -= inc
+            cur += datetime.timedelta(days=inc)
+
+    return all_data
+    
+
+def process_mbta_dwells(sdate, stops, edate=None):
     # get data
-    api_data = MbtaPerformanceAPI.get_api_data(date, "dwells", {
+    api_data = MbtaPerformanceAPI.get_api_data(sdate, "dwells", {
         "stop": stops,
-    })
+    }, edate)
 
     # combine all travel times data
     dwells = []
@@ -116,11 +190,9 @@ def dwells(date, stops):
     for dwell_dict in dwells:
         # convert to datetime
         dwell_dict["arr_dt"] = stamp_to_dt(
-            int(dwell_dict.get("arr_dt"))
-        ).strftime(DATE_FORMAT)
+            dwell_dict.get("arr_dt"))
         dwell_dict["dep_dt"] = stamp_to_dt(
-            int(dwell_dict.get("dep_dt"))
-        ).strftime(DATE_FORMAT)
+            dwell_dict.get("dep_dt"))
         # convert to int
         dwell_dict["dwell_time_sec"] = int(dwell_dict.get("dwell_time_sec"))
         dwell_dict["direction"] = int(dwell_dict.get("direction"))
@@ -141,8 +213,8 @@ def alerts(date, params):
     for alert_item in alert_items:
         for alert_version in alert_item["alert_versions"]:
             flat_alerts.append({
-                "valid_from": stamp_to_dt(int(alert_version["valid_from"])).strftime(DATE_FORMAT),
-                "valid_to": stamp_to_dt(int(alert_version["valid_to"])).strftime(DATE_FORMAT),
+                "valid_from": stamp_to_dt(alert_version["valid_from"]),
+                "valid_to": stamp_to_dt(alert_version["valid_to"]),
                 "text": alert_version["header_text"]
             })
     return flat_alerts

--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -10,8 +10,10 @@ def stamp_to_dt(stamp):
     dt = datetime.datetime.fromtimestamp(stamp, pytz.timezone("America/New_York"))
     return dt.strftime(DATE_FORMAT)
 
+
 def use_S3(date):
     return (date.today() - date).days >= 90
+
 
 def partition_S3_dates(start_date, end_date):
     CUTOFF = datetime.date.today() - datetime.timedelta(days=90)
@@ -28,7 +30,8 @@ def partition_S3_dates(start_date, end_date):
         api_dates = (CUTOFF, end_date)
 
     return (s3_dates, api_dates)
-        
+
+
 def headways(sdate, stops, edate=None):
     if edate is None:
         if use_S3(sdate):
@@ -46,7 +49,7 @@ def headways(sdate, stops, edate=None):
 
     if api_interval:
         start, end = api_interval
-        delta = (end - start).days + 1 # to make it pythonic: we want to include the end date
+        delta = (end - start).days + 1  # to make it pythonic: we want to include the end date
         # MBTA api won't accept queries > 7 days.
         # We could move this logic inside the api (since it generates multiple requests), or leave it here.
         cur = start
@@ -57,7 +60,7 @@ def headways(sdate, stops, edate=None):
             cur += datetime.timedelta(days=inc)
 
     return all_data
-        
+
 
 def process_mbta_headways(sdate, stops, edate=None):
     # get data
@@ -86,10 +89,11 @@ def process_mbta_headways(sdate, stops, edate=None):
 
     return headways
 
+
 def travel_times(sdate, from_stops, to_stops, edate=None):
     if edate is None:
         if use_S3(sdate):
-            return s3_historical.travel_times(from_stops, to_stops, sdate)
+            return s3_historical.travel_times(from_stops[0], to_stops[0], sdate)
         else:
             return process_mbta_travel_times(sdate, from_stops, to_stops)
 
@@ -99,11 +103,11 @@ def travel_times(sdate, from_stops, to_stops, edate=None):
         start, end = s3_interval
         delta = (end - start).days + 1
         for i in range(delta):
-            all_data.extend(s3_historical.travel_times(from_stops, to_stops, start + datetime.timedelta(days=i)))
+            all_data.extend(s3_historical.travel_times(from_stops[0], to_stops[0], start + datetime.timedelta(days=i)))
 
     if api_interval:
         start, end = api_interval
-        delta = (end - start).days + 1 # to make it pythonic: we want to include the end date
+        delta = (end - start).days + 1  # to make it pythonic: we want to include the end date
         # MBTA api won't accept queries > 7 days.
         # We could move this logic inside the api (since it generates multiple requests), or leave it here.
         cur = start
@@ -116,13 +120,13 @@ def travel_times(sdate, from_stops, to_stops, edate=None):
 
     return all_data
 
+
 def process_mbta_travel_times(sdate, from_stops, to_stops, edate=None):
     # get data
     api_data = MbtaPerformanceAPI.get_api_data(sdate, "traveltimes", {
         "from_stop": from_stops,
         "to_stop": to_stops
-    },
-    edate)
+    }, end_day=edate)
 
     # combine all travel times data
     travel = []
@@ -145,6 +149,7 @@ def process_mbta_travel_times(sdate, from_stops, to_stops, edate=None):
 
     return travel
 
+
 def dwells(sdate, stops, edate=None):
     if edate is None:
         if use_S3(sdate):
@@ -162,7 +167,7 @@ def dwells(sdate, stops, edate=None):
 
     if api_interval:
         start, end = api_interval
-        delta = (end - start).days + 1 # to make it pythonic: we want to include the end date
+        delta = (end - start).days + 1  # to make it pythonic: we want to include the end date
         # MBTA api won't accept queries > 7 days.
         # We could move this logic inside the api (since it generates multiple requests), or leave it here.
         cur = start
@@ -173,7 +178,7 @@ def dwells(sdate, stops, edate=None):
             cur += datetime.timedelta(days=inc)
 
     return all_data
-    
+
 
 def process_mbta_dwells(sdate, stops, edate=None):
     # get data

--- a/server/chalicelib/s3.py
+++ b/server/chalicelib/s3.py
@@ -6,23 +6,16 @@ BUCKET = "tm-mbta-performance"
 s3 = boto3.resource("s3")
 
 
-STUPIDLY_SIMPLE_CACHE = {}
-
-
 def download_sorted_events(stop_id, year, month, day):
     # Download events from S3
     try:
         key = f"Events/daily-data/{stop_id}/Year={year}/Month={month}/Day={day}/events.csv.gz"
-        if key in STUPIDLY_SIMPLE_CACHE:
-            decompressed = STUPIDLY_SIMPLE_CACHE[key]
-        else:
-            obj = s3.Object(BUCKET, key)
-            s3_data = obj.get()["Body"].read()
-            # Uncompress
-            decompressed = zlib.decompress(
-                s3_data, wbits=zlib.MAX_WBITS | 16).decode("ascii").split("\r\n")
+        obj = s3.Object(BUCKET, key)
+        s3_data = obj.get()["Body"].read()
+        # Uncompress
+        decompressed = zlib.decompress(
+            s3_data, wbits=zlib.MAX_WBITS | 16).decode("ascii").split("\r\n")
 
-            STUPIDLY_SIMPLE_CACHE[key] = decompressed
     except s3.meta.client.exceptions.NoSuchKey:
         # raise Exception(f"Data not available on S3 for key {key} ") from None
         print(f"WARNING: No data available on S3 for key: {key}")

--- a/server/chalicelib/s3_historical.py
+++ b/server/chalicelib/s3_historical.py
@@ -9,8 +9,8 @@ EVENT_ARRIVAL = ["ARR", "PRA"]
 EVENT_DEPARTURE = ["DEP", "PRD"]
 
 
-def dwells(stop_id, year, month, day):
-    rows_by_time = s3.download_sorted_events(stop_id[0], year, month, day)
+def dwells(stop_id, date):
+    rows_by_time = s3.download_sorted_events(stop_id[0], date.year, date.month, date.day)
 
     dwells = []
     for i in range(0, len(rows_by_time) - 1):
@@ -34,8 +34,8 @@ def dwells(stop_id, year, month, day):
     return dwells
 
 
-def headways(stop_id, year, month, day):
-    rows_by_time = s3.download_sorted_events(stop_id[0], year, month, day)
+def headways(stop_id, date):
+    rows_by_time = s3.download_sorted_events(stop_id[0], date.year, date.month, date.day)
 
     only_departures = list(
         filter(lambda row: row['event_type'] in EVENT_DEPARTURE, rows_by_time))
@@ -74,9 +74,9 @@ def find_trip_id_arrival(trip_id, event_list):
         return None
 
 
-def travel_times(stop_a, stop_b, year, month, day):
-    rows_by_time_a = s3.download_sorted_events(stop_a, year, month, day)
-    rows_by_time_b = s3.download_sorted_events(stop_b, year, month, day)
+def travel_times(stop_a, stop_b, date):
+    rows_by_time_a = s3.download_sorted_events(stop_a, date.year, date.month, date.day)
+    rows_by_time_b = s3.download_sorted_events(stop_b, date.year, date.month, date.day)
 
     only_departures = list(
         filter(lambda event: event["event_type"] in EVENT_DEPARTURE, rows_by_time_a))


### PR DESCRIPTION
Minimizing the number of API requests for aggregation by bunching them together (mbta api can take a week at a time) to improve performance.
This also paves the road for executing multiple s3 object downloads in parallel.

~~The code right now is a bit messy, and still has some bugs, but I'm pretty sure `headways` is working as intended, and I just messed up the copy/pasting for travel_times and dwells.~~ EDIT: known bugs have been addressed and code has been linted. Design might not be the best- I was aiming for quick implementation minimizing refactoring.