### PR TITLE
Slow Zones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "highcharts": "^9.3.3",
         "highcharts-react-official": "^3.1.0",
         "lodash.merge": "^4.6.2",
+        "moment": "^2.29.1",
         "react": "^17.0.0",
         "react-chartjs-2": "^2.11.1",
         "react-dom": "^17.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,21 @@
       "hasInstallScript": true,
       "dependencies": {
         "@tippyjs/react": "^4.0.2",
+        "@types/react": "^17.0.39",
         "chart.js": "^2.9.4",
         "classnames": "^2.2.6",
         "concurrently": "^7.0.0",
         "flatpickr": "^4.6.9",
+        "highcharts": "^9.3.3",
+        "highcharts-react-official": "^3.1.0",
         "lodash.merge": "^4.6.2",
         "react": "^17.0.0",
         "react-chartjs-2": "^2.11.1",
         "react-dom": "^17.0.0",
         "react-router-dom": "^5.1.2",
         "react-scripts": "^5.0.0",
-        "react-select": "^4.0.0"
+        "react-select": "^4.0.0",
+        "typescript": "^4.5.5"
       },
       "devDependencies": {
         "eslint": "^8.0.0"
@@ -3029,6 +3033,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.3.tgz",
       "integrity": "sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w=="
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
     "node_modules/@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
@@ -3044,6 +3053,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
+    "node_modules/@types/react": {
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -3056,6 +3075,11 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -7296,6 +7320,20 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highcharts": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz",
+      "integrity": "sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg=="
+    },
+    "node_modules/highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "peerDependencies": {
+        "highcharts": ">=6.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/history": {
@@ -13263,7 +13301,6 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16466,6 +16503,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.3.tgz",
       "integrity": "sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w=="
     },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
     "@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
@@ -16481,6 +16523,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
+    "@types/react": {
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -16493,6 +16545,11 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -19615,6 +19672,17 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "highcharts": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz",
+      "integrity": "sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg=="
+    },
+    "highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "requires": {}
     },
     "history": {
       "version": "4.10.1",
@@ -23887,8 +23955,7 @@
     "typescript": {
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "peer": true
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "highcharts": "^9.3.3",
     "highcharts-react-official": "^3.1.0",
     "lodash.merge": "^4.6.2",
+    "moment": "^2.29.1",
     "react": "^17.0.0",
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,21 @@
   "private": true,
   "dependencies": {
     "@tippyjs/react": "^4.0.2",
+    "@types/react": "^17.0.39",
     "chart.js": "^2.9.4",
     "classnames": "^2.2.6",
     "concurrently": "^7.0.0",
     "flatpickr": "^4.6.9",
+    "highcharts": "^9.3.3",
+    "highcharts-react-official": "^3.1.0",
     "lodash.merge": "^4.6.2",
     "react": "^17.0.0",
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^5.0.0",
-    "react-select": "^4.0.0"
+    "react-select": "^4.0.0",
+    "typescript": "^4.5.5"
   },
   "devDependencies": {
     "eslint": "^8.0.0"

--- a/src/App.css
+++ b/src/App.css
@@ -428,7 +428,6 @@ button:disabled,
     'line'
     'date';
     row-gap: 15px;
-    font-size: 14px
   }
 
   .slow-zone .line-toggle , .chart-toggle , .direction-toggle{ 
@@ -593,3 +592,8 @@ button:disabled,
 .Blue input:checked + span{
   background-color:var( --blue-line);
 }
+
+.slow-zone {
+  font-size: 14px;
+}
+

--- a/src/App.css
+++ b/src/App.css
@@ -67,8 +67,9 @@
 
 
 .empty-state #slowzone-button {
-  background-color: var(--bus);
-  padding: 5px;
+  background-color: #333;
+  color:white;
+  padding: 3px 8px 3px 8px;
   margin-left: 5px;
   cursor: pointer;
 }
@@ -427,6 +428,7 @@ button:disabled,
     'line'
     'date';
     row-gap: 15px;
+    font-size: 14px
   }
 
   .slow-zone .line-toggle , .chart-toggle , .direction-toggle{ 
@@ -465,7 +467,7 @@ button:disabled,
     grid-area: stations;
   }
 
-  .station-configuration .slow-zone > .option-date {
+  .station-configuration > .option-date {
     grid-area: date;
     display: flex;
   }

--- a/src/App.css
+++ b/src/App.css
@@ -417,6 +417,16 @@ button:disabled,
     row-gap: 10px;
   }
 
+  .slow-zone {
+    padding-top:10px;
+    padding-bottom: 10px;
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-areas: 'chart-toggle';
+    row-gap: 15px;
+    justify-items:center
+  }
+
   .station-configuration .from-to-label,
   .station-configuration .date-label {
     width: 30px;
@@ -526,4 +536,52 @@ button:disabled,
 .today-disclaimer {
   font-style: italic;
   padding-top: 30px;
+}
+
+.button-toggle {
+  margin:4px;
+  background-color:#EFEFEF;
+  border-radius:4px;
+  border:1px solid #D0D0D0;
+  overflow:auto;
+  float:left;
+  cursor: pointer;
+}
+.button-toggle label {
+  float:left;
+  width: 4.0em;
+  cursor: pointer;
+  color: black
+}
+
+.button-toggle label span {
+  text-align:center;
+  padding:3px 0px;
+  display:block;
+}
+
+.button-toggle label input {
+  position:absolute;
+  top:-20px;
+}
+
+.button-toggle input:checked + span {
+  color:#fff;
+}
+
+.button-toggle input:disabled + span {
+  color:#fff;
+  cursor: not-allowed	;
+}
+
+.Red input:checked + span{
+  background-color:var( --red-line);
+}
+
+.Orange input:checked + span{
+  background-color:var( --orange-line);
+}
+
+.Blue input:checked + span{
+  background-color:var( --blue-line);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -167,6 +167,7 @@
 
 .station-configuration {
   padding: 10px;
+  line-height: 1.0;
 }
 
 select,
@@ -363,6 +364,10 @@ button:disabled,
   .station-configuration .select-component {
     flex-grow: 1;
     flex-shrink: 1;
+  }
+
+  .slowzones-switch-label {
+    width: 100px;
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -421,14 +421,18 @@ button:disabled,
     padding-top:10px;
     padding-bottom: 10px;
     display: grid;
-    grid-template-columns: 100%;
+    grid-template-columns:100%;
     grid-template-areas: 
-    'chart-toggle'
+    'line'
+    'line'
     'date';
     row-gap: 15px;
-    justify-items:center
   }
 
+  .slow-zone .line-toggle , .chart-toggle , .direction-toggle{ 
+    justify-self: center;
+  }
+  
   .station-configuration .from-to-label,
   .station-configuration .date-label {
     width: 30px;

--- a/src/App.css
+++ b/src/App.css
@@ -422,7 +422,9 @@ button:disabled,
     padding-bottom: 10px;
     display: grid;
     grid-template-columns: 100%;
-    grid-template-areas: 'chart-toggle';
+    grid-template-areas: 
+    'chart-toggle'
+    'date';
     row-gap: 15px;
     justify-items:center
   }
@@ -459,7 +461,7 @@ button:disabled,
     grid-area: stations;
   }
 
-  .station-configuration > .option-date {
+  .station-configuration .slow-zone > .option-date {
     grid-area: date;
     display: flex;
   }

--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,19 @@
   width: 200px;
 }
 
+.empty-state #slowzone-container {
+  padding-bottom: 24px;
+  text-align: center;
+}
+
+
+.empty-state #slowzone-button {
+  background-color: var(--bus);
+  padding: 5px;
+  margin-left: 5px;
+  cursor: pointer;
+}
+
 .chart.is-loading {
   opacity: 0.3;
   pointer-events: none;

--- a/src/App.js
+++ b/src/App.js
@@ -392,7 +392,7 @@ class App extends React.Component {
     return <div className="main-column">
       <div className="empty-state">
         {error_message && <>{error_message}</>}
-        <div id="slowzone-container"> Check our our new <Link to='/slowzones'><button id="slowzone-button">Slow Zone Tracker</button></Link></div>
+        <div id="slowzone-container"> Check out our new <Link to='/slowzones'><button id="slowzone-button">Slow Zone Tracker</button></Link></div>
         {!error_message && <>See MBTA rapid transit performance data, including travel times between stations, headways,
         and dwell times, for any given day. <span style={{fontWeight: "bold"}}>Select a line, station pair, and date above to get started.</span><div style={{marginTop: 10}}>Looking for something interesting? <span style={{fontWeight: "bold"}}>Try one of these dates:</span></div>
         <Select

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { ProgressBar, progressBarRate } from './ui/ProgressBar';
 import './App.css';
 import Select from './inputs/Select';
 import { configPresets } from './presets';
+import { Link } from 'react-router-dom/cjs/react-router-dom.min';
 
 const PRODUCTION = "dashboard.transitmatters.org";
 
@@ -392,6 +393,7 @@ class App extends React.Component {
     return <div className="main-column">
       <div className="empty-state">
         {error_message && <>{error_message}</>}
+        <div id="slowzone-container"> Check our our new <Link to='/slowzones'><button id="slowzone-button">Slow Zone Tracker</button></Link></div>
         {!error_message && <>See MBTA rapid transit performance data, including travel times between stations, headways,
         and dwell times, for any given day. <span style={{fontWeight: "bold"}}>Select a line, station pair, and date above to get started.</span><div style={{marginTop: 10}}>Looking for something interesting? <span style={{fontWeight: "bold"}}>Try one of these dates:</span></div>
         <Select

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SingleDaySet, AggregateSet } from './ChartSets';
 import StationConfiguration from './StationConfiguration';
-import { withRouter, Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import { lookup_station_by_id, get_stop_ids_for_stations, line_name } from './stations';
 import { trainDateRange, busDateRange } from './constants';
 import { recognize } from './alerts/AlertFilter';

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SingleDaySet, AggregateSet } from './ChartSets';
 import StationConfiguration from './StationConfiguration';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import { lookup_station_by_id, get_stop_ids_for_stations, line_name } from './stations';
 import { trainDateRange, busDateRange } from './constants';
 import { recognize } from './alerts/AlertFilter';
@@ -10,7 +10,6 @@ import { ProgressBar, progressBarRate } from './ui/ProgressBar';
 import './App.css';
 import Select from './inputs/Select';
 import { configPresets } from './presets';
-import { Link } from 'react-router-dom/cjs/react-router-dom.min';
 
 const PRODUCTION = "dashboard.transitmatters.org";
 

--- a/src/App.js
+++ b/src/App.js
@@ -392,7 +392,7 @@ class App extends React.Component {
     return <div className="main-column">
       <div className="empty-state">
         {error_message && <>{error_message}</>}
-        <div id="slowzone-container"> Check out our new <Link to='/slowzones'><button id="slowzone-button">Slow Zone Tracker</button></Link></div>
+        {/* <div id="slowzone-container"> Check out our new <Link to='/slowzones'><button id="slowzone-button">Slow Zone Tracker</button></Link></div> */}
         {!error_message && <>See MBTA rapid transit performance data, including travel times between stations, headways,
         and dwell times, for any given day. <span style={{fontWeight: "bold"}}>Select a line, station pair, and date above to get started.</span><div style={{marginTop: 10}}>Looking for something interesting? <span style={{fontWeight: "bold"}}>Try one of these dates:</span></div>
         <Select

--- a/src/charts/Title.js
+++ b/src/charts/Title.js
@@ -1,4 +1,4 @@
-import { colorsForLine } from '../constants.js';
+import { colorsForLine } from '../constants';
 
 const getLineColor = (lineName) => colorsForLine[lineName] || 'black';
 const titleColor = 'gray';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const colorsForLine: Record<string, string>= {
 };
 
 export const getDateThreeMonthsAgo = () => {
-	return moment().subtract(3, 'months')
+	return moment().subtract(3, 'months').startOf('day')
 }
 
 export const TODAY_SERVICE_DATE = () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import moment from "moment";
+
 const FRONTEND_TO_BACKEND_MAP = new Map([
 	["localhost", ""], // this becomes a relative path that is proxied through CRA:3000 to python on :5000
 	["127.0.0.1", ""],
@@ -20,6 +22,10 @@ export const colorsForLine: Record<string, string>= {
 	Green: '#00834d',
 	bus: '#ffc72c',
 };
+
+export const getDateThreeMonthsAgo = () => {
+	return moment().subtract(3, 'months')
+}
 
 export const TODAY_SERVICE_DATE = () => {
 	// toISOString returns in UTC.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,11 +12,8 @@ export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(
 	window.location.hostname
   );
 
-interface ColorsForLine {
-	[key:string]: string
-}
 
-export const colorsForLine: ColorsForLine = {
+export const colorsForLine: Record<string, string>= {
 	Red: '#da291c',
 	Orange: '#ed8b00',
 	Blue: '#003da5',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,22 @@
-export const colorsForLine = {
+const FRONTEND_TO_BACKEND_MAP = new Map([
+	["localhost", ""], // this becomes a relative path that is proxied through CRA:3000 to python on :5000
+	["127.0.0.1", ""],
+	["dashboard.transitmatters.org", "https://dashboard-api2.transitmatters.org"],
+	[
+	  "dashboard-beta.transitmatters.org",
+	  "https://dashboard-api-beta.transitmatters.org",
+	],
+  ]);
+  
+export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(
+	window.location.hostname
+  );
+
+interface ColorsForLine {
+	[key:string]: string
+}
+
+export const colorsForLine: ColorsForLine = {
 	Red: '#da291c',
 	Orange: '#ed8b00',
 	Blue: '#003da5',

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import OpenSource from './OpenSource';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { SlowZones } from './slowzones/SlowZones';
 
 ReactDOM.render(
   <BrowserRouter>
@@ -19,6 +20,9 @@ ReactDOM.render(
       </Route>
       <Route exact path="/bus">
         <App bus_mode={true} />
+      </Route>
+      <Route exact path="/slowzones">
+        <SlowZones />
       </Route>
     </Switch>
   </BrowserRouter>,

--- a/src/inputs/date.js
+++ b/src/inputs/date.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import flatpickr from 'flatpickr';
 import 'flatpickr/dist/themes/light.css';
+import moment from 'moment';
 
 const ua = window.navigator.userAgent;
 const isMobile = /Android|webOS|iPhone|iPad|BlackBerry|IEMobile|Opera Mini/i.test(ua);
@@ -19,7 +20,7 @@ const RegularDateInput = (props) => {
     <input
       type="date"
       value={props.value}
-      onChange={(evt) => props.onChange(evt.target.value)}
+      onChange={(evt) => props.onChange(props.useMoment? moment(evt.target.value) : evt.target.value)}
       placeholder={props.placeholder}
       min={props.options.minDate}
       max={maxDate}
@@ -52,7 +53,7 @@ class Flatpickr extends React.Component {
         // if we get here, we've already decided on flatpickr. Don't resort to mobile-native.
         disableMobile: true,
         date: this.props.value,
-        onChange: (sel, dateStr, inst) => this.props.onChange(dateStr),
+        onChange: (sel, dateStr, inst) => this.props.onChange(this.props.useMoment ? moment(dateStr) : dateStr),
         ...this.props.options
       });
   }

--- a/src/inputs/date.js
+++ b/src/inputs/date.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import flatpickr from 'flatpickr';
 import 'flatpickr/dist/themes/light.css';
-import moment from 'moment';
 
 const ua = window.navigator.userAgent;
 const isMobile = /Android|webOS|iPhone|iPad|BlackBerry|IEMobile|Opera Mini/i.test(ua);
@@ -15,12 +14,11 @@ const RegularDateInput = (props) => {
     const local_date = new Date(iso_date.valueOf() - (offset * 60 * 1000));
     maxDate = local_date.toISOString().split("T")[0];
   }
-
   return(
     <input
       type="date"
       value={props.value}
-      onChange={(evt) => props.onChange(props.useMoment? moment(evt.target.value) : evt.target.value)}
+      onChange={(evt) => props.onChange(evt.target.value)}
       placeholder={props.placeholder}
       min={props.options.minDate}
       max={maxDate}
@@ -53,7 +51,7 @@ class Flatpickr extends React.Component {
         // if we get here, we've already decided on flatpickr. Don't resort to mobile-native.
         disableMobile: true,
         date: this.props.value,
-        onChange: (sel, dateStr, inst) => this.props.onChange(this.props.useMoment ? moment(dateStr) : dateStr),
+        onChange: (sel, dateStr, inst) => this.props.onChange(dateStr),
         ...this.props.options
       });
   }

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -70,7 +70,7 @@ const SlowZoneNav = ({
         </div>
         <div className="chart-toggle">
           <div className="option option-mode">
-            <span className="switch-label">Total slow time</span>
+            <span className="switch-label slowzones-switch-label">Total slow time</span>
             <label className="option switch">
               <input
                 type="checkbox"
@@ -85,31 +85,34 @@ const SlowZoneNav = ({
               />
               <span className="slider"></span>
             </label>
-            <span className="switch-label">Line segments</span>
+            <span className="switch-label slowzones-switch-label">Line segments</span>
           </div>
         </div>
-
-        {chartView === "xrange" && (
-          <div className="direction-toggle">
-            <div className="option option-mode">
-              <span className="switch-label">Southbound</span>
-              <label className="option switch">
-                <input
-                  type="checkbox"
-                  checked={direction === "northbound"}
-                  onChange={() => {
-                    if (direction === "northbound") setDireciton("southbound");
-                    else {
-                      setDireciton("northbound");
-                    }
-                  }}
-                />
-                <span className="slider"></span>
-              </label>
-              <span className="switch-label">Northbound</span>
-            </div>
-          </div>
-        )}
+        <div className="direction-toggle">
+        <div className="option option-mode"
+        style={{
+          // Disable the northbound/southbound slider in "total slow time" mode
+          opacity: chartView === "xrange" ? 1.0 : 0.5,
+          pointerEvents: chartView === "xrange" ? "auto" : "none"}
+        }
+        >
+          <span className="switch-label">Southbound</span>
+          <label className="option switch">
+            <input
+              type="checkbox"
+              checked={direction === "northbound"}
+              onChange={() => {
+                if (direction === "northbound") setDireciton("southbound");
+                else {
+                  setDireciton("northbound");
+                }
+              }}
+            />
+            <span className="slider"></span>
+          </label>
+          <span className="switch-label">Northbound</span>
+        </div>
+        </div>
         <div className="option option-date">
           <span className="date-label">Date</span>
           <DatePicker

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -1,6 +1,9 @@
 import classNames from "classnames";
+import DatePicker from "../inputs/date";
 import { optionsForSelect } from "./SlowZones";
 import { ChartView, Direction } from "./types";
+import { getDateThreeMonthsAgo, trainDateRange } from "../constants";
+import moment from "moment";
 
 interface SlowZoneNavProps {
   chartView: ChartView;
@@ -9,7 +12,12 @@ interface SlowZoneNavProps {
   setDireciton: Function;
   selectedLines: string[];
   toggleLine: (value: string) => void;
+  startDate: string;
+  endDate: string;
+  setStartDate: Function;
+  setEndDate: Function;
 }
+
 const SlowZoneNav = ({
   chartView,
   setChartView,
@@ -17,16 +25,24 @@ const SlowZoneNav = ({
   selectedLines,
   toggleLine,
   setDireciton,
+  startDate,
+  endDate,
+  setStartDate,
+  setEndDate,
 }: SlowZoneNavProps) => {
   const getIsChecked = (value: string) => {
     return selectedLines.includes(value);
   };
+  const clear = ()=>{
+    setStartDate(getDateThreeMonthsAgo().toISOString())
+    setEndDate(moment().endOf('day').toISOString())
+  }
   return (
     <div className="station-configuration-wrapper">
       <div className="slow-zone station-configuration  main-column">
         <div className="line-toggle">
           <div className="option ">
-            {optionsForSelect().map((opt, index) => (
+            {optionsForSelect().map((opt) => (
               <div
                 key={opt.value}
                 className={classNames("button-toggle", opt.value)}
@@ -86,6 +102,30 @@ const SlowZoneNav = ({
             </div>
           </div>
         )}
+        <div className="option option-date">
+          <span className="date-label">Date</span>
+          <DatePicker
+            value={startDate}
+            onChange={setStartDate}
+            options={trainDateRange}
+            placeholder="Select date..."
+          />
+
+          <span className="date-label end-date-label">to</span>
+          <DatePicker
+            value={endDate}
+            onChange={setEndDate}
+            options={trainDateRange}
+            placeholder="Select date..."
+            minDate={startDate}
+          />
+          <button
+            className="clear-button"
+            onClick={clear}
+          >
+            🅧
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -3,7 +3,8 @@ import DatePicker from "../inputs/date";
 import { optionsForSelect } from "./SlowZones";
 import { ChartView, Direction } from "./types";
 import { getDateThreeMonthsAgo, trainDateRange } from "../constants";
-import moment from "moment";
+import moment, { Moment } from "moment";
+import { useMemo } from "react";
 
 interface SlowZoneNavProps {
   chartView: ChartView;
@@ -12,8 +13,8 @@ interface SlowZoneNavProps {
   setDireciton: Function;
   selectedLines: string[];
   toggleLine: (value: string) => void;
-  startDate: string;
-  endDate: string;
+  startDate: Moment;
+  endDate: Moment;
   setStartDate: Function;
   setEndDate: Function;
 }
@@ -37,6 +38,12 @@ const SlowZoneNav = ({
     setStartDate(getDateThreeMonthsAgo());
     setEndDate(moment().endOf("day"));
   };
+
+  const startMoment = useMemo(() => startDate.format("YYYY-MM-DD"), [
+    startDate,
+  ]);
+  const endMoment = useMemo(() => endDate.format("YYYY-MM-DD"), [endDate]);
+
   return (
     <div className="station-configuration-wrapper">
       <div className="slow-zone station-configuration main-column">
@@ -69,8 +76,9 @@ const SlowZoneNav = ({
                 type="checkbox"
                 checked={chartView === "xrange"}
                 onChange={() => {
-                  if (chartView === "line") setChartView("xrange");
-                  else {
+                  if (chartView === "line") {
+                    setChartView("xrange");
+                  } else {
                     setChartView("line");
                   }
                 }}
@@ -105,21 +113,19 @@ const SlowZoneNav = ({
         <div className="option option-date">
           <span className="date-label">Date</span>
           <DatePicker
-            value={startDate}
+            value={startMoment}
             onChange={setStartDate}
-            options={trainDateRange}
+            options={{ maxDate: endMoment, minDate: trainDateRange.minDate }}
+            maxDate={endMoment}
             placeholder="Select date..."
-            useMoment={true}
           />
 
           <span className="date-label end-date-label">to</span>
           <DatePicker
-            value={endDate}
+            value={endMoment}
             onChange={setEndDate}
-            options={trainDateRange}
+            options={{ minDate: startMoment, maxDate: trainDateRange.maxDate }}
             placeholder="Select date..."
-            minDate={startDate}
-            useMoment={true}
           />
           <button className="clear-button" onClick={clear}>
             🅧

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -33,15 +33,15 @@ const SlowZoneNav = ({
   const getIsChecked = (value: string) => {
     return selectedLines.includes(value);
   };
-  const clear = ()=>{
-    setStartDate(getDateThreeMonthsAgo().toISOString())
-    setEndDate(moment().endOf('day').toISOString())
-  }
+  const clear = () => {
+    setStartDate(getDateThreeMonthsAgo());
+    setEndDate(moment().endOf("day"));
+  };
   return (
     <div className="station-configuration-wrapper">
-      <div className="slow-zone station-configuration  main-column">
+      <div className="slow-zone station-configuration main-column">
         <div className="line-toggle">
-          <div className="option ">
+          <div className="option mode">
             {optionsForSelect().map((opt) => (
               <div
                 key={opt.value}
@@ -109,6 +109,7 @@ const SlowZoneNav = ({
             onChange={setStartDate}
             options={trainDateRange}
             placeholder="Select date..."
+            useMoment={true}
           />
 
           <span className="date-label end-date-label">to</span>
@@ -118,11 +119,9 @@ const SlowZoneNav = ({
             options={trainDateRange}
             placeholder="Select date..."
             minDate={startDate}
+            useMoment={true}
           />
-          <button
-            className="clear-button"
-            onClick={clear}
-          >
+          <button className="clear-button" onClick={clear}>
             🅧
           </button>
         </div>

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -1,0 +1,96 @@
+import classNames from "classnames";
+import RadioForm from "../inputs/radio";
+import { line_name, subway_lines } from "../stations";
+import { optionsForSelect } from "./SlowZones";
+import { ChartView, Direction } from "./types";
+
+interface SlowZoneNavProps {
+  chartView: ChartView;
+  setChartView: Function;
+  direction: Direction;
+  setDireciton: Function;
+  selectedLines: string[];
+  toggleLine: (value: string) => void;
+}
+const SlowZoneNav = ({
+  chartView,
+  setChartView,
+  direction,
+  selectedLines,
+  toggleLine,
+  setDireciton,
+}: SlowZoneNavProps) => {
+  const getIsChecked = (value: string) => {
+    return selectedLines.includes(value);
+  };
+  return (
+    <div className="station-configuration-wrapper">
+      <div className="slow-zone station-configuration  main-column">
+        <div className="line-toggle">
+          <div className="option ">
+            {optionsForSelect().map((opt, index) => (
+              <div
+                key={opt.value}
+                className={classNames("button-toggle", opt.value)}
+              >
+                <label>
+                  <input
+                    type="checkbox"
+                    disabled={opt.disabled}
+                    value={opt.value}
+                    onChange={({ target: { value } }) => toggleLine(value)}
+                    checked={getIsChecked(opt.value) && !opt.disabled}
+                  />
+                  <span>{opt.value}</span>
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="chart-toggle">
+          <div className="option option-mode">
+            <span className="switch-label">Total Slow Time</span>
+            <label className="option switch">
+              <input
+                type="checkbox"
+                checked={chartView === "xrange"}
+                onChange={() => {
+                  if (chartView === "line") setChartView("xrange");
+                  else {
+                    setChartView("line");
+                  }
+                }}
+              />
+              <span className="slider"></span>
+            </label>
+            <span className="switch-label">Line Segments</span>
+          </div>
+        </div>
+
+        {chartView === "xrange" && (
+          <div className="direction-toggle">
+            <div className="option option-mode">
+              <span className="switch-label">Southbound</span>
+              <label className="option switch">
+                <input
+                  type="checkbox"
+                  checked={direction === "northbound"}
+                  onChange={() => {
+                    if (direction === "northbound") setDireciton("southbound");
+                    else {
+                      setDireciton("northbound");
+                    }
+                  }}
+                />
+                <span className="slider"></span>
+              </label>
+              <span className="switch-label">Northbound</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SlowZoneNav;

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -1,6 +1,4 @@
 import classNames from "classnames";
-import RadioForm from "../inputs/radio";
-import { line_name, subway_lines } from "../stations";
 import { optionsForSelect } from "./SlowZones";
 import { ChartView, Direction } from "./types";
 

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -70,7 +70,7 @@ const SlowZoneNav = ({
         </div>
         <div className="chart-toggle">
           <div className="option option-mode">
-            <span className="switch-label">Total Slow Time</span>
+            <span className="switch-label">Total slow time</span>
             <label className="option switch">
               <input
                 type="checkbox"
@@ -85,7 +85,7 @@ const SlowZoneNav = ({
               />
               <span className="slider"></span>
             </label>
-            <span className="switch-label">Line Segments</span>
+            <span className="switch-label">Line segments</span>
           </div>
         </div>
 

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -11,7 +11,6 @@ import {
   generateXrangeOptions,
   X_MIN,
 } from "./formattingUtils";
-import { APP_DATA_BASE_PATH } from "../constants";
 xrange(Highcharts);
 exporting(Highcharts);
 
@@ -23,7 +22,7 @@ export const SlowZones = () => {
   useEffect(() => {
     if (chartView === "line") {
       const url = new URL(
-        `${APP_DATA_BASE_PATH}/static/slowzones/delay_totals.json`,
+        `/static/slowzones/delay_totals.json`,
         window.location.origin
       );
       fetch(url.toString())
@@ -32,13 +31,12 @@ export const SlowZones = () => {
           const filteredData = data.filter(
             (d: any) => new Date(d.date) > X_MIN
           );
-          console.log(filteredData)
           const options = generateLineOptions(filteredData, setChartView);
           setOptions(options);
         });
     } else {
       const url = new URL(
-        `${APP_DATA_BASE_PATH}/static/slowzones/all_slow.json`,
+        `/static/slowzones/all_slow.json`,
         window.location.origin
       );
       fetch(url.toString())

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -45,12 +45,9 @@ export const SlowZones = () => {
 
   const setTotalDelaysOptions = (data: any) => {
     const filteredData = data.filter((d: any) => {
-      return moment(d.date).isBetween(
-        startDate,
-        endDate,
-        undefined,
-        "[]"
-      );
+      return moment(d.date)
+        .add(5, "hours")
+        .isBetween(startDate, endDate, undefined, "[]");
     });
     const options = generateLineOptions(filteredData, selectedLines, startDate);
     setOptions(options);
@@ -124,10 +121,12 @@ export const SlowZones = () => {
         setDireciton={setDirection}
         selectedLines={selectedLines}
         toggleLine={toggleLine}
-        startDate={startDate.format("YYYY-MM-DD")}
-        endDate={endDate.format("YYYY-MM-DD")}
-        setStartDate={setStartDate}
-        setEndDate={setEndDate}
+        startDate={startDate}
+        endDate={endDate}
+        setStartDate={(date: any) => {
+          setStartDate(moment(date));
+        }}
+        setEndDate={(date: any) => setEndDate(moment(date))}
       />
       {options && (
         <HighchartsReact

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ChartView, Direction, SlowZone } from "./types";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
@@ -91,6 +91,7 @@ export const SlowZones = () => {
           });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chartView, direction, selectedLines]);
 
   const toggleLine = (line: string) => {

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { ChartView, Direction, SlowZone } from "./types";
+import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+import xrange from "highcharts/modules/xrange";
+import exporting from "highcharts/modules/exporting";
+
+import {
+  formatSlowZones,
+  generateLineOptions,
+  generateXrangeOptions,
+  X_MIN,
+} from "./formattingUtils";
+import { APP_DATA_BASE_PATH } from "../constants";
+xrange(Highcharts);
+exporting(Highcharts);
+
+export const SlowZones = () => {
+  const [options, setOptions] = useState<Highcharts.Options>();
+  const [chartView, setChartView] = useState<ChartView>("line");
+  const [direction, setDirection] = useState<Direction>("southbound");
+
+  useEffect(() => {
+    if (chartView === "line") {
+      const url = new URL(
+        `${APP_DATA_BASE_PATH}/static/slowzones/delay_totals.json`,
+        window.location.origin
+      );
+      fetch(url.toString())
+        .then((resp) => resp.json())
+        .then((data) => {
+          const filteredData = data.filter(
+            (d: any) => new Date(d.date) > X_MIN
+          );
+          console.log(filteredData)
+          const options = generateLineOptions(filteredData, setChartView);
+          setOptions(options);
+        });
+    } else {
+      const url = new URL(
+        `${APP_DATA_BASE_PATH}/static/slowzones/all_slow.json`,
+        window.location.origin
+      );
+      fetch(url.toString())
+        .then((resp) => resp.json())
+        .then((data) => {
+          const formattedData = formatSlowZones(data);
+          const filteredData = formattedData.filter(
+            (d: SlowZone) => d.start > X_MIN
+          );
+
+          const options = generateXrangeOptions(
+            filteredData.filter((d: SlowZone) => d.direction === direction),
+            setChartView,
+            direction,
+            setDirection
+          );
+          setOptions(options);
+        });
+    }
+  }, [chartView, direction]);
+
+  return (
+    <HighchartsReact
+      containerProps={{ style: { height: "75vh", paddingTop: "20px" } }}
+      options={options}
+      highcharts={Highcharts}
+      immutable={true}
+    />
+  );
+};

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -40,21 +40,19 @@ export const SlowZones = () => {
   ]);
   const [totalDelays, setTotalDelays] = useState<any>();
   const [allSlow, setAllSlow] = useState<any>();
-  const [startDate, setStartDate] = useState(
-    getDateThreeMonthsAgo().format("YYYY-MM-D")
-  );
-  const [endDate, setEndDate] = useState(moment().format("YYYY-MM-D"));
+  const [startDate, setStartDate] = useState(getDateThreeMonthsAgo());
+  const [endDate, setEndDate] = useState(moment());
 
   const setTotalDelaysOptions = (data: any) => {
     const filteredData = data.filter((d: any) => {
-      return d.date >= startDate && d.date <= endDate;
+      return moment(d.date).isBetween(
+        startDate,
+        endDate,
+        undefined,
+        "[]"
+      );
     });
-    const options = generateLineOptions(
-      filteredData,
-      selectedLines,
-      startDate,
-      endDate
-    );
+    const options = generateLineOptions(filteredData, selectedLines, startDate);
     setOptions(options);
   };
 
@@ -62,12 +60,9 @@ export const SlowZones = () => {
     const formattedData = formatSlowZones(data);
     const filteredData = formattedData.filter(
       (d: SlowZone) =>
-        // Starts in the range
-        ((d.start >= new Date(startDate) && d.start <= new Date(endDate)) ||
-          (d.start <= new Date(startDate) && d.end >= new Date(endDate)) ||
-          (d.start <= new Date(startDate) &&
-            d.end <= new Date(endDate) &&
-            d.end >= new Date(startDate))) &&
+        (d.start.isBetween(startDate, endDate, undefined, "[]") ||
+          d.end.isBetween(startDate, endDate, undefined, "[]") ||
+          (d.start.isBefore(startDate) && d.end.isAfter(endDate))) &&
         selectedLines.includes(d.color) &&
         d.direction === direction
     );
@@ -129,8 +124,8 @@ export const SlowZones = () => {
         setDireciton={setDirection}
         selectedLines={selectedLines}
         toggleLine={toggleLine}
-        startDate={startDate}
-        endDate={endDate}
+        startDate={startDate.format("YYYY-MM-DD")}
+        endDate={endDate.format("YYYY-MM-DD")}
         setStartDate={setStartDate}
         setEndDate={setEndDate}
       />

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -64,7 +64,7 @@ export const SlowZones = () => {
         d.direction === direction
     );
 
-    const options = generateXrangeOptions(filteredData, direction);
+    const options = generateXrangeOptions(filteredData, direction, startDate);
     setOptions(options);
   };
 

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChartView, Direction, SlowZone } from "./types";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
@@ -11,59 +11,114 @@ import {
   generateXrangeOptions,
   X_MIN,
 } from "./formattingUtils";
+import SlowZoneNav from "./SlowZoneNav";
+import { line_name, subway_lines } from "../stations";
 xrange(Highcharts);
 exporting(Highcharts);
+
+export const optionsForSelect = () => {
+  const lines = subway_lines();
+  return lines.map((line) => {
+    return {
+      value: line,
+      label: line_name(line),
+      disabled: line_name(line) === "Green Line",
+    };
+  });
+};
 
 export const SlowZones = () => {
   const [options, setOptions] = useState<Highcharts.Options>();
   const [chartView, setChartView] = useState<ChartView>("line");
   const [direction, setDirection] = useState<Direction>("southbound");
+  const [selectedLines, setSelectedLines] = useState<any[]>([
+    "Red",
+    "Orange",
+    "Blue",
+  ]);
+  const [totalDelays, setTotalDelays] = useState<any>();
+  const [allSlow, setAllSlow] = useState<any>();
+
+  const setTotalDelaysOptions = (data: any) => {
+    const filteredData = data.filter((d: any) => new Date(d.date) > X_MIN);
+    const options = generateLineOptions(filteredData, selectedLines);
+    setOptions(options);
+  };
+
+  const setAllSlowOptions = (data: any) => {
+    const formattedData = formatSlowZones(data);
+    const filteredData = formattedData.filter(
+      (d: SlowZone) =>
+        d.start > X_MIN &&
+        selectedLines.includes(d.color) &&
+        d.direction === direction
+    );
+
+    const options = generateXrangeOptions(filteredData, direction);
+    setOptions(options);
+  };
 
   useEffect(() => {
     if (chartView === "line") {
-      const url = new URL(
-        `/static/slowzones/delay_totals.json`,
-        window.location.origin
-      );
-      fetch(url.toString())
-        .then((resp) => resp.json())
-        .then((data) => {
-          const filteredData = data.filter(
-            (d: any) => new Date(d.date) > X_MIN
-          );
-          const options = generateLineOptions(filteredData, setChartView);
-          setOptions(options);
-        });
+      if (totalDelays) {
+        // We only want to fetch each dataset once
+        setTotalDelaysOptions(totalDelays);
+      } else {
+        const url = new URL(
+          `/static/slowzones/delay_totals.json`,
+          window.location.origin
+        );
+        fetch(url.toString())
+          .then((resp) => resp.json())
+          .then((data) => {
+            setTotalDelays(data);
+            setTotalDelaysOptions(data);
+          });
+      }
     } else {
-      const url = new URL(
-        `/static/slowzones/all_slow.json`,
-        window.location.origin
-      );
-      fetch(url.toString())
-        .then((resp) => resp.json())
-        .then((data) => {
-          const formattedData = formatSlowZones(data);
-          const filteredData = formattedData.filter(
-            (d: SlowZone) => d.start > X_MIN
-          );
-
-          const options = generateXrangeOptions(
-            filteredData.filter((d: SlowZone) => d.direction === direction),
-            setChartView,
-            direction,
-            setDirection
-          );
-          setOptions(options);
-        });
+      if (allSlow) {
+        setAllSlowOptions(allSlow);
+      } else {
+        const url = new URL(
+          `/static/slowzones/all_slow.json`,
+          window.location.origin
+        );
+        fetch(url.toString())
+          .then((resp) => resp.json())
+          .then((data) => {
+            setAllSlow(data);
+            setAllSlowOptions(data);
+          });
+      }
     }
-  }, [chartView, direction]);
+  }, [chartView, direction, selectedLines]);
+
+  const toggleLine = (line: string) => {
+    if (selectedLines.includes(line)) {
+      setSelectedLines(selectedLines.filter((value) => value !== line));
+    } else {
+      setSelectedLines([...selectedLines, line]);
+    }
+  };
 
   return (
-    <HighchartsReact
-      containerProps={{ style: { height: "75vh", paddingTop: "20px" } }}
-      options={options}
-      highcharts={Highcharts}
-      immutable={true}
-    />
+    <>
+      <SlowZoneNav
+        chartView={chartView}
+        setChartView={setChartView}
+        direction={direction}
+        setDireciton={setDirection}
+        selectedLines={selectedLines}
+        toggleLine={toggleLine}
+      />
+      {options && (
+        <HighchartsReact
+          containerProps={{ style: { height: "75vh", paddingTop: "5px" } }}
+          options={options}
+          highcharts={Highcharts}
+          immutable={true}
+        />
+      )}
+    </>
   );
 };

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -112,9 +112,7 @@ export const generateXrangeSeries = (data: any) => {
 
 export const generateXrangeOptions = (
   data: SlowZone[],
-  setChartView: Function,
   direction: Direction,
-  setDirection: Function
 ): any => ({
   chart: {
     type: "xrange",
@@ -132,7 +130,9 @@ export const generateXrangeOptions = (
       text: "Date",
     },
   },
-
+  legend: {
+    enabled: false,
+  },
   yAxis: {
     type: "category",
     title: {
@@ -160,44 +160,38 @@ export const generateXrangeOptions = (
     },
   },
   series: generateXrangeSeries(data),
-  exporting: {
-    scale: "1",
-    width: "1500px",
-    height: "1500px",
-    buttons: {
-      customButton: {
-        text: "Regular View",
-        onclick: function () {
-          setChartView("line");
-        },
-      },
-      button2: {
-        text: "Change Direction",
-        onclick: function () {
-          setDirection(
-            direction === "southbound" ? "northbound" : "southbound"
-          );
-        },
-      },
-    },
-  },
+  
 });
 
 // Line options
-export const groupByLineDailyTotals = (data: any) => {
+export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
   const RED_LINE = data.map((day: any) => Number((day.Red / 60).toFixed(2)));
   const BLUE_LINE = data.map((day: any) => Number((day.Blue / 60).toFixed(2)));
-  const ORANGE_LINE = data.map((day: any) => Number((day.Orange/60).toFixed(2)));
+  const ORANGE_LINE = data.map((day: any) =>
+    Number((day.Orange / 60).toFixed(2))
+  );
   return [
-    { name: "Red", color: colorsForLine["Red"], data: RED_LINE },
-    { name: "Blue", color: colorsForLine["Blue"], data: BLUE_LINE },
-    { name: "Orange", color: colorsForLine["Orange"], data: ORANGE_LINE },
+    selectedLines.includes("Red") && {
+      name: "Red",
+      color: colorsForLine["Red"],
+      data: RED_LINE,
+    },
+    selectedLines.includes("Blue") && {
+      name: "Blue",
+      color: colorsForLine["Blue"],
+      data: BLUE_LINE,
+    },
+    selectedLines.includes("Orange") && {
+      name: "Orange",
+      color: colorsForLine["Orange"],
+      data: ORANGE_LINE,
+    },
   ];
 };
 
 export const generateLineOptions = (
   data: SlowZone[],
-  setChartView: Function
+  selectedLines: string[]
 ): any => ({
   title: {
     text: `Slow Zones`,
@@ -208,23 +202,15 @@ export const generateLineOptions = (
       text: "Slow Time Per Day (minutes)",
     },
   },
-  series: groupByLineDailyTotals(data),
+  series: groupByLineDailyTotals(data, selectedLines),
   plotOptions: {
     series: {
-      pointStart: Date.UTC(
-        2021,0,1
-      ),
+      pointStart: Date.UTC(2021, 0, 1),
       pointInterval: DAY_MS,
     },
   },
-  exporting: {
-    buttons: {
-      customButton: {
-        text: "Detailed View",
-        onclick: () => {
-          setChartView("xrange");
-        },
-      },
-    },
+  legend: {
+    enabled: false,
   },
+ 
 });

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment, { Moment } from "moment";
 import { colorsForLine } from "../constants";
 import { lookup_station_by_id } from "../stations";
 import { Direction, SlowZone } from "./types";
@@ -38,8 +38,8 @@ export const formatSlowZones = (data: any) =>
     const to = lookup_station_by_id(x.color, x.to_id);
     const direction = getDirection(to, from);
     return {
-      start: new Date(x.start),
-      end: new Date(x.end),
+      start: moment(x.start),
+      end: moment(x.end),
       from: from.stop_name,
       to: to.stop_name,
       uid: +x.id,
@@ -84,16 +84,8 @@ export const generateXrangeSeries = (data: any) => {
       name: name,
       color: colorsForLine[line[0]],
       data: data.map((d) => ({
-        x: Date.UTC(
-          d.start.getUTCFullYear(),
-          d.start.getUTCMonth(),
-          d.start.getUTCDate()
-        ),
-        x2: Date.UTC(
-          d.end.getUTCFullYear(),
-          d.end.getUTCMonth(),
-          d.end.getUTCDate()
-        ),
+        x: d.start.utc().valueOf(),
+        x2: d.end.utc().valueOf(),
         y: routes.indexOf(d.id),
         custom: { ...d },
       })),
@@ -192,8 +184,7 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
 export const generateLineOptions = (
   data: SlowZone[],
   selectedLines: string[],
-  startDate: string,
-  endDate: string
+  startDate: Moment,
 ): any => ({
   title: {
     text: `Slow zones`,
@@ -210,8 +201,7 @@ export const generateLineOptions = (
   series: groupByLineDailyTotals(data, selectedLines),
   plotOptions: {
     series: {
-      pointStart: moment(startDate),
-      pointEnd: moment(endDate),
+      pointStart: startDate.add(1,'day').valueOf(),
       pointInterval: DAY_MS,
       animation: false,
     },

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -201,7 +201,7 @@ export const generateLineOptions = (
   series: groupByLineDailyTotals(data, selectedLines),
   plotOptions: {
     series: {
-      pointStart: startDate.add(1,'day').valueOf(),
+      pointStart: startDate.valueOf(),
       pointInterval: DAY_MS,
       animation: false,
     },

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -10,9 +10,15 @@ const capitalize = (s: string) => {
 };
 
 const getDashUrl = (d: any) => {
-  let then: any = new Date(d.custom.startDate);
-  then.setDate(then.getDate() - 14); // two weeks of baseline for comparison
-  then = then.toISOString().split("T")[0];
+  const dateDiff = moment(d.custom.startDate).diff(d.x2, "months");
+  let then;
+  if (dateDiff <= -7) {
+    then = moment(d.x2).subtract(7, 'months').toISOString().split("T")[0]
+  } else {
+    then = new Date(d.custom.startDate);
+    then.setDate(then.getDate() - 14); // two weeks of baseline for comparison
+    then = then.toISOString().split("T")[0];
+  }
 
   let now: any = new Date(d.x2);
   now.setDate(now.getDate() + 14); // two weeks after for comparison.
@@ -138,9 +144,15 @@ export const generateXrangeOptions = (
     reversed: true,
   },
   tooltip: {
-    formatter: function (this: any){
-      return `<div><span style="font-size: 10px">${moment(this.point.custom.startDate).format('MMMM Do YYYY')} - ${moment(this.point.x2).format('MMMM Do YYYY')}</span><br/> <span style="color:${this.point.color}">●</span> ${this.point.series.name}: <b>${this.point.yCategory}</b><br/></div>`
-    }
+    formatter: function (this: any) {
+      return `<div><span style="font-size: 10px">${moment(
+        this.point.custom.startDate
+      ).format("MMMM Do YYYY")} - ${moment(this.point.x2).format(
+        "MMMM Do YYYY"
+      )}</span><br/> <span style="color:${this.point.color}">●</span> ${
+        this.point.series.name
+      }: <b>${this.point.yCategory}</b><br/></div>`;
+    },
   },
   plotOptions: {
     series: {
@@ -194,6 +206,11 @@ export const generateLineOptions = (
   selectedLines: string[],
   startDate: Moment
 ): any => ({
+  exporting: {
+    csv: {
+      itemDelimiter: ";",
+    },
+  },
   credits: { enabled: false },
   title: {
     text: `Slow zones`,
@@ -219,9 +236,13 @@ export const generateLineOptions = (
     },
   },
   tooltip: {
-    formatter: function (this: any){
-      return `<div><span style="font-size: 10px">${moment(this.point.x).format('MMMM Do YYYY')}</span><br/> <span style="color:${this.point.color}">●</span> ${this.point.series.name}: <b>${this.point.y}</b><br/></div>`
-    }
+    formatter: function (this: any) {
+      return `<div><span style="font-size: 10px">${moment(this.point.x).format(
+        "MMMM Do YYYY"
+      )}</span><br/> <span style="color:${this.point.color}">●</span> ${
+        this.point.series.name
+      }: <b>${this.point.y}</b><br/></div>`;
+    },
   },
   legend: {
     enabled: false,

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -34,9 +34,7 @@ const getDirection = (to: any, from: any) => {
 // Data formatting & cleanup
 export const formatSlowZones = (data: any) =>
   data.map((x: any) => {
-    // @ts-ignore
     const from = lookup_station_by_id(x.color, x.fr_id);
-    // @ts-ignore
     const to = lookup_station_by_id(x.color, x.to_id);
     const direction = getDirection(to, from);
     return {
@@ -56,7 +54,7 @@ export const formatSlowZones = (data: any) =>
   });
 
 export const groupByRoute = (data: SlowZone[]) =>
-  data.reduce((series: any, sz: SlowZone) => {
+  data.reduce((series: Record<string, SlowZone[]>, sz: SlowZone) => {
     const key = sz.id;
     const s = (series[key] || []).concat(sz);
     series[key] = s;
@@ -64,7 +62,7 @@ export const groupByRoute = (data: SlowZone[]) =>
   }, {});
 
 export const groupByLine = (data: SlowZone[]) =>
-  data.reduce((series: any, sz: any) => {
+  data.reduce((series: Record<string, SlowZone[]>, sz: any) => {
     const key = sz.color;
     const s = (series[key] || []).concat(sz);
     series[key] = s;
@@ -80,11 +78,12 @@ export const getRoutes = (data: SlowZone[]) => {
 export const generateXrangeSeries = (data: any) => {
   const routes = getRoutes(data);
   const groupedByLine = groupByLine(data);
-  return Object.entries(groupedByLine).map((line: any) => {
+  return Object.entries(groupedByLine).map((line) => {
+    const [name, data] = line;
     return {
-      name: line[0],
+      name: name,
       color: colorsForLine[line[0]],
-      data: line[1].map((d: SlowZone) => ({
+      data: data.map((d) => ({
         x: Date.UTC(
           d.start.getUTCFullYear(),
           d.start.getUTCMonth(),
@@ -112,7 +111,7 @@ export const generateXrangeSeries = (data: any) => {
 
 export const generateXrangeOptions = (
   data: SlowZone[],
-  direction: Direction,
+  direction: Direction
 ): any => ({
   chart: {
     type: "xrange",
@@ -121,9 +120,8 @@ export const generateXrangeOptions = (
     enabled: false,
   },
   title: {
-    text: `${capitalize(direction)} Slow Zones`,
+    text: `${capitalize(direction)} slow zones`,
   },
-
   xAxis: {
     type: "datetime",
     title: {
@@ -132,6 +130,9 @@ export const generateXrangeOptions = (
   },
   legend: {
     enabled: false,
+  },
+  time: {
+    timezone: "America/New_York",
   },
   yAxis: {
     type: "category",
@@ -145,8 +146,7 @@ export const generateXrangeOptions = (
     series: {
       cursor: "pointer",
       events: {
-        // @ts-ignore
-        click: function (event) {
+        click: function (event: any) {
           window.open(getDashUrl(event.point), "_blank");
         },
       },
@@ -160,7 +160,6 @@ export const generateXrangeOptions = (
     },
   },
   series: generateXrangeSeries(data),
-  
 });
 
 // Line options
@@ -194,13 +193,16 @@ export const generateLineOptions = (
   selectedLines: string[]
 ): any => ({
   title: {
-    text: `Slow Zones`,
+    text: `Slow zones`,
   },
   xAxis: { type: "datetime", title: { text: "Date" } },
   yAxis: {
     title: {
-      text: "Slow Time Per Day (minutes)",
+      text: "Slow time per day (minutes)",
     },
+  },
+  time: {
+    timezone: "America/New_York",
   },
   series: groupByLineDailyTotals(data, selectedLines),
   plotOptions: {
@@ -212,5 +214,4 @@ export const generateLineOptions = (
   legend: {
     enabled: false,
   },
- 
 });

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -184,12 +184,16 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
 export const generateLineOptions = (
   data: SlowZone[],
   selectedLines: string[],
-  startDate: Moment,
+  startDate: Moment
 ): any => ({
+  credits: { enabled: false },
   title: {
     text: `Slow zones`,
   },
-  xAxis: { type: "datetime", title: { text: "Date" } },
+  xAxis: {
+    type: "datetime",
+    title: { text: "Date" },
+  },
   yAxis: {
     title: {
       text: "Slow time per day (minutes)",

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -1,8 +1,8 @@
+import moment from "moment";
 import { colorsForLine } from "../constants";
 import { lookup_station_by_id } from "../stations";
 import { Direction, SlowZone } from "./types";
 
-export const X_MIN = new Date(2021, 0, 0);
 const DAY_MS = 1000 * 60 * 60 * 24;
 
 const capitalize = (s: string) => {
@@ -157,6 +157,7 @@ export const generateXrangeOptions = (
       groupPadding: 0,
       showInLegend: true,
       colorByPoint: false,
+      animation: false,
     },
   },
   series: generateXrangeSeries(data),
@@ -190,7 +191,9 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
 
 export const generateLineOptions = (
   data: SlowZone[],
-  selectedLines: string[]
+  selectedLines: string[],
+  startDate: string,
+  endDate: string
 ): any => ({
   title: {
     text: `Slow zones`,
@@ -207,8 +210,10 @@ export const generateLineOptions = (
   series: groupByLineDailyTotals(data, selectedLines),
   plotOptions: {
     series: {
-      pointStart: Date.UTC(2021, 0, 1),
+      pointStart: moment(startDate),
+      pointEnd: moment(endDate),
       pointInterval: DAY_MS,
+      animation: false,
     },
   },
   legend: {

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -1,0 +1,230 @@
+import { colorsForLine } from "../constants";
+import { lookup_station_by_id } from "../stations";
+import { Direction, SlowZone } from "./types";
+
+export const X_MIN = new Date(2021, 0, 0);
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+const capitalize = (s: string) => {
+  return s && s[0].toUpperCase() + s.slice(1);
+};
+
+const getDashUrl = (d: any) => {
+  let then: any = new Date(d.x);
+  then.setDate(then.getDate() - 14); // two weeks of baseline for comparison
+  then = then.toISOString().split("T")[0];
+
+  let now: any = new Date(d.x2);
+  now.setDate(now.getDate() + 14); // two weeks after for comparison.
+  const today = new Date();
+  if (today < now) {
+    now = today;
+  }
+  now = now.toISOString().split("T")[0];
+
+  return `https://dashboard.transitmatters.org/rapidtransit?config=${d.custom.color},${d.custom.fr_id},${d.custom.to_id},${then},${now}`;
+};
+
+const getDirection = (to: any, from: any) => {
+  const toOrder = to.order;
+  const fromOrder = from.order;
+  return toOrder > fromOrder ? "southbound" : "northbound";
+};
+
+// Data formatting & cleanup
+export const formatSlowZones = (data: any) =>
+  data.map((x: any) => {
+    // @ts-ignore
+    const from = lookup_station_by_id(x.color, x.fr_id);
+    // @ts-ignore
+    const to = lookup_station_by_id(x.color, x.to_id);
+    const direction = getDirection(to, from);
+    return {
+      start: new Date(x.start),
+      end: new Date(x.end),
+      from: from.stop_name,
+      to: to.stop_name,
+      uid: +x.id,
+      id: from.stop_name + "-" + to.stop_name,
+      delay: +x.delay,
+      duration: +x.duration,
+      color: x.color,
+      fr_id: x.fr_id,
+      to_id: x.to_id,
+      direction,
+    };
+  });
+
+export const groupByRoute = (data: SlowZone[]) =>
+  data.reduce((series: any, sz: SlowZone) => {
+    const key = sz.id;
+    const s = (series[key] || []).concat(sz);
+    series[key] = s;
+    return series;
+  }, {});
+
+export const groupByLine = (data: SlowZone[]) =>
+  data.reduce((series: any, sz: any) => {
+    const key = sz.color;
+    const s = (series[key] || []).concat(sz);
+    series[key] = s;
+    return series;
+  }, {});
+
+export const getRoutes = (data: SlowZone[]) => {
+  const groupObj = groupByRoute(data);
+  return Object.keys(groupObj);
+};
+
+// Xrange options
+export const generateXrangeSeries = (data: any) => {
+  const routes = getRoutes(data);
+  const groupedByLine = groupByLine(data);
+  return Object.entries(groupedByLine).map((line: any) => {
+    return {
+      name: line[0],
+      color: colorsForLine[line[0]],
+      data: line[1].map((d: SlowZone) => ({
+        x: Date.UTC(
+          d.start.getUTCFullYear(),
+          d.start.getUTCMonth(),
+          d.start.getUTCDate()
+        ),
+        x2: Date.UTC(
+          d.end.getUTCFullYear(),
+          d.end.getUTCMonth(),
+          d.end.getUTCDate()
+        ),
+        y: routes.indexOf(d.id),
+        custom: { ...d },
+      })),
+      dataLabels: {
+        enabled: true,
+        // @ts-ignore
+        formatter: function () {
+          // @ts-ignore
+          return `${this.point.custom.delay.toFixed(0)} s`;
+        },
+      },
+    };
+  });
+};
+
+export const generateXrangeOptions = (
+  data: SlowZone[],
+  setChartView: Function,
+  direction: Direction,
+  setDirection: Function
+): any => ({
+  chart: {
+    type: "xrange",
+  },
+  credits: {
+    enabled: false,
+  },
+  title: {
+    text: `${capitalize(direction)} Slow Zones`,
+  },
+
+  xAxis: {
+    type: "datetime",
+    title: {
+      text: "Date",
+    },
+  },
+
+  yAxis: {
+    type: "category",
+    title: {
+      text: "Line Segments",
+    },
+    categories: getRoutes(data),
+    reversed: true,
+  },
+  plotOptions: {
+    series: {
+      cursor: "pointer",
+      events: {
+        // @ts-ignore
+        click: function (event) {
+          window.open(getDashUrl(event.point), "_blank");
+        },
+      },
+      borderRadius: 0,
+      borderWidth: 1,
+      grouping: false,
+      pointPadding: 0.15,
+      groupPadding: 0,
+      showInLegend: true,
+      colorByPoint: false,
+    },
+  },
+  series: generateXrangeSeries(data),
+  exporting: {
+    scale: "1",
+    width: "1500px",
+    height: "1500px",
+    buttons: {
+      customButton: {
+        text: "Regular View",
+        onclick: function () {
+          setChartView("line");
+        },
+      },
+      button2: {
+        text: "Change Direction",
+        onclick: function () {
+          setDirection(
+            direction === "southbound" ? "northbound" : "southbound"
+          );
+        },
+      },
+    },
+  },
+});
+
+// Line options
+export const groupByLineDailyTotals = (data: any) => {
+  const RED_LINE = data.map((day: any) => Number((day.Red / 60).toFixed(2)));
+  const BLUE_LINE = data.map((day: any) => Number((day.Blue / 60).toFixed(2)));
+  const ORANGE_LINE = data.map((day: any) => Number((day.Orange/60).toFixed(2)));
+  return [
+    { name: "Red", color: colorsForLine["Red"], data: RED_LINE },
+    { name: "Blue", color: colorsForLine["Blue"], data: BLUE_LINE },
+    { name: "Orange", color: colorsForLine["Orange"], data: ORANGE_LINE },
+  ];
+};
+
+export const generateLineOptions = (
+  data: SlowZone[],
+  setChartView: Function
+): any => ({
+  title: {
+    text: `Slow Zones`,
+  },
+  xAxis: { type: "datetime", title: { text: "Date" } },
+  yAxis: {
+    title: {
+      text: "Slow Time Per Day (minutes)",
+    },
+  },
+  series: groupByLineDailyTotals(data),
+  plotOptions: {
+    series: {
+      pointStart: Date.UTC(
+        2021,0,1
+      ),
+      pointInterval: DAY_MS,
+    },
+  },
+  exporting: {
+    buttons: {
+      customButton: {
+        text: "Detailed View",
+        onclick: () => {
+          setChartView("xrange");
+        },
+      },
+    },
+  },
+});

--- a/src/slowzones/types.ts
+++ b/src/slowzones/types.ts
@@ -1,7 +1,9 @@
+import { Moment } from "moment";
+
 export interface SlowZone {
   service_date: number;
-  start: Date;
-  end: Date;
+  start: Moment;
+  end: Moment;
   mean_metric: number;
   duration: number;
   baseline: number;

--- a/src/slowzones/types.ts
+++ b/src/slowzones/types.ts
@@ -1,0 +1,23 @@
+export interface SlowZone {
+  service_date: number;
+  start: Date;
+  end: Date;
+  mean_metric: number;
+  duration: number;
+  baseline: number;
+  delay: number;
+  color: string;
+  fr_id: number;
+  to_id: number;
+  from: string;
+  to: string;
+  uuid: number;
+  id: string;
+  from_short: string;
+  to_short: string;
+  direction: Direction;
+}
+
+export type Direction = "northbound" | "southbound";
+
+export type ChartView = "line" | "xrange";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
#### This PR
- Adds slow zone information at `/slowzones`
- Has two graphs, one for total "slow" time per day, and one for all slow zones.
- There is also a dropdown bar on the top right that allows you to save the charts as `png/jpg`

#### Notes
- You'll have to add `all_slow.json` to `public/static/slowzones` locally to test (let me know if you have any troubles)
- I'd love some input on design / copy
- I could add a date filter if needed. Right now I'm starting at 1/1/2021
#### Gifs / Screenshots
![Screen Shot 2022-02-18 at 10 23 13 AM](https://user-images.githubusercontent.com/1361408/154711189-d5c4d30b-dc8e-4f30-870c-4cdb85ff46fd.png)
![2022-02-18 10 27 45](https://user-images.githubusercontent.com/1361408/154712081-5f03fb85-2bf1-4762-b1a9-781c711dd98e.gif)

