### PR TITLE
Fix breakage when alerts are malformed

### DIFF
--- a/server/chalicelib/s3_alerts.py
+++ b/server/chalicelib/s3_alerts.py
@@ -3,11 +3,14 @@ from chalicelib import MbtaPerformanceAPI, s3
 
 
 def routes_for_alert(alert):
-    routes = set()
-    for alert_version in alert["alert_versions"]:
-        for informed_entity in alert_version["informed_entity"]:
-            routes.add(informed_entity["route_id"])
-    return routes
+    try:
+        routes = set()
+        for alert_version in alert["alert_versions"]:
+            for informed_entity in alert_version["informed_entity"]:
+                routes.add(informed_entity["route_id"])
+        return routes
+    except Exception:
+        return set()
 
 
 def key(day):

--- a/server/chalicelib/s3_alerts.py
+++ b/server/chalicelib/s3_alerts.py
@@ -3,14 +3,15 @@ from chalicelib import MbtaPerformanceAPI, s3
 
 
 def routes_for_alert(alert):
+    routes = set()
     try:
-        routes = set()
         for alert_version in alert["alert_versions"]:
             for informed_entity in alert_version["informed_entity"]:
                 routes.add(informed_entity["route_id"])
-        return routes
     except Exception:
-        return set()
+        pass
+
+    return routes
 
 
 def key(day):

--- a/server/chalicelib/s3_alerts.py
+++ b/server/chalicelib/s3_alerts.py
@@ -8,8 +8,8 @@ def routes_for_alert(alert):
         for alert_version in alert["alert_versions"]:
             for informed_entity in alert_version["informed_entity"]:
                 routes.add(informed_entity["route_id"])
-    except Exception:
-        pass
+    except KeyError as e:
+        print(f"Handled KeyError: Couldn't access {e} from alert {alert}")
 
     return routes
 


### PR DESCRIPTION
Some alerts didn't have proper route info... if that happens, the alert parsing was bailing out early. Example: https://dashboard.transitmatters.org/rapidtransit?config=Orange,70034,70024,2021-02-22

Might as well throw (ha) a try/except at the problem