### PR TITLE
add todayDiclaimer for messy day-of data

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -509,3 +509,8 @@ button:disabled,
   font-style: italic;
   padding-top: 30px;
 }
+
+.today-disclaimer {
+  font-style: italic;
+  padding-top: 30px;
+}

--- a/src/ChartSets.js
+++ b/src/ChartSets.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { AggregateByTimeSelectable } from './charts/SelectableCharts';
 import { SingleDayLine, AggregateByDate } from './charts/line';
 import { station_direction } from './stations';
-import { BusDisclaimer } from './ui/notes';
+import { BusDisclaimer, TodayDisclaimer } from './ui/notes';
+import { TODAY } from './constants';
 
 const dataFields = {
   traveltimes: {
@@ -133,6 +134,7 @@ const SingleDaySet = (props) => {
           date={props.startDate}
         />
       }
+      {props.startDate === TODAY && <TodayDisclaimer />}
       {props.bus_mode && <BusDisclaimer />}
     </div>
   )

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,8 @@ export const colorsForLine = {
 	bus: '#ffc72c',
 };
 
+export const TODAY = new Date().toISOString().split("T")[0];
+
 export const trainDateRange = {
 	minDate: "2016-01-15",
 	maxDate: "today"

--- a/src/presets.js
+++ b/src/presets.js
@@ -15,8 +15,6 @@ const createConfigPresetValue = (line, fromStationName, toStationName, date_star
 	}
 };
 
-// const TODAY = new Date().toISOString().split("T")[0];
-
 export const configPresets = [
 	{
 		label: "Jan 12, 2022 — Red Line door problem",

--- a/src/ui/notes.js
+++ b/src/ui/notes.js
@@ -10,4 +10,12 @@ const BusDisclaimer = () => {
     )
 };
 
-export { BusDisclaimer };
+const TodayDisclaimer = () => {
+    return(
+        <div className="today-disclaimer">
+            Today's data haven't been cleaned yet and may be a little messy.
+        </div>
+    )
+}
+
+export { BusDisclaimer, TodayDisclaimer };


### PR DESCRIPTION
Adds disclaimer for current day's data which may be messy.
It turn out that the T's overnight processing doesn't clean up all the mess, so we may want to consider other approaches in addition to this.
![image](https://user-images.githubusercontent.com/8498946/152703915-7862ecb8-4714-4706-8860-d292a61d09d5.png)

This also won't handle the midnight-3am scenario without more complicated logic... I can add if desired.

