### PR TITLE
Add northern OL preset April 2021

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -389,8 +389,8 @@ class App extends React.Component {
         and dwell times, for any given day. <span style={{fontWeight: "bold"}}>Select a line, station pair, and date above to get started.</span><div style={{marginTop: 10}}>Looking for something interesting? <span style={{fontWeight: "bold"}}>Try one of these dates:</span></div>
         <Select
           onChange={value => {
-            const { line, date_start, from, to } = value;
-            this.updateConfiguration({ line, date_start }, false);
+            const { line, date_start, date_end, from, to } = value;
+            this.updateConfiguration({ line, date_start, date_end }, false);
             setTimeout(() => this.updateConfiguration({ from, to }));
           }}
           options={configPresets}

--- a/src/StationConfiguration.js
+++ b/src/StationConfiguration.js
@@ -68,8 +68,16 @@ export default class StationConfiguration extends React.Component {
     this.setupPickers();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     this.setupPickers();
+
+    // If the date_end prop shows up because a config preset set it,
+    //  then show the end date picker.
+    if(this.props.current.date_end !== prevProps.current.date_end) {
+      this.setState({
+        show_date_end_picker: !!this.props.current.date_end,
+      });
+    }
   }
 
   handleSelectDate(field_name) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1119,7 +1119,7 @@ export const configPresets = [
 		value: createConfigPresetValue("Orange", "Community College", "North Station", '2020-11-01', '2021-02-17'),
 	},
 	{
-		label: "[New!] Spring 2020 — Green Line (C branch) COVID effect",
+		label: "[New!] Spring 2020 — Green Line (C-branch) COVID-19 pandemic effect",
 		value: createConfigPresetValue("Green", "Englewood Avenue", "Saint Marys Street", '2020-01-31', '2020-07-05'),
 	},
 	{

--- a/src/constants.js
+++ b/src/constants.js
@@ -1094,18 +1094,26 @@ export const stations = {
 	}]
 };
 
-const createConfigPresetValue = (line, fromStationName, toStationName, date_start) => {
+const createConfigPresetValue = (line, fromStationName, toStationName, date_start, date_end = undefined) => {
 	const fromStation = stations[line].find(s => s.stop_name === fromStationName);
 	const toStation = stations[line].find(s => s.stop_name === toStationName);
 	return {
 		line,
 		date_start,
+		date_end,
 		from: fromStation,
 		to: toStation,
 	}
 };
 
+// Returns today's EST/EDT date in a format like "2021-04-12". Thanks Canada!
+const TODAY = new Date().toLocaleString('fr-CA', { timeZone: 'America/New_York' }).split(" ")[0];
+
 export const configPresets = [
+	{
+		label: "[New!] April 2021 — Orange Line slow zone",
+		value: createConfigPresetValue("Orange", "Oak Grove", "Wellington", '2021-03-01', TODAY),
+	},
 	{
 		label: "January 17, 2021 — Red Line",
 		value: createConfigPresetValue("Red", "Braintree", "Andrew", '2021-01-17'),

--- a/src/constants.js
+++ b/src/constants.js
@@ -1115,6 +1115,14 @@ export const configPresets = [
 		value: createConfigPresetValue("Orange", "Oak Grove", "Wellington", '2021-03-01', TODAY),
 	},
 	{
+		label: "[New!] December 2020 — Orange Line slow zone",
+		value: createConfigPresetValue("Orange", "Community College", "North Station", '2020-11-01', '2021-02-17'),
+	},
+	{
+		label: "[New!] Spring 2020 — Green Line (C branch) COVID effect",
+		value: createConfigPresetValue("Green", "Englewood Avenue", "Saint Marys Street", '2020-01-31', '2020-07-05'),
+	},
+	{
 		label: "January 17, 2021 — Red Line",
 		value: createConfigPresetValue("Red", "Braintree", "Andrew", '2021-01-17'),
 	},


### PR DESCRIPTION
Add an option to the presets for the April 2021 OL slow zone, with a dynamic end date that's always today.