### PR TITLE
Slow zones CSS fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -167,6 +167,7 @@
 
 .station-configuration {
   padding: 10px;
+  line-height: 1.0;
 }
 
 select,
@@ -363,6 +364,10 @@ button:disabled,
   .station-configuration .select-component {
     flex-grow: 1;
     flex-shrink: 1;
+  }
+
+  .slowzones-switch-label {
+    width: 100px;
   }
 }
 

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -70,7 +70,7 @@ const SlowZoneNav = ({
         </div>
         <div className="chart-toggle">
           <div className="option option-mode">
-            <span className="switch-label">Total slow time</span>
+            <span className="switch-label slowzones-switch-label">Total slow time</span>
             <label className="option switch">
               <input
                 type="checkbox"
@@ -85,31 +85,32 @@ const SlowZoneNav = ({
               />
               <span className="slider"></span>
             </label>
-            <span className="switch-label">Line segments</span>
+            <span className="switch-label slowzones-switch-label">Line segments</span>
           </div>
         </div>
-
-        {chartView === "xrange" && (
-          <div className="direction-toggle">
-            <div className="option option-mode">
-              <span className="switch-label">Southbound</span>
-              <label className="option switch">
-                <input
-                  type="checkbox"
-                  checked={direction === "northbound"}
-                  onChange={() => {
-                    if (direction === "northbound") setDireciton("southbound");
-                    else {
-                      setDireciton("northbound");
-                    }
-                  }}
-                />
-                <span className="slider"></span>
-              </label>
-              <span className="switch-label">Northbound</span>
-            </div>
-          </div>
-        )}
+        <div className="option option-mode"
+        style={{
+          // Disable the northbound/southbound slider in "total slow time" mode
+          opacity: chartView === "xrange" ? 1.0 : 0.5,
+          pointerEvents: chartView === "xrange" ? "auto" : "none"}
+        }
+        >
+          <span className="switch-label">Southbound</span>
+          <label className="option switch">
+            <input
+              type="checkbox"
+              checked={direction === "northbound"}
+              onChange={() => {
+                if (direction === "northbound") setDireciton("southbound");
+                else {
+                  setDireciton("northbound");
+                }
+              }}
+            />
+            <span className="slider"></span>
+          </label>
+          <span className="switch-label">Northbound</span>
+        </div>
         <div className="option option-date">
           <span className="date-label">Date</span>
           <DatePicker

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -88,6 +88,7 @@ const SlowZoneNav = ({
             <span className="switch-label slowzones-switch-label">Line segments</span>
           </div>
         </div>
+        <div className="direction-toggle">
         <div className="option option-mode"
         style={{
           // Disable the northbound/southbound slider in "total slow time" mode
@@ -110,6 +111,7 @@ const SlowZoneNav = ({
             <span className="slider"></span>
           </label>
           <span className="switch-label">Northbound</span>
+        </div>
         </div>
         <div className="option option-date">
           <span className="date-label">Date</span>


### PR DESCRIPTION
⚠️ This PR's base is Seth's branch, not main!
~⚠️ Still need to test on mobile~

- Fix bar height weirdness with a line-height adjustment. It seems a property from bulma framework was causing this, not 100% sure though...
- Widen the "Total slow time" and "Line segments" labels by a tiny bit so they fit on one line
- In "Total slow time" mode, disable the slider and reduce opacity instead of making it disappear completely

(Fixes #171)