### PR TITLE
use population std to prevent NaN json error

### DIFF
--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -58,9 +58,10 @@ def travel_times_over_time(sdate, edate, from_stop, to_stop):
     # combine summary stats
     summary_stats_final = summary_stats.append(summary_stats_peak)
 
+    # filter peak status
+    results = summary_stats_final.loc[summary_stats_final['peak'] == 'all']
     # convert to dictionary
-    summary_stats_dict = summary_stats_final.to_dict('records')
-    return list(filter(lambda x: x['peak'] == 'all', summary_stats_dict))
+    return results.to_dict('records')
 
 
 def headways_over_time(sdate, edate, stop):
@@ -85,9 +86,10 @@ def headways_over_time(sdate, edate, stop):
     # combine summary stats
     summary_stats_final = summary_stats.append(summary_stats_peak)
 
+    # filter peak status
+    results = summary_stats_final.loc[summary_stats_final['peak'] == 'all']
     # convert to dictionary
-    summary_stats_dict = summary_stats_final.to_dict('records')
-    return list(filter(lambda x: x['peak'] == 'all', summary_stats_dict))
+    return results.to_dict('records')
 
 
 def dwells_over_time(sdate, edate, stop):
@@ -111,6 +113,7 @@ def dwells_over_time(sdate, edate, stop):
     # combine summary stats
     summary_stats_final = summary_stats.append(summary_stats_peak)
 
+    # filter peak status
+    results = summary_stats_final.loc[summary_stats_final['peak'] == 'all']
     # convert to dictionary
-    summary_stats_dict = summary_stats_final.to_dict('records')
-    return list(filter(lambda x: x['peak'] == 'all', summary_stats_dict))
+    return results.to_dict('records')

--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -24,14 +24,17 @@ def train_peak_status(df):
 
 def faster_describe(grouped):
     # This does the same thing as pandas.DataFrame.describe(), but is up to 25x faster!
-    stats = grouped.aggregate(['count', 'mean', 'std', 'min', 'median', 'max'])
+    # also, we can specify population std instead of sample.
+    stats = grouped.aggregate(['count', 'mean', 'min', 'median', 'max'])
+    std = grouped.std(ddof=0)
     q1 = grouped.quantile(0.25)
     q3 = grouped.quantile(0.75)
+    std.name = 'std'
     q1.name = '25%'
     q3.name = '75%'
     # TODO: we can take this out if we filter for 'median' in the front end
     stats.rename(columns={'median': '50%'}, inplace=True)
-    return pd.concat([stats, q1, q3], axis=1)
+    return pd.concat([stats, q1, q3, std], axis=1)
 
 
 def travel_times_over_time(sdate, edate, from_stop, to_stop):

--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -34,7 +34,10 @@ def faster_describe(grouped):
     q3.name = '75%'
     # TODO: we can take this out if we filter for 'median' in the front end
     stats.rename(columns={'median': '50%'}, inplace=True)
-    return pd.concat([stats, q1, q3, std], axis=1)
+    stats = pd.concat([stats, q1, q3, std], axis=1)
+
+    # This will filter out some probable outliers.
+    return stats.loc[stats['count'] > 4]
 
 
 def travel_times_over_time(sdate, edate, from_stop, to_stop):


### PR DESCRIPTION
This will prevent only the NaN error when there's only 1 train reported. Perhaps we should handle NaNs more generally?
Also, maybe it makes sense to throw out any data points where only 1 train came that day, since it's almost guaranteed to be an outlier?

The .loc business is a bit more efficient than what we were doing before.