### PR TITLE
Set API key through deploy.sh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
       TM_FRONTEND_CERT_ARN_BETA: ${{ secrets.TM_FRONTEND_CERT_ARN_BETA }}
       TM_BACKEND_CERT_ARN: ${{ secrets.TM_BACKEND_CERT_ARN }}
       TM_BACKEND_CERT_ARN_BETA: ${{ secrets.TM_BACKEND_CERT_ARN_BETA }}
+      MBTA_V2_API_KEY: ${{ secrets.MBTA_V2_API_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy_beta.yml
+++ b/.github/workflows/deploy_beta.yml
@@ -17,6 +17,7 @@ jobs:
       TM_FRONTEND_CERT_ARN_BETA: ${{ secrets.TM_FRONTEND_CERT_ARN_BETA }}
       TM_BACKEND_CERT_ARN: ${{ secrets.TM_BACKEND_CERT_ARN }}
       TM_BACKEND_CERT_ARN_BETA: ${{ secrets.TM_BACKEND_CERT_ARN_BETA }}
+      MBTA_V2_API_KEY: ${{ secrets.MBTA_V2_API_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,7 +38,13 @@ sed -i "s/git-id/version $GIT_ID/" ./build/index.html
 pushd server/ > /dev/null
 pipenv run chalice package --stage $CHALICE_STAGE --merge-template frontend-cfn.json cfn/
 aws cloudformation package --template-file cfn/sam.json --s3-bucket $BACKEND_BUCKET --output-template-file cfn/packaged.yaml
-aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides TMFrontendHostname=$FRONTEND_HOSTNAME TMFrontendCertArn=$FRONTEND_CERT_ARN TMBackendCertArn=$BACKEND_CERT_ARN
+
+aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides \
+    TMFrontendHostname=$FRONTEND_HOSTNAME \
+    TMFrontendCertArn=$FRONTEND_CERT_ARN \
+    TMBackendCertArn=$BACKEND_CERT_ARN \
+    MbtaV2ApiKey=$MBTA_V2_API_KEY
+
 popd > /dev/null
 aws s3 sync build/ s3://$FRONTEND_HOSTNAME
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,7 +38,6 @@ sed -i "s/git-id/version $GIT_ID/" ./build/index.html
 pushd server/ > /dev/null
 pipenv run chalice package --stage $CHALICE_STAGE --merge-template frontend-cfn.json cfn/
 aws cloudformation package --template-file cfn/sam.json --s3-bucket $BACKEND_BUCKET --output-template-file cfn/packaged.yaml
-
 aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides \
     TMFrontendHostname=$FRONTEND_HOSTNAME \
     TMFrontendCertArn=$FRONTEND_CERT_ARN \

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,11 @@ This is the repository for the TransitMatters data dashboard. Client code is wri
 	* `TM_BACKEND_CERT_ARN_BETA`
 	* (You may also need to set `AWS_DEFAULT_REGION` in your shell to `us-east-1`. Maybe not! We're not sure.)
 3. Execute `./deploy.sh` (for production) or `./deploy.sh beta` (for beta).
-	* If you get an error, check the CloudFormation stack status in AWS Console. Good luck!
+
+Additional notes:
+- If you're running this locally, your local MBTA-performance API key (which might be your own) will get uploaded to AWS!
+- If you're on a platform with a non-GNU `sed`, deploy.sh might fail. On macOS, this is fixed by `brew install gnu-sed` and adding it to your PATH.
+- If you get an unexplained error, check the CloudFormation stack status in AWS Console. Good luck!
 
 ### Linting
 To lint frontend and backend code, run `npm run lint` in the root directory

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -13,12 +13,25 @@
     "TMBackendCertArn": {
       "Type": "String",
       "Description": "The ACM ARN of the backend certificate."
+    },
+    "MbtaV2ApiKey": {
+      "Type": "String",
+      "Description": "MBTA-performance API key."
     }
   },
   "Resources": {
     "ApiGatewayCustomDomain": {
       "Properties": {
         "RegionalCertificateArn": { "Ref": "TMBackendCertArn" }
+      }
+    },
+    "APIHandler": {
+      "Properties": {
+        "Environment": {
+          "Variables": {
+            "MBTA_V2_API_KEY": { "Ref": "MbtaV2ApiKey" }
+          }
+        }
       }
     },
     "FrontendBucket": {


### PR DESCRIPTION
Deployments sometimes cause the backend to break because the API key isn't set automatically. It's now passed in through GitHub secrets into deploy.sh like it's supposed to be. Sorry this took so long @nathan-weinberg!!

Fixes https://github.com/transitmatters/t-performance-dash/issues/82