### PR TITLE
Add feedback link in footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,8 +33,7 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <footer class="footer"><a href="https://transitmatters.org/transitmatters-labs">TransitMatters Labs</a> | <a href="https://transitmatters.org/blog/2020/8/3/rolling-out-our-data-dashboard">Release blog</a> | <a
-      href="https://github.com/transitmatters/t-performance-dash">Source code</a> | <a href="/opensource">Open source
-      attributions</a></footer>
+      href="https://github.com/transitmatters/t-performance-dash">Source code</a> | <a href="/opensource">Attribution</a> | <a href="mailto:labs@transitmatters.org?subject=Data%20Dashboard%20Feedback">📩 Send feedback</a></footer>
 </body>
 
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <footer class="footer"><a href="https://transitmatters.org/transitmatters-labs">TransitMatters Labs</a> | <a href="https://transitmatters.org/blog/2020/8/3/rolling-out-our-data-dashboard">Release blog</a> | <a
-      href="https://github.com/transitmatters/t-performance-dash">Source code</a> | <a href="/opensource">Attribution</a> | <a href="mailto:labs@transitmatters.org?subject=Data%20Dashboard%20Feedback">📩 Send feedback</a></footer>
+      href="https://github.com/transitmatters/t-performance-dash">Source code</a> | <a href="/opensource">Attribution</a> | <a href="mailto:labs@transitmatters.org?subject=[Dashboard%20Feedback]%20-%20">🚀 Send feedback</a></footer>
 </body>
 
 </html>


### PR DESCRIPTION
I threw in the envelope 📩 instead of the rocket 🚀. Mailto goes to `labs@` with a simple, but generic subject. At the moment, displays the same on main and beta.

I like @androotubelli suggestion of trying this and seeing whether users actually use it.

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/193453/110193626-fcb9c700-7e02-11eb-8a77-a88eed19515b.png">
