### PR TITLE
Use 3:30-3:30 days when determining whether to query T API for alerts, and cron two days ago instead

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -13,13 +13,14 @@ cors_config = CORSConfig(
 )
 
 
-# Every day at 10am UTC: store alerts from the previous day
+# Every day at 10am UTC: store alerts from the past
+# It's called yesterday for now but it's really two days ago!!
 @app.schedule(Cron(0, 10, '*', '*', '?', '*'))
 def store_yesterday_alerts(event):
     # Only do this on the main site
     if TM_FRONTEND_HOST == "dashboard.transitmatters.org":
-        yesterday = date.today() - timedelta(days=1)
-        s3_alerts.store_alerts(yesterday)
+        two_days_ago = date.today() - timedelta(days=2)
+        s3_alerts.store_alerts(two_days_ago)
 
 
 def parse_user_date(user_date):

--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -104,8 +104,12 @@ def dwells(day, params):
 
 def alerts(day, params):
     try:
+        # Grab the current "transit day" (3:30am-3:30am)
         today = current_transit_day()
-        if day == today or (day >= MBTA_HAS_ALERTS_WE_THINK and day < WE_STARTED_COLLECTING_ALERTS):
+        yesterday = today - datetime.timedelta(days=1)
+
+        # Use the API for today and yesterday's transit day, otherwise us.
+        if day >= yesterday or (day >= MBTA_HAS_ALERTS_WE_THINK and day < WE_STARTED_COLLECTING_ALERTS):
             api_data = MbtaPerformanceAPI.get_api_data(day, "pastalerts", params)
         elif day >= WE_STARTED_COLLECTING_ALERTS:
             # This is stupid because we're emulating MBTA-performance ick

--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -11,6 +11,16 @@ def stamp_to_dt(stamp):
     return datetime.datetime.fromtimestamp(stamp, pytz.timezone("America/New_York"))
 
 
+# Transit days run 3:30am-3:30am local time
+def current_transit_day():
+    bos_tz = pytz.timezone("America/New_York")
+    today = datetime.date.today()
+    now = bos_tz.localize(datetime.datetime.now())
+    if now >= now.replace(hour=0, minute=0) and now < now.replace(hour=3, minute=30):
+        today -= datetime.timedelta(days=1)
+    return today
+
+
 def headways(day, params):
     # get data
     api_data = MbtaPerformanceAPI.get_api_data(day, "headways", params)
@@ -94,8 +104,7 @@ def dwells(day, params):
 
 def alerts(day, params):
     try:
-        today = datetime.date.today()
-
+        today = current_transit_day()
         if day == today or (day >= MBTA_HAS_ALERTS_WE_THINK and day < WE_STARTED_COLLECTING_ALERTS):
             api_data = MbtaPerformanceAPI.get_api_data(day, "pastalerts", params)
         elif day >= WE_STARTED_COLLECTING_ALERTS:


### PR DESCRIPTION
I think @friendchris is right about this!

1. We need to do the 3:30am math for determining which alert day to use at request time
2. The job itself was already using transit days, since it was using @friendchris MbtaPerformanceAPI.py
3. That _still_ presents a problem for the job, because the job runs at 5am (or 6am on DST), not 3:31. So between 3:30 and 5am/6am, there will be a gap where it's the new transit day, but we haven't downloaded yet.
4. To fix #3, just use the API for today AND yesterday's "transit days". 