### PR TITLE
hotfix: force flatpickr for everyone

### DIFF
--- a/src/inputs/date.js
+++ b/src/inputs/date.js
@@ -4,7 +4,8 @@ import 'flatpickr/dist/themes/light.css';
 
 const ua = window.navigator.userAgent;
 const isMobile = /Android|webOS|iPhone|iPad|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-const useFlatPickr = !isMobile;
+// `max:` doesn't work on iOS, so using flatpickr for everyone
+const useFlatPickr = true; // !isMobile;
 
 const RegularDateInput = (props) => {
   let maxDate = props.options.maxDate;
@@ -49,6 +50,7 @@ class Flatpickr extends React.Component {
   createFlatpickr = () => {
     this.flatpickr = flatpickr(this.node,
       {
+        disableMobile: true, // we've already decided on flatpickr at this point
         date: this.props.value,
         onChange: (sel, dateStr, inst) => this.props.onChange(dateStr),
         ...this.props.options


### PR DESCRIPTION
Fixing bug on iOS because apple decided html5 <input type=date>'s max: prop shouldn't do anything.
New version is currently deployed on beta if you have an iPhone and want to confirm.
(thanks @purcellif17 !!)