### PR TITLE
[Short and sweet] Fix station picker deserialization

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import classNames from 'classnames';
 
 const Select = props => {
-    const { options, onChange, defaultLabel = "", value, className } = props;
+    const { options, optionComparator, onChange, defaultLabel = "", value, className } = props;
     const elementRef = useRef(null);
 
     const handleChange = (evt) => {
@@ -10,7 +10,7 @@ const Select = props => {
         onChange(option && option.value);
     }
 
-    const matchingIndex = options.findIndex(o => o.value.stop_name === value.stop_name);
+    const matchingIndex = options.findIndex(optionComparator || (o => o.value === value));
 
     return (
         <div className={classNames('select-component', className, options.length === 0 && 'disabled')}>

--- a/src/Select.js
+++ b/src/Select.js
@@ -10,7 +10,7 @@ const Select = props => {
         onChange(option && option.value);
     }
 
-    const matchingIndex = options.findIndex(o => o.value === value);
+    const matchingIndex = options.findIndex(o => o.value.stop_name === value.stop_name);
 
     return (
         <div className={classNames('select-component', className, options.length === 0 && 'disabled')}>

--- a/src/StationConfiguration.js
+++ b/src/StationConfiguration.js
@@ -124,6 +124,8 @@ export default class StationConfiguration extends React.Component {
                 value={this.decode("from")}
                 options={this.optionsForField("from")}
                 onChange={this.handleSelectOption("from")}
+                // Non-standard value comparator because from/to gets copied by onpopstate :/
+                optionComparator={o => o.value.stop_name === this.decode("from")?.stop_name}
                 defaultLabel="Select a station..."
               />
             </div>
@@ -133,6 +135,8 @@ export default class StationConfiguration extends React.Component {
                 value={this.decode("to")}
                 options={this.optionsForField("to")}
                 onChange={this.handleSelectOption("to")}
+                // Non-standard value comparator because from/to gets copied by onpopstate :/
+                optionComparator={o => o.value.stop_name === this.decode("to")?.stop_name}
                 defaultLabel="Select a station..."
               />
             </div>


### PR DESCRIPTION
Fixes issue #76. This happens on `main`, so this PR is against main.

The station picker cannot deserialize station info from the URL right now, because we cannot match station indices based on objects—they're not the same. Have to compare stop names themselves instead.