### PR TITLE
Progress Bar refactor

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -20,7 +20,7 @@ const TODAY = new Date().toISOString().split("T")[0];
 export const configPresets = [
 	{
 		label: "June to December 2021 — Orange Line slow zones",
-		value: createConfigPresetValue("Orange", "Downtown Crossing", "Green Street", "2021-06-01", "2021-12-31")
+		value: createConfigPresetValue("Orange", "Downtown Crossing", "Green Street", "2021-06-01", TODAY)
 	},
 	{
 		label: "September 9, 2021 — Route 28 first day of school traffic",

--- a/src/ui/ProgressBar.css
+++ b/src/ui/ProgressBar.css
@@ -3,9 +3,8 @@
   position: absolute;
   background-color: gray;
   color: black;
-  border-radius: 10px;
+  border-radius: 0px 10px 10px 0px;
   width: 0%;
   height: 8px;
   transition: width 0.5s ease-in-out;
-  visibility: hidden;;
 }

--- a/src/ui/ProgressBar.js
+++ b/src/ui/ProgressBar.js
@@ -1,19 +1,81 @@
 import React from "react";
 import './ProgressBar.css';
 
-const ProgressBar = (props) => {
-  const { progress } = props;
-  if (!(progress >= 0 && progress < 100)) {
-    return (null);
+function progressBarRate(date_start, date_end) {
+  // Single day: no rate
+  if(!date_end) {
+    return null;
+  }
+  // Aggregation: fake rate based on how many days
+  const ms = (new Date(date_end) - new Date(date_start));
+  const days = ms / (1000*60*60*24);
+  const months = days / 30;
+  const total_seconds_expected = 3.0 * months;
+  return 100 / total_seconds_expected;
+}
+
+
+class ProgressBar extends React.Component{
+  /**
+   * This is now a completely uncontrolled component.
+   * Once mounted, it will run until 95% or it's unmounted.
+   * key is used by App.js to make React mount a new one each time.
+   * props: rate, key
+   */
+  constructor(props) {
+    super(props);
+    this.timer = null;
+    this.state = {
+      progress: 0
+    }
   }
 
-  return (
-    <div className="progress-bar" style={{
-      width: `${progress}%`,
-      backgroundColor: props.color || "grey",
-      visibility: progress < 100 && "visible",
-    }} />
-  );
-};
+  componentDidMount() {
+    this.startTimer();
+  }
 
-export default ProgressBar;
+  componentWillUnmount() {
+    this.stopTimer();
+  }
+
+  startTimer() {
+    // shouldn't be necessary to reset, but just in case
+    this.stopTimer();
+    this.setState({
+      progress: 0,
+    });
+    this.timer = setInterval(
+      () => this.tick(),
+      1000
+    );
+  }
+
+  stopTimer() {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+    this.timer = null;
+  }
+
+  tick() {
+    this.setState((state, props) => {
+      const newProgress = state.progress + props.rate;
+      if (newProgress < 95) {
+        return { progress: newProgress };
+      } else {
+        this.stopTimer();
+        return { progress: 95 };
+      }
+    });
+  }
+
+  render() {
+    return (
+      <div className="progress-bar"
+        style={{width: `${this.state.progress}%`}}
+      />
+    )
+  }
+}
+
+export { ProgressBar, progressBarRate };


### PR DESCRIPTION
I wanted this to be a "minor bug fix", and functionality-wise, it is. But it's structurally different enough that it probably warrants a separate review. Thanks, and sorry!

==========
ProgressBar now encapsulates its own "progress" state. This prevents everything in App from rerendering with the timer (since state was being updated). 
The `key` is used to tell React when to "refresh" the progress bar (i.e. on configuration change), which it does by mounting a brand new one. Visibility is controlled by presence or absence in the DOM instead of css.