### PR TITLE
Add backend healthcheck

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -49,10 +49,17 @@ def mutlidict_to_dict(mutlidict):
 
 @app.route("/healthcheck", cors=cors_config)
 def healthcheck():
+    # These functions must return True or False :-)
     checks = [
-        len(secrets.MBTA_V2_API_KEY) > 0,
-        "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"]))
+        lambda: len(secrets.MBTA_V2_API_KEY) > 0,
+        lambda: "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"]))
     ]
+
+    for i in range(0, len(checks)):
+        try:
+            checks[i] = checks[i]()
+        except Exception:
+            checks[i] = False
 
     if all(checks):
         return {


### PR DESCRIPTION
The train tracker issue this morning reminded me that the dashboard needs a real health check. This checks to make sure the API key has a non-zero length, and that it can get alerts from S3. 500 error if a check fails, and a number output indicating which one.