### PR TITLE
Alerty

### DIFF
--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -195,7 +195,8 @@ def alerts(day, params):
     try:
         # Grab the current "transit day" (3:30am-3:30am)
         today = current_transit_day()
-        yesterday = today - datetime.timedelta(days=1)
+        # yesterday + 1 bonus day to cover the gap, since aws is only populated at 5/6am.
+        yesterday = today - datetime.timedelta(days=2)
 
         # Use the API for today and yesterday's transit day, otherwise us.
         if day >= yesterday:
@@ -223,4 +224,4 @@ def alerts(day, params):
         return flat_alerts
     except Exception:
         traceback.print_exc()
-        return []
+        return None

--- a/server/chalicelib/s3_alerts.py
+++ b/server/chalicelib/s3_alerts.py
@@ -19,10 +19,13 @@ def key(day):
     return f"Alerts/{str(day)}.json.gz"
 
 
-def get_alerts(day, route):
+def get_alerts(day, routes):
     alerts_str = s3.download(key(day), "utf8")
     alerts = json.loads(alerts_str)[0]["past_alerts"]
-    return list(filter(lambda alert: route[0] in routes_for_alert(alert), alerts))
+    def matches_route(alert):
+        targets = routes_for_alert(alert)
+        return any(r in targets for r in routes)
+    return list(filter(matches_route, alerts))
 
 
 def store_alerts(day):

--- a/server/chalicelib/s3_alerts.py
+++ b/server/chalicelib/s3_alerts.py
@@ -22,9 +22,11 @@ def key(day):
 def get_alerts(day, routes):
     alerts_str = s3.download(key(day), "utf8")
     alerts = json.loads(alerts_str)[0]["past_alerts"]
+
     def matches_route(alert):
         targets = routes_for_alert(alert)
         return any(r in targets for r in routes)
+
     return list(filter(matches_route, alerts))
 
 

--- a/server/refill_slowzones.py
+++ b/server/refill_slowzones.py
@@ -1,0 +1,30 @@
+import datetime
+
+from chalicelib.parallel import date_range
+from chalicelib.s3_alerts import store_alerts, get_alerts
+
+
+START = datetime.date(2022,1,3)
+END = datetime.date.today() - datetime.timedelta(days=2)
+
+def do_alerts_exist(d):
+    try:
+        get_alerts(d, ["Red"])
+    except Exception as err:
+        if err.response["Error"]["Code"] == "NoSuchKey":
+            return False
+    return True
+
+
+for d in date_range(START, END):
+    if do_alerts_exist(d):
+        continue
+    print("storing", d)
+    for i in range(3):
+        print("  attempt", i+1, "of 3")
+        try:
+            store_alerts(d)
+            print("success")
+            break
+        except:
+            continue

--- a/server/refill_slowzones.py
+++ b/server/refill_slowzones.py
@@ -3,10 +3,14 @@ import datetime
 from chalicelib.parallel import date_range
 from chalicelib.s3_alerts import store_alerts, get_alerts
 
+import sys
+if len(sys.argv) < 3:
+    print("usage: python refill_slowzones.py 2021-04-12 2021-05-01")
+start_str = sys.argv[1]
+end_str = sys.argv[2]
 
-START = datetime.date(2022, 1, 3)
-END = datetime.date.today() - datetime.timedelta(days=2)
-
+START = datetime.datetime.strptime(start_str, "%Y-%m-%d").date()
+END = datetime.datetime.strptime(end_str, "%Y-%m-%d").date()
 
 def do_alerts_exist(d):
     try:

--- a/server/refill_slowzones.py
+++ b/server/refill_slowzones.py
@@ -12,6 +12,7 @@ end_str = sys.argv[2]
 START = datetime.datetime.strptime(start_str, "%Y-%m-%d").date()
 END = datetime.datetime.strptime(end_str, "%Y-%m-%d").date()
 
+
 def do_alerts_exist(d):
     try:
         get_alerts(d, ["Red"])

--- a/server/refill_slowzones.py
+++ b/server/refill_slowzones.py
@@ -4,8 +4,9 @@ from chalicelib.parallel import date_range
 from chalicelib.s3_alerts import store_alerts, get_alerts
 
 
-START = datetime.date(2022,1,3)
+START = datetime.date(2022, 1, 3)
 END = datetime.date.today() - datetime.timedelta(days=2)
+
 
 def do_alerts_exist(d):
     try:
@@ -21,10 +22,10 @@ for d in date_range(START, END):
         continue
     print("storing", d)
     for i in range(3):
-        print("  attempt", i+1, "of 3")
+        print("  attempt", i + 1, "of 3")
         try:
             store_alerts(d)
             print("success")
             break
-        except:
+        except Exception:
             continue

--- a/src/App.js
+++ b/src/App.js
@@ -360,7 +360,8 @@ class App extends React.Component {
           alerts: null,
         });
         this.fetchDataset('alerts', controller.signal, {
-          route: configuration.line,
+          // split so the 114/116/117 get their fun too.
+          route: configuration.line.split("/"),
         });
       }
 

--- a/src/ChartSets.js
+++ b/src/ChartSets.js
@@ -3,7 +3,7 @@ import { AggregateByTimeSelectable } from './charts/SelectableCharts';
 import { SingleDayLine, AggregateByDate } from './charts/line';
 import { station_direction } from './stations';
 import { BusDisclaimer, TodayDisclaimer } from './ui/notes';
-import { TODAY } from './constants';
+import { TODAY_SERVICE_DATE } from './constants';
 
 const dataFields = {
   traveltimes: {
@@ -32,7 +32,7 @@ const headwayTitle = {
   false: "Time between trains (headways)"
 }
 
-function getLocationDescription(from, to, line) {  
+function getLocationDescription(from, to, line) {
   if (from && to) {
     return {
       to: to.stop_name,
@@ -134,7 +134,7 @@ const SingleDaySet = (props) => {
           date={props.startDate}
         />
       }
-      {props.startDate === TODAY && <TodayDisclaimer />}
+      {props.startDate === TODAY_SERVICE_DATE() && <TodayDisclaimer />}
       {props.bus_mode && <BusDisclaimer />}
     </div>
   )

--- a/src/alerts/AlertBar.js
+++ b/src/alerts/AlertBar.js
@@ -46,8 +46,12 @@ export default function AlertBar(props) {
 
 
   const renderBoxes = () => {
-    if (isLoading || !alerts) {
+    if (isLoading) {
       return null;
+    }
+
+    if (!alerts) {
+      return <div>Unable to retrieve this day's MBTA incidents.</div>
     }
 
     const [start, end] = chartTimeframe(today);

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,14 @@ export const colorsForLine = {
 	bus: '#ffc72c',
 };
 
-export const TODAY = new Date().toISOString().split("T")[0];
+export const TODAY_SERVICE_DATE = () => {
+	// toISOString returns in UTC.
+	// I want "3am Eastern", which is UTC-07:00.
+	// and when DST ends and it's actually 4am EST, that's fine too.
+	const d = new Date();
+	d.setHours(d.getHours() - 7);
+	return d.toISOString().split("T")[0];
+}
 
 export const trainDateRange = {
 	minDate: "2016-01-15",


### PR DESCRIPTION
- add script that can be used to manually refill slowzones on s3 if/when the lambda fails (has been okay this month, but in dec there were many issues)
- differentiate between "no alerts" and "alerts not found"-- an important distinction!!
- allow alert fetching for 114/6/7