### PR TITLE
Aggregation refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "classnames": "^2.2.6",
     "concurrently": "^5.2.0",
     "flatpickr": "4.5.7",
+    "lodash.merge": "^4.6.2",
     "react": "^16.13.1",
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^16.13.1",

--- a/src/App.js
+++ b/src/App.js
@@ -113,7 +113,7 @@ class App extends React.Component {
     this.setIsLoadingDataset = this.setIsLoadingDataset.bind(this);
     this.getIsLoadingDataset = this.getIsLoadingDataset.bind(this);
     this.getDoneLoading = this.getDoneLoading.bind(this);
-    this.getTimescale = this.getTimescale.bind(this);
+    this.isAggregation = this.isAggregation.bind(this);
     this.progressBarRate = this.progressBarRate.bind(this);
     this.restartProgressBar = this.restartProgressBar.bind(this);
     this.permittedRange = this.permittedRange.bind(this);
@@ -258,11 +258,11 @@ class App extends React.Component {
     return this.state.datasetLoadingState[name];
   }
 
-  getTimescale() {
+  isAggregation() {
     if (this.state.configuration.date_end) {
-      return "day";
+      return true;
     }
-    return "hour";
+    return false;
   }
 
   restartProgressBar() {
@@ -422,9 +422,8 @@ class App extends React.Component {
   }
 
   progressBarRate() {
-    const is_aggregation = this.getTimescale() === 'hour';
     // Single day: no rate
-    if(is_aggregation) {
+    if(!this.isAggregation()) {
       return null;
     }
 
@@ -439,9 +438,7 @@ class App extends React.Component {
   }
 
   renderCharts() {
-    const timescale = this.getTimescale();
-    // TODO: move this into config
-    if (timescale === 'hour') {
+    if (!this.isAggregation()) {
       return <div className='charts main-column'>
         <SingleDayLine
           title={"Travel times"}
@@ -511,7 +508,7 @@ class App extends React.Component {
     const { configuration, error_message } = this.state;
     const { from, to, date_start } = configuration;
     const canShowCharts = from && to && !error_message;
-    const canShowAlerts = from && to && date_start && this.getTimescale() === 'hour';
+    const canShowAlerts = from && to && date_start && !this.isAggregation();
     const recognized_alerts = this.state.alerts?.filter(recognize);
     const hasNoLoadedCharts = ['traveltimes', 'dwells', 'headways']
       .every(kind => this.getIsLoadingDataset(kind));
@@ -526,7 +523,7 @@ class App extends React.Component {
             isLoading={this.getIsLoadingDataset("alerts")}
             isHidden={hasNoLoadedCharts}
           />}
-          {canShowCharts && !this.getDoneLoading() && this.getTimescale() === 'day' && <ProgressBar progress={this.state.progress} />}
+          {canShowCharts && !this.getDoneLoading() && this.isAggregation() && <ProgressBar progress={this.state.progress} />}
         </div>
         {!canShowCharts && this.renderEmptyState(error_message)}
         {canShowCharts && this.renderCharts()}

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactGA from 'react-ga';
-import Line from './line';
+import { SingleDayLine, AggregateLine } from './line';
 import StationConfiguration from './StationConfiguration';
 import { withRouter } from 'react-router-dom';
 import { lookup_station_by_id, station_direction, get_stop_ids_for_stations } from './stations';
@@ -440,57 +440,71 @@ class App extends React.Component {
 
   renderCharts() {
     const timescale = this.getTimescale();
-    const is_aggregation = timescale === 'hour';
-    return <div className='charts main-column'>
-      <Line
-        title={"Travel times"}
-        location={this.locationDescription(true)}
-        tooltipUnit={"travel time"}
-        timescale={timescale}
-        seriesName={is_aggregation ? 'travel time' : 'Median travel time'}
-        isLoading={this.getIsLoadingDataset('traveltimes')}
-        data={this.state.traveltimes}
-        xField={is_aggregation ? 'dep_dt' : 'service_date'}
-        xFieldLabel={is_aggregation ? 'Time of day' : 'Day'}
-        xFieldUnit={timescale}
-        suggestedXRange={this.suggestXRange()}
-        yField={is_aggregation ? 'travel_time_sec' : '50%'}
-        yFieldLabel={"Minutes"}
-        benchmarkField={'benchmark_travel_time_sec'}
-      />
-      <Line
-        title={'Time between trains (headways)'}
-        location={this.locationDescription(false)}
-        tooltipUnit={"headway"}
-        timescale={timescale}
-        seriesName={is_aggregation ? 'headway' : 'Median headway'}
-        isLoading={this.getIsLoadingDataset('headways')}
-        data={this.state.headways}
-        xField={is_aggregation ? 'current_dep_dt' : 'service_date'}
-        xFieldLabel={is_aggregation ? 'Time of day' : 'Day'}
-        xFieldUnit={timescale}
-        suggestedXRange={this.suggestXRange()}
-        yField={is_aggregation ? 'headway_time_sec' : '50%'}
-        yFieldLabel={'Minutes'}
-        benchmarkField={'benchmark_headway_time_sec'}
-      />
-      <Line
-        title={'Time spent at station (dwells)'}
-        location={this.locationDescription(false)}
-        tooltipUnit={"dwell time"}
-        timescale={timescale}
-        seriesName={is_aggregation ? 'dwell time' : 'Median dwell time'}
-        isLoading={this.getIsLoadingDataset('dwells')}
-        data={this.state.dwells}
-        xField={is_aggregation ? 'arr_dt' : 'service_date'}
-        xFieldLabel={is_aggregation ? 'Time of day' : 'Day'}
-        xFieldUnit={timescale}
-        suggestedXRange={this.suggestXRange()}
-        yField={is_aggregation ? 'dwell_time_sec' : '50%'}
-        yFieldLabel={'Minutes'}
-        benchmarkField={null}
-      />
-    </div>
+    // TODO: move this into config
+    if (timescale === 'hour') {
+      return <div className='charts main-column'>
+        <SingleDayLine
+          title={"Travel times"}
+          data={this.state.traveltimes}
+          seriesName={"travel time"}
+          xField={'dep_dt'}
+          yField={'travel_time_sec'}
+          benchmarkField={'benchmark_travel_time_sec'}
+          location={this.locationDescription(true)}
+          isLoading={this.getIsLoadingDataset('traveltimes')}
+          suggestedXRange={this.suggestXRange()}
+        />
+        <SingleDayLine
+          title={'Time between trains (headways)'}
+          data={this.state.headways}
+          seriesName={"headway"}
+          xField={"current_dep_dt"}
+          yField={'headway_time_sec'}
+          benchmarkField={'benchmark_headway_time_sec'}
+          location={this.locationDescription(false)}
+          isLoading={this.getIsLoadingDataset('headways')}
+          suggestedXRange={this.suggestXRange()}
+        />
+        <SingleDayLine
+          title={'Time spent at station (dwells)'}
+          data={this.state.dwells}
+          seriesName={"dwell time"}
+          xField={"arr_dt"}
+          yField={"dwell_time_sec"}
+          benchmarkField={null}
+          location={this.locationDescription(false)}
+          isLoading={this.getIsLoadingDataset('dwells')}
+          suggestedXRange={this.suggestXRange()}
+        />
+      </div>
+    } else {
+      return <div className='charts main-column'>
+        <AggregateLine
+          title={"Travel times"}
+          data={this.state.traveltimes}
+          seriesName={"Median travel time"}
+          location={this.locationDescription(true)}
+          isLoading={this.getIsLoadingDataset('traveltimes')}
+          suggestedXRange={this.suggestXRange()}
+        />
+        <AggregateLine
+          title={'Time between trains (headways)'}
+          data={this.state.headways}
+          seriesName={'Median headway'}
+          location={this.locationDescription(false)}
+          isLoading={this.getIsLoadingDataset('headways')}
+          suggestedXRange={this.suggestXRange()}
+        />
+        <AggregateLine
+          title={'Time spent at station (dwells)'}
+          data={this.state.dwells}
+          seriesName={'Median dwell time'}
+          location={this.locationDescription(false)}
+          isLoading={this.getIsLoadingDataset('dwells')}
+          suggestedXRange={this.suggestXRange()}
+        />
+      </div>
+    }
   }
 
   render() {

--- a/src/App.js
+++ b/src/App.js
@@ -259,10 +259,7 @@ class App extends React.Component {
   }
 
   isAggregation() {
-    if (this.state.configuration.date_end) {
-      return true;
-    }
-    return false;
+    return !!this.state.configuration.date_end;
   }
 
   restartProgressBar() {
@@ -416,7 +413,37 @@ class App extends React.Component {
   }
 
   renderCharts() {
-    if (!this.isAggregation()) {
+    if (this.isAggregation()) {
+      return <div className='charts main-column'>
+        <AggregateLine
+          title={"Travel times"}
+          data={this.state.traveltimes}
+          seriesName={"Median travel time"}
+          location={this.locationDescription(true)}
+          isLoading={this.getIsLoadingDataset('traveltimes')}
+          startDate={this.state.configuration.date_start}
+          endDate={this.state.configuration.date_end}
+        />
+        <AggregateLine
+          title={'Time between trains (headways)'}
+          data={this.state.headways}
+          seriesName={'Median headway'}
+          location={this.locationDescription(false)}
+          isLoading={this.getIsLoadingDataset('headways')}
+          startDate={this.state.configuration.date_start}
+          endDate={this.state.configuration.date_end}
+        />
+        <AggregateLine
+          title={'Time spent at station (dwells)'}
+          data={this.state.dwells}
+          seriesName={'Median dwell time'}
+          location={this.locationDescription(false)}
+          isLoading={this.getIsLoadingDataset('dwells')}
+          startDate={this.state.configuration.date_start}
+          endDate={this.state.configuration.date_end}
+        />
+      </div>
+    } else {
       return <div className='charts main-column'>
         <SingleDayLine
           title={"Travel times"}
@@ -450,36 +477,6 @@ class App extends React.Component {
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('dwells')}
           date={this.state.configuration.date_start}
-        />
-      </div>
-    } else {
-      return <div className='charts main-column'>
-        <AggregateLine
-          title={"Travel times"}
-          data={this.state.traveltimes}
-          seriesName={"Median travel time"}
-          location={this.locationDescription(true)}
-          isLoading={this.getIsLoadingDataset('traveltimes')}
-          startDate={this.state.configuration.date_start}
-          endDate={this.state.configuration.date_end}
-        />
-        <AggregateLine
-          title={'Time between trains (headways)'}
-          data={this.state.headways}
-          seriesName={'Median headway'}
-          location={this.locationDescription(false)}
-          isLoading={this.getIsLoadingDataset('headways')}
-          startDate={this.state.configuration.date_start}
-          endDate={this.state.configuration.date_end}
-        />
-        <AggregateLine
-          title={'Time spent at station (dwells)'}
-          data={this.state.dwells}
-          seriesName={'Median dwell time'}
-          location={this.locationDescription(false)}
-          isLoading={this.getIsLoadingDataset('dwells')}
-          startDate={this.state.configuration.date_start}
-          endDate={this.state.configuration.date_end}
         />
       </div>
     }

--- a/src/App.js
+++ b/src/App.js
@@ -147,20 +147,21 @@ class App extends React.Component {
       }
     };
 
-    if(update.configuration.date_end) {
-      if(!this.permittedRange(update.configuration.date_start, update.configuration.date_end)) {
-        this.setState({
-          error_message: RANGE_TOO_LARGE_ERROR,
-        });
-        // Setting refetch to false prevents data download, but lets this.state.configuration update still
-        refetch = false;
-      }
-      else {
-        this.setState({
-          error_message: null,
-        });
-      }
+    if (
+      update.configuration.date_end &&
+      !this.permittedRange(update.configuration.date_start, update.configuration.date_end)
+    ) {
+      this.setState({
+        error_message: RANGE_TOO_LARGE_ERROR,
+      });
+      // Setting refetch to false prevents data download, but lets this.state.configuration update still
+      refetch = false;
+    } else {
+      this.setState({
+        error_message: null,
+      });
     }
+
     if (config_change.line && config_change.line !== this.state.configuration.line) {
       update.configuration.from = null;
       update.configuration.to = null;

--- a/src/App.js
+++ b/src/App.js
@@ -109,7 +109,6 @@ class App extends React.Component {
     this.download = this.download.bind(this);
     this.updateConfiguration = this.updateConfiguration.bind(this);
     this.chartTimeframe = this.chartTimeframe.bind(this);
-    this.suggestXRange = this.suggestXRange.bind(this);
     this.setIsLoadingDataset = this.setIsLoadingDataset.bind(this);
     this.getIsLoadingDataset = this.getIsLoadingDataset.bind(this);
     this.getDoneLoading = this.getDoneLoading.bind(this);
@@ -351,28 +350,6 @@ class App extends React.Component {
     return {};
   }
 
-  suggestXRange(single_day) {
-    if (single_day) {
-      // Force plot to show 6am today to 1am tomorrow at minimum
-      const today = `${this.state.configuration.date_start}T00:00:00`;
-
-      let low = new Date(today);
-      low.setHours(6,0);
-
-      let high = new Date(today);
-      high.setDate(high.getDate() + 1);
-      high.setHours(1,0);
-
-      return [low, high];
-    } else {
-      // Force plot to show entire date range selected even if no data
-      const start = `${this.state.configuration.date_start}T00:00:00`;
-      const end = `${this.state.configuration.date_end}T00:00:00`;
-
-      return [new Date(start), new Date(end)];
-    }
-  }
-
   chartTimeframe() {
     // Set alert-bar interval to be 5:30am today to 1am tomorrow.
     const today = `${this.state.configuration.date_start}T00:00:00`;
@@ -450,7 +427,7 @@ class App extends React.Component {
           benchmarkField={'benchmark_travel_time_sec'}
           location={this.locationDescription(true)}
           isLoading={this.getIsLoadingDataset('traveltimes')}
-          suggestedXRange={this.suggestXRange(true)}
+          date={this.state.configuration.date_start}
         />
         <SingleDayLine
           title={'Time between trains (headways)'}
@@ -461,7 +438,7 @@ class App extends React.Component {
           benchmarkField={'benchmark_headway_time_sec'}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('headways')}
-          suggestedXRange={this.suggestXRange(true)}
+          date={this.state.configuration.date_start}
         />
         <SingleDayLine
           title={'Time spent at station (dwells)'}
@@ -472,7 +449,7 @@ class App extends React.Component {
           benchmarkField={null}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('dwells')}
-          suggestedXRange={this.suggestXRange(true)}
+          date={this.state.configuration.date_start}
         />
       </div>
     } else {
@@ -483,7 +460,8 @@ class App extends React.Component {
           seriesName={"Median travel time"}
           location={this.locationDescription(true)}
           isLoading={this.getIsLoadingDataset('traveltimes')}
-          suggestedXRange={this.suggestXRange(false)}
+          startDate={this.state.configuration.date_start}
+          endDate={this.state.configuration.date_end}
         />
         <AggregateLine
           title={'Time between trains (headways)'}
@@ -491,7 +469,8 @@ class App extends React.Component {
           seriesName={'Median headway'}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('headways')}
-          suggestedXRange={this.suggestXRange(false)}
+          startDate={this.state.configuration.date_start}
+          endDate={this.state.configuration.date_end}
         />
         <AggregateLine
           title={'Time spent at station (dwells)'}
@@ -499,7 +478,8 @@ class App extends React.Component {
           seriesName={'Median dwell time'}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('dwells')}
-          suggestedXRange={this.suggestXRange(false)}
+          startDate={this.state.configuration.date_start}
+          endDate={this.state.configuration.date_end}
         />
       </div>
     }

--- a/src/App.js
+++ b/src/App.js
@@ -350,8 +350,8 @@ class App extends React.Component {
     return {};
   }
 
-  suggestXRange() {
-    if (this.getTimescale() === 'hour') {
+  suggestXRange(single_day) {
+    if (single_day) {
       // Force plot to show 6am today to 1am tomorrow at minimum
       const today = `${this.state.configuration.date_start}T00:00:00`;
 
@@ -452,7 +452,7 @@ class App extends React.Component {
           benchmarkField={'benchmark_travel_time_sec'}
           location={this.locationDescription(true)}
           isLoading={this.getIsLoadingDataset('traveltimes')}
-          suggestedXRange={this.suggestXRange()}
+          suggestedXRange={this.suggestXRange(true)}
         />
         <SingleDayLine
           title={'Time between trains (headways)'}
@@ -463,7 +463,7 @@ class App extends React.Component {
           benchmarkField={'benchmark_headway_time_sec'}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('headways')}
-          suggestedXRange={this.suggestXRange()}
+          suggestedXRange={this.suggestXRange(true)}
         />
         <SingleDayLine
           title={'Time spent at station (dwells)'}
@@ -474,7 +474,7 @@ class App extends React.Component {
           benchmarkField={null}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('dwells')}
-          suggestedXRange={this.suggestXRange()}
+          suggestedXRange={this.suggestXRange(true)}
         />
       </div>
     } else {
@@ -485,7 +485,7 @@ class App extends React.Component {
           seriesName={"Median travel time"}
           location={this.locationDescription(true)}
           isLoading={this.getIsLoadingDataset('traveltimes')}
-          suggestedXRange={this.suggestXRange()}
+          suggestedXRange={this.suggestXRange(false)}
         />
         <AggregateLine
           title={'Time between trains (headways)'}
@@ -493,7 +493,7 @@ class App extends React.Component {
           seriesName={'Median headway'}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('headways')}
-          suggestedXRange={this.suggestXRange()}
+          suggestedXRange={this.suggestXRange(false)}
         />
         <AggregateLine
           title={'Time spent at station (dwells)'}
@@ -501,7 +501,7 @@ class App extends React.Component {
           seriesName={'Median dwell time'}
           location={this.locationDescription(false)}
           isLoading={this.getIsLoadingDataset('dwells')}
-          suggestedXRange={this.suggestXRange()}
+          suggestedXRange={this.suggestXRange(false)}
         />
       </div>
     }

--- a/src/line.js
+++ b/src/line.js
@@ -269,4 +269,3 @@ class AggregateLine extends React.Component {
 }
 
 export { SingleDayLine, AggregateLine };
-    

--- a/src/line.js
+++ b/src/line.js
@@ -8,7 +8,7 @@ import drawTitle from './Title';
 Chart.Tooltip.positioners.first = (tooltipItems, eventPos) => {
   let x = eventPos.x;
   let y = eventPos.y;
-  
+
   let firstElem = tooltipItems[0];
   if (firstElem && firstElem.hasValue()) {
     const pos = firstElem.tooltipPosition();
@@ -52,7 +52,7 @@ const point_colors = (data, metric_field, benchmark_field) => {
     else if (ratio > 2.0) {
       return '#bb5cc1'; //purple
     }
-    
+
     return '#1c1c1c'; //whatever
   });
 }
@@ -175,18 +175,19 @@ class SingleDayLine extends React.Component {
                 high.setDate(high.getDate() + 1);
                 high.setHours(1,0);
                 axis.min = Math.min(axis.min, low) || null;
-                axis.max = Math.max(axis.max, high) || null;}
+                axis.max = Math.max(axis.max, high) || null;
               }
-            ]
-          }
-        }}
-        plugins={[{
-          afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
-        }]}
-        />
-        </div>
-        {this.props.benchmarkField && <Legend />}
-        </div>
+            }
+          ]
+        }
+      }}
+      plugins={[{
+        afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
+      }]}
+      />
+      </div>
+      {this.props.benchmarkField && <Legend />}
+      </div>
     );
     // TODO: hide legend when benchmarks are 0s
   }
@@ -268,18 +269,19 @@ class AggregateLine extends React.Component {
                 const low = new Date(`${this.props.startDate}T00:00:00`);
                 const high= new Date(`${this.props.endDate}T00:00:00`);
                 axis.min = Math.min(axis.min, low) || null;
-                axis.max = Math.max(axis.max, high) || null;}
+                axis.max = Math.max(axis.max, high) || null;
               }
-            ]
-          }
-        }}
-        plugins={[{
-          afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
-        }]}
-        />
-        </div>
-        <LegendLongTerm />
-        </div>
+            }
+          ]
+        }
+      }}
+      plugins={[{
+        afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
+      }]}
+      />
+      </div>
+      <LegendLongTerm />
+      </div>
     );
   }
 }

--- a/src/line.js
+++ b/src/line.js
@@ -134,10 +134,6 @@ class SingleDayLine extends React.Component {
         tooltips: {
           // TODO: tooltip is under title words
           callbacks: {
-            title: (tooltipItems, _) => {
-              const date = new Date(tooltipItems[0].xLabel);
-              return date.toLocaleTimeString();
-            },
             afterBody: (tooltipItems) => {
               return departure_from_normal_string(tooltipItems[0].value, tooltipItems[1].value);
             }
@@ -153,7 +149,8 @@ class SingleDayLine extends React.Component {
             type: 'time',
             time: {
               unit: 'hour',
-              unitStepSize: 1
+              unitStepSize: 1,
+              tooltipFormat: "LTS" // locale time with seconds
             },
             scaleLabel: {
               labelString: "Time of day",
@@ -248,9 +245,9 @@ class AggregateLine extends React.Component {
           xAxes: [{
             type: 'time',
             time: {
-              tooltipFormat: "ddd MMM D YYYY",
               unit: 'day',
-              unitStepSize: 1
+              unitStepSize: 1,
+              tooltipFormat: "ddd MMM D YYYY"
             },
             ticks: {
               // force graph to show startDate to endDate, even if missing data

--- a/src/line.js
+++ b/src/line.js
@@ -101,7 +101,7 @@ class SingleDayLine extends React.Component {
     benchmarkField
     location (description used to generate title)
     isLoading
-    suggestedXRange
+    date
     */
     const { isLoading } = this.props;
     let labels = this.props.data.map(item => item[this.props.xField]);
@@ -163,10 +163,19 @@ class SingleDayLine extends React.Component {
               scaleLabel: {
                 labelString: "Time of day",
               },
-              // make sure graph shows /at least/ suggestedXRange, either end will extend to not hide points.
-              afterDataLimits: (axis) => {if (this.props.isLoading) return; // prevents weird sliding animation
-                axis.min = Math.min(axis.min, this.props.suggestedXRange[0]) || null;
-                axis.max = Math.max(axis.max, this.props.suggestedXRange[1]) || null;}
+              // make sure graph shows /at least/ 6am today to 1am tomorrow
+              afterDataLimits: (axis) => {
+                if (this.props.isLoading) {
+                  return; // prevents weird sliding animation
+                }
+                const today = new Date(`${this.props.date}T00:00:00`);
+                let low = new Date(today);
+                low.setHours(6,0);
+                let high = new Date(today);
+                high.setDate(high.getDate() + 1);
+                high.setHours(1,0);
+                axis.min = Math.min(axis.min, low) || null;
+                axis.max = Math.max(axis.max, high) || null;}
               }
             ]
           }
@@ -193,7 +202,8 @@ class AggregateLine extends React.Component {
     seriesName
     location
     isLoading
-    suggestedXRange
+    startDate
+    endDate
     */
     const { isLoading } = this.props;
     let labels = this.props.data.map(item => item['service_date']);
@@ -250,13 +260,15 @@ class AggregateLine extends React.Component {
                 unit: 'day',
                 unitStepSize: 1
               },
-              scaleLabel: {
-                labelString: 'Day'
-              },
-              // make sure graph shows /at least/ suggestedXRange, either end will extend to not hide points.
-              afterDataLimits: (axis) => {if (this.props.isLoading) return; // prevents weird sliding animation
-                axis.min = Math.min(axis.min, this.props.suggestedXRange[0]) || null;
-                axis.max = Math.max(axis.max, this.props.suggestedXRange[1]) || null;}
+              // make sure graph shows /at least/ startDate to endDate, even if missing data
+              afterDataLimits: (axis) => {
+                if (this.props.isLoading) {
+                  return; // prevents weird sliding animation
+                }
+                const low = new Date(`${this.props.startDate}T00:00:00`);
+                const high= new Date(`${this.props.endDate}T00:00:00`);
+                axis.min = Math.min(axis.min, low) || null;
+                axis.max = Math.max(axis.max, high) || null;}
               }
             ]
           }

--- a/src/line.js
+++ b/src/line.js
@@ -66,6 +66,9 @@ merge(defaults, {
         top: 25
       }
     },
+    legend: {
+      display: false
+    },
     title: {
       // empty title to set font and leave room for drawTitle fn
       display: true,
@@ -106,7 +109,6 @@ class SingleDayLine extends React.Component {
       <div className={classNames('chart', isLoading && 'is-loading')}>
       <div className="chart-container">
       <Line
-      legend={{ display: false }}
       data={{
         labels,
         datasets: [
@@ -174,10 +176,10 @@ class SingleDayLine extends React.Component {
         }]}
         />
         </div>
-        {this.props.yField !== "dwell_time_sec" && <Legend />}
+        {this.props.benchmarkField && <Legend />}
         </div>
-        // TODO: hide legend when benchmarks are not present/0s
     );
+    // TODO: hide legend when benchmarks are 0s
   }
 }
  
@@ -199,7 +201,6 @@ class AggregateLine extends React.Component {
       <div className={classNames('chart', isLoading && 'is-loading')}>
       <div className="chart-container">
       <Line
-      legend={{ display: false }}
       data={{
         labels,
         datasets: [

--- a/src/line.js
+++ b/src/line.js
@@ -93,15 +93,15 @@ class SingleDayLine extends React.Component {
   render() {
     /*
     Props:
-    title
-    data
-    seriesName
-    xField
-    yField
-    benchmarkField
-    location (description used to generate title)
-    isLoading
-    date
+      title
+      data
+      seriesName
+      xField
+      yField
+      benchmarkField
+      location (description used to generate title)
+      isLoading
+      date
     */
     const { isLoading } = this.props;
     let labels = this.props.data.map(item => item[this.props.xField]);
@@ -139,46 +139,40 @@ class SingleDayLine extends React.Component {
               return date.toLocaleTimeString();
             },
             afterBody: (tooltipItems) => {
-              if (tooltipItems.length === 2) {
-                return departure_from_normal_string(tooltipItems[0].value, tooltipItems[1].value);
-              }
+              return departure_from_normal_string(tooltipItems[0].value, tooltipItems[1].value);
             }
           }
         },
         scales: {
-          yAxes: [
-            {
-              scaleLabel: {
-                labelString: "Minutes"
-              }
+          yAxes: [{
+            scaleLabel: {
+              labelString: "Minutes"
             }
-          ],
-          xAxes: [
-            {
-              type: 'time',
-              time: {
-                unit: 'hour',
-                unitStepSize: 1
-              },
-              scaleLabel: {
-                labelString: "Time of day",
-              },
-              // make sure graph shows /at least/ 6am today to 1am tomorrow
-              afterDataLimits: (axis) => {
-                if (this.props.isLoading) {
-                  return; // prevents weird sliding animation
-                }
-                const today = new Date(`${this.props.date}T00:00:00`);
-                let low = new Date(today);
-                low.setHours(6,0);
-                let high = new Date(today);
-                high.setDate(high.getDate() + 1);
-                high.setHours(1,0);
-                axis.min = Math.min(axis.min, low) || null;
-                axis.max = Math.max(axis.max, high) || null;
+          }],
+          xAxes: [{
+            type: 'time',
+            time: {
+              unit: 'hour',
+              unitStepSize: 1
+            },
+            scaleLabel: {
+              labelString: "Time of day",
+            },
+            // make sure graph shows /at least/ 6am today to 1am tomorrow
+            afterDataLimits: (axis) => {
+              if (this.props.isLoading) {
+                return; // prevents weird sliding animation
               }
+              const today = new Date(`${this.props.date}T00:00:00`);
+              let low = new Date(today);
+              low.setHours(6,0);
+              let high = new Date(today);
+              high.setDate(high.getDate() + 1);
+              high.setHours(1,0);
+              axis.min = Math.min(axis.min, low) || null;
+              axis.max = Math.max(axis.max, high) || null;
             }
-          ]
+          }]
         }
       }}
       plugins={[{
@@ -198,13 +192,13 @@ class AggregateLine extends React.Component {
   render() {
     /*
     Props:
-    title
-    data
-    seriesName
-    location
-    isLoading
-    startDate
-    endDate
+      title
+      data
+      seriesName
+      location
+      isLoading
+      startDate
+      endDate
     */
     const { isLoading } = this.props;
     let labels = this.props.data.map(item => item['service_date']);
@@ -246,33 +240,24 @@ class AggregateLine extends React.Component {
       }}
       options={{
         scales: {
-          yAxes: [
-            {
-              scaleLabel: {
-                labelString: "Minutes"
-              }
+          yAxes: [{
+            scaleLabel: {
+              labelString: "Minutes"
             }
-          ],
-          xAxes: [
-            {
-              type: 'time',
-              time: {
-                tooltipFormat: "ddd MMM D YYYY",
-                unit: 'day',
-                unitStepSize: 1
-              },
-              // make sure graph shows /at least/ startDate to endDate, even if missing data
-              afterDataLimits: (axis) => {
-                if (this.props.isLoading) {
-                  return; // prevents weird sliding animation
-                }
-                const low = new Date(`${this.props.startDate}T00:00:00`);
-                const high= new Date(`${this.props.endDate}T00:00:00`);
-                axis.min = Math.min(axis.min, low) || null;
-                axis.max = Math.max(axis.max, high) || null;
-              }
+          }],
+          xAxes: [{
+            type: 'time',
+            time: {
+              tooltipFormat: "ddd MMM D YYYY",
+              unit: 'day',
+              unitStepSize: 1
+            },
+            ticks: {
+              // force graph to show startDate to endDate, even if missing data
+              min: new Date(`${this.props.startDate}T00:00:00`),
+              max: new Date(`${this.props.endDate}T00:00:00`),
             }
-          ]
+          }]
         }
       }}
       plugins={[{

--- a/src/line.js
+++ b/src/line.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Line, Chart } from 'react-chartjs-2';
+import { Line, Chart, defaults } from 'react-chartjs-2';
+import merge from 'lodash.merge';
 import {Legend, LegendLongTerm} from './Legend';
 import drawTitle from './Title';
 
 Chart.Tooltip.positioners.first = (tooltipItems, eventPos) => {
   let x = eventPos.x;
   let y = eventPos.y;
-
+  
   let firstElem = tooltipItems[0];
   if (firstElem && firstElem.hasValue()) {
     const pos = firstElem.tooltipPosition();
@@ -51,152 +52,224 @@ const point_colors = (data, metric_field, benchmark_field) => {
     else if (ratio > 2.0) {
       return '#bb5cc1'; //purple
     }
-
+    
     return '#1c1c1c'; //whatever
   });
 }
 
-class LineClass extends React.Component {
+merge(defaults, {
+  global: {
+    responsive: true,
+    maintainAspectRatio: false,
+    layout: {
+      padding: {
+        top: 25
+      }
+    },
+    title: {
+      // empty title to set font and leave room for drawTitle fn
+      display: true,
+      text: "",
+      fontSize: 16,
+    },
+    tooltips: {
+      mode: "index",
+      position: "first"
+    }
+  },
+  scale: {
+    scaleLabel: {
+      display: true,
+      fontSize: 14
+    }
+  }
+});
 
+class SingleDayLine extends React.Component {
+  
   render() {
     /*
     Props:
-      seriesName
-      xField
-      xFieldLabel
-      yField
-      yFieldLabel
-      benchmarkField
-      alerts
+    title
+    data
+    seriesName
+    xField
+    yField
+    benchmarkField
+    location (description used to generate title)
+    isLoading
+    suggestedXRange
     */
     const { isLoading } = this.props;
     let labels = this.props.data.map(item => item[this.props.xField]);
     return (
       <div className={classNames('chart', isLoading && 'is-loading')}>
-        <div className="chart-container">
-          <Line
-            legend={{ display: false }}
-            data={{
-              labels,
-              datasets: [
-                {
-                  label: this.props.timescale === 'hour' ? `Actual ${this.props.seriesName}` : this.props.seriesName,
-                  fill: false,
-                  lineTension: 0.1,
-                  pointBackgroundColor: point_colors(this.props.data, this.props.yField, this.props.benchmarkField),
-                  pointHoverRadius: 3,
-                  pointHoverBackgroundColor: point_colors(this.props.data, this.props.yField, this.props.benchmarkField),
-                  pointRadius: 3,
-                  pointHitRadius: 10,
-                  data: this.props.data.map(item => (item[this.props.yField] / 60).toFixed(2))
-                },
-                {
-                  label: "25th percentile",
-                  fill: 1,
-                  backgroundColor: "rgba(191,200,214,0.5)",
-                  lineTension: 0.4,
-                  pointRadius: 0,
-                  data: this.props.data.map(item => (item["25%"] / 60).toFixed(2))
-                },
-                {
-                  label: "75th percentile",
-                  fill: 1,
-                  backgroundColor: "rgba(191,200,214,0.5)",
-                  lineTension: 0.4,
-                  pointRadius: 0,
-                  data: this.props.data.map(item => (item["75%"] / 60).toFixed(2))
-                },
-                {
-                  label: `Benchmark MBTA ${this.props.seriesName}`,
-                  data: this.props.data.map(item => (item[this.props.benchmarkField] / 60).toFixed(2)),
-                  pointRadius: 0
-                }
-              ]
-            }}
-            options={{
-              responsive: true,
-              maintainAspectRatio: false,
-              layout: {
-                padding: {
-                  top: 25
-                }
-              },
-              title: {
-                // empty title here to leave space and set font for the drawTitle process
-                display: true,
-                text: "",
-                fontSize: 16
-              },
-              tooltips: {
-                mode: "index",
-                position: "first",
-                callbacks: {
-                  title: (tooltipItems, _) => {
-                    if (this.props.timescale === "day") {
-                      /* In aggregation mode, dates come back from the server no times.
-                        Because we're -4/-5 UTC, the resulting strings become 7pm/8pm the previous day with affixing 00:00:00.
-                        Blegh */
-                      const date = new Date(`${tooltipItems[0].xLabel}T00:00:00`); // Safari won't parse "2021-03-30" alone
-                      return date.toDateString();
-                    }
-                    else if(this.props.timescale === "hour") {
-                      const date = new Date(tooltipItems[0].xLabel);
-                      return date.toLocaleTimeString();
-                    }
-                  },
-                  // label: (tooltipItem, _) => {
-                  //   if (tooltipItem.datasetIndex === 0) {
-                  //     return `Actual ${this.props.tooltipUnit}: ${parseFloat(tooltipItem.value).toFixed(2)}`;
-                  //   }
-                  //   return `Benchmark MBTA ${this.props.tooltipUnit}: ${parseFloat(tooltipItem.value).toFixed(2)}`;
-                  // },
-                  afterBody: (tooltipItems) => {
-                    if (tooltipItems.length === 2) {
-                      return departure_from_normal_string(tooltipItems[0].value, tooltipItems[1].value);
-                    }
-                  }
-                }
-              },
-              scales: {
-                yAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      fontSize: 14,
-                      labelString: this.props.yFieldLabel
-                    }
-                  }
-                ],
-                xAxes: [
-                  {
-                    type: this.props.xFieldType || 'time',
-                    time: {
-                      unit: this.props.xFieldUnit || 'hour',
-                      unitStepSize: 1
-                    },
-                    scaleLabel: {
-                      display: true,
-                      fontSize: 14,
-                      labelString: this.props.xFieldLabel
-                    },
-                    // make sure graph shows /at least/ suggestedXRange, either end will extend to not hide points.
-                    afterDataLimits: (axis) => {if (this.props.isLoading) return; // prevents weird sliding animation
-                                                axis.min = Math.min(axis.min, this.props.suggestedXRange[0]) || null;
-                                                axis.max = Math.max(axis.max, this.props.suggestedXRange[1]) || null;}
-                  }
-                ]
+      <div className="chart-container">
+      <Line
+      legend={{ display: false }}
+      data={{
+        labels,
+        datasets: [
+          {
+            label: `Actual ${this.props.seriesName}`,
+            fill: false,
+            lineTension: 0.1,
+            pointBackgroundColor: point_colors(this.props.data, this.props.yField, this.props.benchmarkField),
+            pointHoverRadius: 3,
+            pointHoverBackgroundColor: point_colors(this.props.data, this.props.yField, this.props.benchmarkField),
+            pointRadius: 3,
+            pointHitRadius: 10,
+            data: this.props.data.map(item => (item[this.props.yField] / 60).toFixed(2))
+          },
+          {
+            label: `Benchmark MBTA ${this.props.seriesName}`,
+            data: this.props.data.map(item => (item[this.props.benchmarkField] / 60).toFixed(2)),
+            pointRadius: 0
+          }
+        ]
+      }}
+      options={{
+        tooltips: {
+          // TODO: tooltip is under title words
+          callbacks: {
+            title: (tooltipItems, _) => {
+              const date = new Date(tooltipItems[0].xLabel);
+              return date.toLocaleTimeString();
+            },
+            afterBody: (tooltipItems) => {
+              if (tooltipItems.length === 2) {
+                return departure_from_normal_string(tooltipItems[0].value, tooltipItems[1].value);
               }
-            }}
-            plugins={[{
-              afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
-            }]}
-          />
+            }
+          }
+        },
+        scales: {
+          yAxes: [
+            {
+              scaleLabel: {
+                labelString: "Minutes"
+              }
+            }
+          ],
+          xAxes: [
+            {
+              type: 'time',
+              time: {
+                unit: 'hour',
+                unitStepSize: 1
+              },
+              scaleLabel: {
+                labelString: "Time of day",
+              },
+              // make sure graph shows /at least/ suggestedXRange, either end will extend to not hide points.
+              afterDataLimits: (axis) => {if (this.props.isLoading) return; // prevents weird sliding animation
+                axis.min = Math.min(axis.min, this.props.suggestedXRange[0]) || null;
+                axis.max = Math.max(axis.max, this.props.suggestedXRange[1]) || null;}
+              }
+            ]
+          }
+        }}
+        plugins={[{
+          afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
+        }]}
+        />
         </div>
-        {this.props.timescale === 'day' && <LegendLongTerm />}
-        {this.props.timescale === 'hour' && this.props.yField !== "dwell_time_sec" && <Legend />}
-      </div>
+        {this.props.yField !== "dwell_time_sec" && <Legend />}
+        </div>
+        // TODO: hide legend when benchmarks are not present/0s
+    );
+  }
+}
+ 
+class AggregateLine extends React.Component {
+  
+  render() {
+    /*
+    Props:
+    title
+    data
+    seriesName
+    location
+    isLoading
+    suggestedXRange
+    */
+    const { isLoading } = this.props;
+    let labels = this.props.data.map(item => item['service_date']);
+    return (
+      <div className={classNames('chart', isLoading && 'is-loading')}>
+      <div className="chart-container">
+      <Line
+      legend={{ display: false }}
+      data={{
+        labels,
+        datasets: [
+          {
+            label: this.props.seriesName,
+            fill: false,
+            lineTension: 0.1,
+            pointBackgroundColor: '#1c1c1c',
+            pointHoverRadius: 3,
+            pointHoverBackgroundColor: '#1c1c1c',
+            pointRadius: 3,
+            pointHitRadius: 10,
+            data: this.props.data.map(item => (item["50%"] / 60).toFixed(2))
+          },
+          {
+            label: "25th percentile",
+            fill: 1,
+            backgroundColor: "rgba(191,200,214,0.5)",
+            lineTension: 0.4,
+            pointRadius: 0,
+            data: this.props.data.map(item => (item["25%"] / 60).toFixed(2))
+          },
+          {
+            label: "75th percentile",
+            fill: 1,
+            backgroundColor: "rgba(191,200,214,0.5)",
+            lineTension: 0.4,
+            pointRadius: 0,
+            data: this.props.data.map(item => (item["75%"] / 60).toFixed(2))
+          },
+        ]
+      }}
+      options={{
+        scales: {
+          yAxes: [
+            {
+              scaleLabel: {
+                labelString: "Minutes"
+              }
+            }
+          ],
+          xAxes: [
+            {
+              type: 'time',
+              time: {
+                tooltipFormat: "ddd MMM D YYYY",
+                unit: 'day',
+                unitStepSize: 1
+              },
+              scaleLabel: {
+                labelString: 'Day'
+              },
+              // make sure graph shows /at least/ suggestedXRange, either end will extend to not hide points.
+              afterDataLimits: (axis) => {if (this.props.isLoading) return; // prevents weird sliding animation
+                axis.min = Math.min(axis.min, this.props.suggestedXRange[0]) || null;
+                axis.max = Math.max(axis.max, this.props.suggestedXRange[1]) || null;}
+              }
+            ]
+          }
+        }}
+        plugins={[{
+          afterDraw: (chart) => drawTitle(this.props.title, this.props.location, chart)
+        }]}
+        />
+        </div>
+        <LegendLongTerm />
+        </div>
     );
   }
 }
 
-export default LineClass;
+export { SingleDayLine, AggregateLine };
+    


### PR DESCRIPTION
This has been a bit overdue- it should resolve #63 
Chart types are now separate, which should make adding a new chart type for buses and peak/off-peak stuff easier. 

Hopefully things are cleaner/more readable, but let me know if I've gone too far.

Major things include:
- turning our `Line` chart into two types: `SingleDayLine` and `AggregateLine`. Most common settings are factored out into defaults, and so each chart can have more specific logic built in. Git diff is making a mess of this, it might be easier to read just the final file.
- E.g for the above: the suggestedXRange logic was moved out of App.js and into each chart's axis settings (as an `afterDraw` function).
- There was a bug where picking a date range >8months and then quitting multi-day mode would leave you stuck with the 8-month error, even on refresh. A slight logic change has solved that issue.