### PR TITLE
Changed Window Header Title to match other TM Labs apps

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     content="Explore MBTA subway and bus performance data with the TransitMatters Data Dashboard." />
   <meta name="twitter:image" content="https://dashboard.transitmatters.org/twitter-card.jpg" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <title>TransitMatters Data Dashboard</title>
+  <title>Data Dashboard</title>
   <script>
     window.goatcounter = { no_onload: true };
   </script>

--- a/src/App.js
+++ b/src/App.js
@@ -68,7 +68,7 @@ const urlFromState = (config) => {
 };
 
 const documentTitle = (config) => {
-  const pieces = ["TransitMatters Data Dashboard"];
+  const pieces = ["Data Dashboard"];
   if (config.line) {
     pieces.splice(0, 0, line_name(config.line));
   }


### PR DESCRIPTION
All of our other active apps do not have "TransitMatters" in the front of their tities, this PR does the same for Data Dashboard (yay standardization again)
![image](https://user-images.githubusercontent.com/31703736/163283334-c3f32649-fc84-4b17-b264-f51a13b5947b.png)
