### PR TITLE
Improve local development API path code.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,12 +12,13 @@ import Select from './Select';
 import { configPresets } from './constants';
 
 const FRONTEND_TO_BACKEND_MAP = new Map([
-  ["localhost", ""], // this becomes a relative path that is proxied through CRA:3000 to python on :5000
-  ["127.0.0.1", ""],
   ["dashboard.transitmatters.org", "https://dashboard-api2.transitmatters.org"],
   ["dashboard-beta.transitmatters.org", "https://dashboard-api-beta.transitmatters.org"]
 ]);
-const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname);
+
+// Fetch the absolute location of the API to load from; fall back to "" which
+// acts as a relative path for local development.
+const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname) || "";
 
 const MAX_AGGREGATION_MONTHS = 8;
 const RANGE_TOO_LARGE_ERROR = `Please select a range no larger than ${MAX_AGGREGATION_MONTHS} months.`;


### PR DESCRIPTION
Previously, when loading the dashboard on a host other than localhost (e.g.
a development server name), the lookup would fail and return "undefined",
which would break the API requests in a confusing way. Rather than hardcoding
localhost, just fall back to the relative path option for any falsey thing.