### PR TITLE
Switch to monthly event files

### DIFF
--- a/server/bus/gen_bus_data.sh
+++ b/server/bus/gen_bus_data.sh
@@ -5,7 +5,7 @@ if [ -z "$routes" ]; then
 	routes="1"
 fi
 
-for y in 2018 2019 2020 2021; do
+for y in 2018 2019 2020 2021 2022; do
     for f in $(find data/input/$y/ -name '*.csv'); do
 	echo "Generating stop data from $f"
         poetry run python bus2train.py $f data/output -r $routes

--- a/server/bus/gen_latest_bus_data.sh
+++ b/server/bus/gen_latest_bus_data.sh
@@ -5,4 +5,4 @@ newfile=$1
 poetry run python bus2train.py $newfile data/output -r 1  15  22  23  28  32  39  57  66  71  73  77  111 114 116 117;
 # sample upload command below. note that an aws cp --recursive will be faster.
 # aws s3 sync --dryrun data/output/Events/ s3://tm-mbta-performance/Events/
-# aws s3 cp --recursive --dryrun data/output/Events/daily-bus-data/ s3://tm-mbta-performance/Events/daily-bus-data/
+# aws s3 cp --recursive --dryrun data/output/Events/ s3://tm-mbta-performance/Events/

--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -89,7 +89,7 @@ def calc_travel_times_by_date(df):
     summary_stats_peak = faster_describe(df.groupby(['service_date', 'peak'])['travel_time_sec'])
 
     # combine summary stats
-    summary_stats_final = summary_stats.append(summary_stats_peak)
+    summary_stats_final = pd.concat([summary_stats, summary_stats_peak])
 
     return summary_stats_final
 
@@ -145,7 +145,7 @@ def headways_over_time(sdate, edate, stops):
     summary_stats_peak = faster_describe(df.groupby(['service_date', 'peak'])['headway_time_sec'])
 
     # combine summary stats
-    summary_stats_final = summary_stats.append(summary_stats_peak)
+    summary_stats_final = pd.concat([summary_stats, summary_stats_peak])
 
     # filter peak status
     results = summary_stats_final.loc[summary_stats_final['peak'] == 'all']
@@ -177,7 +177,7 @@ def dwells_over_time(sdate, edate, stops):
     summary_stats_peak = faster_describe(df.groupby(['service_date', 'peak'])['dwell_time_sec'])
 
     # combine summary stats
-    summary_stats_final = summary_stats.append(summary_stats_peak)
+    summary_stats_final = pd.concat([summary_stats, summary_stats_peak])
 
     # filter peak status
     results = summary_stats_final.loc[summary_stats_final['peak'] == 'all']

--- a/server/chalicelib/parallel.py
+++ b/server/chalicelib/parallel.py
@@ -24,6 +24,7 @@ def make_parallel(single_func, THREAD_COUNT=5):
 def date_range(start, end):
     return pd.date_range(start, end)
 
+
 def month_range(start, end):
     # This is kinda funky, but is stil simpler than other approaches
     # pandas won't generate a monthly date_range that includes Jan and Feb for Jan31-Feb1 e.g.

--- a/server/chalicelib/parallel.py
+++ b/server/chalicelib/parallel.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-import datetime
+import pandas as pd
 
 
 def make_parallel(single_func, THREAD_COUNT=5):
@@ -22,7 +22,13 @@ def make_parallel(single_func, THREAD_COUNT=5):
 
 
 def date_range(start, end):
-    cur = start
-    while cur <= end:
-        yield cur
-        cur += datetime.timedelta(days=1)
+    return pd.date_range(start, end)
+
+def month_range(start, end):
+    # This is kinda funky, but is stil simpler than other approaches
+    # pandas won't generate a monthly date_range that includes Jan and Feb for Jan31-Feb1 e.g.
+    # So we generate a daily date_range and then resample it down (summing 0s as a no-op in the process) so it aligns.
+    dates = pd.date_range(start, end, freq='1D', inclusive='both')
+    series = pd.Series(0, index=dates)
+    months = series.resample('1M').sum().index
+    return months

--- a/server/chalicelib/s3.py
+++ b/server/chalicelib/s3.py
@@ -34,10 +34,7 @@ def download_one_event_file(date, stop_id):
     """As advertised: single event file from s3"""
     year, month = date.year, date.month
 
-    if is_bus(stop_id):
-        folder = 'monthly-bus-data'
-    else:
-        folder = 'monthly-data'
+    folder = 'monthly-bus-data' if is_bus(stop_id) else 'monthly-data'
     key = f"Events/{folder}/{stop_id}/Year={year}/Month={month}/events.csv.gz"
 
     # Download events from S3

--- a/server/chalicelib/s3.py
+++ b/server/chalicelib/s3.py
@@ -29,16 +29,15 @@ def is_bus(stop_id):
     return ('-0-' in stop_id) or ('-1-' in stop_id)
 
 
-def download_one_event_file(date, stop_id, monthly=False):
+def download_one_event_file(date, stop_id):
     """As advertised: single event file from s3"""
-    year, month, day = date.year, date.month, date.day
+    year, month = date.year, date.month
 
-    if monthly:
+    if is_bus(stop_id):
         folder = 'monthly-bus-data'
-        key = f"Events/{folder}/{stop_id}/Year={year}/Month={month}/events.csv.gz"
     else:
-        folder = 'daily-data'
-        key = f"Events/{folder}/{stop_id}/Year={year}/Month={month}/Day={day}/events.csv.gz"
+        folder = 'monthly-data'
+    key = f"Events/{folder}/{stop_id}/Year={year}/Month={month}/events.csv.gz"
 
     # Download events from S3
     try:
@@ -61,29 +60,14 @@ def download_one_event_file(date, stop_id, monthly=False):
     rows_by_time = sorted(rows, key=lambda row: row["event_time"])
     return rows_by_time
 
-def multiplexed_download_one_event_file(datestop, monthly):
+
+@parallel.make_parallel
+def parallel_download_events(datestop):
     (date, stop) = datestop
-    return download_one_event_file(date, stop, monthly)
-
-parallel_download_events = parallel.make_parallel(multiplexed_download_one_event_file)
-
-def download_single_day_events(date, stops):
-    """Will download events for single day, but can handle multiple stop_ids"""
-    result = []
-    for stop_id in stops:
-        result += download_one_event_file(date, stop_id)
-    return sorted(result, key=lambda row: row["event_time"])
-
-
-# signature: (date_iterable, [stop_id])
-# Will download events for multiple stops, over a date range.
-download_event_range = parallel.make_parallel(download_single_day_events)
+    return download_one_event_file(date, stop)
 
 
 def download_events(sdate, edate, stops):
-    if is_bus(stops[0]):
-        datestops = itertools.product(parallel.month_range(sdate, edate), stops)
-        result = parallel_download_events(datestops, monthly=True)
-        return filter(lambda row: sdate.strftime("%Y-%m-%d") <= row['service_date'] <= edate.strftime("%Y-%m-%d"), result)
-    else:
-        return download_event_range(parallel.date_range(sdate, edate), stops)
+    datestops = itertools.product(parallel.month_range(sdate, edate), stops)
+    result = parallel_download_events(datestops)
+    return filter(lambda row: sdate.strftime("%Y-%m-%d") <= row['service_date'] <= edate.strftime("%Y-%m-%d"), result)

--- a/server/chalicelib/s3.py
+++ b/server/chalicelib/s3.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore
 from botocore.exceptions import ClientError
 import csv
 import itertools
@@ -7,7 +8,7 @@ import zlib
 from chalicelib import parallel
 
 BUCKET = "tm-mbta-performance"
-s3 = boto3.client('s3')
+s3 = boto3.client('s3', config=botocore.client.Config(max_pool_connections=15))
 
 
 # General downloading/uploading

--- a/server/rapid/gen_rapid_events.sh
+++ b/server/rapid/gen_rapid_events.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+for y in `seq 2016 2022`; do
+    for f in $(find data/input/$y/ -name '*.csv'); do
+        echo "Generating stop data from $f"
+        poetry run python process_events.py $f data/output
+    done
+done

--- a/server/rapid/process_events.py
+++ b/server/rapid/process_events.py
@@ -1,7 +1,6 @@
 import argparse
 import pandas as pd
 import pathlib
-import sys
 
 
 def process_events(input_csv, outdir, nozip=False):
@@ -56,6 +55,7 @@ def main():
     pathlib.Path(output_dir).mkdir(exist_ok=True)
 
     process_events(input_csv, output_dir, no_zip)
+
 
 if __name__ == '__main__':
     main()

--- a/server/rapid/process_events.py
+++ b/server/rapid/process_events.py
@@ -1,0 +1,61 @@
+import argparse
+import pandas as pd
+import pathlib
+import sys
+
+
+def process_events(input_csv, outdir, nozip=False):
+    columns = ["service_date", "route_id", "trip_id", "direction_id", "stop_id", "stop_sequence",
+               "vehicle_id", "vehicle_label", "event_type", "event_time_sec"]
+
+    df = pd.read_csv(input_csv, usecols=columns,
+                     parse_dates=["service_date"],
+                     infer_datetime_format=True,
+                     dtype={
+                         "route_id": "str",
+                         "trip_id": "str",
+                         "stop_id": "str",
+                         "vehicle_id": "str",
+                         "vehicle_label": "str",
+                         "event_time": "int"})
+
+    df["event_time"] = df["service_date"] + pd.to_timedelta(df["event_time_sec"], unit="s")
+    df.drop(columns=["event_time_sec"], inplace=True)
+
+    service_date_month = pd.Grouper(key="service_date", freq="1M")
+    grouped = df.groupby([service_date_month, "stop_id"])
+
+    for name, events in grouped:
+        service_date, stop_id = name
+
+        fname = pathlib.Path(outdir,
+                             "Events",
+                             "monthly-data",
+                             str(stop_id),
+                             f"Year={service_date.year}",
+                             f"Month={service_date.month}",
+                             "events.csv.gz")
+        fname.parent.mkdir(parents=True, exist_ok=True)
+        # set mtime to 0 in gzip header for determinism (so we can re-gen old routes, and rsync to s3 will ignore)
+        events.to_csv(fname, index=False, compression={"method": "gzip", "mtime": 0} if not nozip else None)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("input", metavar="INPUT_CSV")
+    parser.add_argument("output", metavar="OUTPUT_DIR")
+
+    parser.add_argument("--nozip", "-nz", action="store_true", help="debug feature to skip gzipping")
+
+    args = parser.parse_args()
+    input_csv = args.input
+    output_dir = args.output
+    no_zip = args.nozip
+
+    pathlib.Path(output_dir).mkdir(exist_ok=True)
+
+    process_events(input_csv, output_dir, no_zip)
+
+if __name__ == '__main__':
+    main()

--- a/server/rapid/setup_rapid_input.sh
+++ b/server/rapid/setup_rapid_input.sh
@@ -1,0 +1,34 @@
+#!/bin/sh -x
+
+mkdir -p data/input
+
+# 2016 is a weird case- seems to be tts, headways, etc. not ARR DEP events.
+wget -O data/input/2016.zip https://www.arcgis.com/sharing/rest/content/items/3e892be850fe4cc4a15d6450de4bd318/data
+wget -O data/input/2017.zip https://www.arcgis.com/sharing/rest/content/items/cde60045db904ad299922f4f8759dcad/data
+wget -O data/input/2018.zip https://www.arcgis.com/sharing/rest/content/items/25c3086e9826407e9f59dd9844f6c975/data
+wget -O data/input/2019.zip https://www.arcgis.com/sharing/rest/content/items/11bbb87f8fb245c2b87ed3c8a099b95f/data
+wget -O data/input/2020.zip https://www.arcgis.com/sharing/rest/content/items/cb4cf52bafb1402b9b978a424ed4dd78/data
+wget -O data/input/2021.zip https://www.arcgis.com/sharing/rest/content/items/611b8c77f30245a0af0c62e2859e8b49/data
+wget -O data/input/2022.zip https://www.arcgis.com/sharing/rest/content/items/99094a0c59e443cdbdaefa071c6df609/data
+
+cd data/input
+for i in `seq 2017 2022`; do
+    unzip -d $i $i.zip
+done
+
+# The following years only have single csv files
+# These are too large to process at once, so we use this sed script
+# to split it into monthly files.
+for y in 2016 2017 2018; do
+    awk -v year=$y -v outdir="$y/" -F "-" '
+        NR==1 {header=$0}; 
+        NF>1 && NR>1 {
+            if(! files[$2]) {
+                print header >> (outdir year "_" $2 ".csv");
+                files[$2] = 1;
+            };
+            print $0 >> (outdir year "_" $2 ".csv");
+        }' $y/Events$y.csv;
+    
+    rm $y/Events$y.csv;
+done

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname)
 const RAPIDTRANSIT_PATH = "/rapidtransit";
 const BUS_PATH = "/bus";
 
-const MAX_AGGREGATION_MONTHS = 8;
+const MAX_AGGREGATION_MONTHS = 36;
 const TOO_EARLY_ERROR = (date) => `Our archives only go back so far. Please select a date no earlier than ${date}.`;
 const TOO_LATE_ERROR = (date) => `Data not yet available. Please select a date no later than ${date}.`;
 const RANGE_TOO_LARGE_ERROR = `Please select a range no larger than ${MAX_AGGREGATION_MONTHS} months.`;
@@ -196,7 +196,7 @@ class App extends React.Component {
       return RANGE_NEGATIVE_ERROR;
     }
     if (date_interval_ms > MAX_AGGREGATION_MONTHS * 31 * 86400 * 1000) {
-      return null; //return RANGE_TOO_LARGE_ERROR;
+      return RANGE_TOO_LARGE_ERROR;
     }
     return null;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname)
 const RAPIDTRANSIT_PATH = "/rapidtransit";
 const BUS_PATH = "/bus";
 
-const MAX_AGGREGATION_MONTHS = 24;
+const MAX_AGGREGATION_MONTHS = 18;
 const TOO_EARLY_ERROR = (date) => `Our archives only go back so far. Please select a date no earlier than ${date}.`;
 const TOO_LATE_ERROR = (date) => `Data not yet available. Please select a date no later than ${date}.`;
 const RANGE_TOO_LARGE_ERROR = `Please select a range no larger than ${MAX_AGGREGATION_MONTHS} months.`;

--- a/src/App.js
+++ b/src/App.js
@@ -296,6 +296,7 @@ class App extends React.Component {
         if(e.name !== "AbortError") {
           console.error(e);
         }
+        this.setIsLoadingDataset(name, false);
       });
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname)
 const RAPIDTRANSIT_PATH = "/rapidtransit";
 const BUS_PATH = "/bus";
 
-const MAX_AGGREGATION_MONTHS = 36;
+const MAX_AGGREGATION_MONTHS = 24;
 const TOO_EARLY_ERROR = (date) => `Our archives only go back so far. Please select a date no earlier than ${date}.`;
 const TOO_LATE_ERROR = (date) => `Data not yet available. Please select a date no later than ${date}.`;
 const RANGE_TOO_LARGE_ERROR = `Please select a range no larger than ${MAX_AGGREGATION_MONTHS} months.`;

--- a/src/App.js
+++ b/src/App.js
@@ -196,7 +196,7 @@ class App extends React.Component {
       return RANGE_NEGATIVE_ERROR;
     }
     if (date_interval_ms > MAX_AGGREGATION_MONTHS * 31 * 86400 * 1000) {
-      return RANGE_TOO_LARGE_ERROR;
+      return null; //return RANGE_TOO_LARGE_ERROR;
     }
     return null;
   }
@@ -296,7 +296,8 @@ class App extends React.Component {
         if(e.name !== "AbortError") {
           console.error(e);
         }
-        this.setIsLoadingDataset(name, false);
+        // we need something like this to fix perpetual loading, but this ain't it
+        // this.setIsLoadingDataset(name, false);
       });
   }
 

--- a/src/ui/ProgressBar.js
+++ b/src/ui/ProgressBar.js
@@ -10,7 +10,7 @@ function progressBarRate(date_start, date_end) {
   const ms = (new Date(date_end) - new Date(date_start));
   const days = ms / (1000*60*60*24);
   const months = days / 30;
-  const total_seconds_expected = 1.25 * months;
+  const total_seconds_expected = 1.33 * months;
   return 100 / total_seconds_expected;
 }
 

--- a/src/ui/ProgressBar.js
+++ b/src/ui/ProgressBar.js
@@ -10,7 +10,7 @@ function progressBarRate(date_start, date_end) {
   const ms = (new Date(date_end) - new Date(date_start));
   const days = ms / (1000*60*60*24);
   const months = days / 30;
-  const total_seconds_expected = 3.0 * months;
+  const total_seconds_expected = 0.83 * months;
   return 100 / total_seconds_expected;
 }
 

--- a/src/ui/ProgressBar.js
+++ b/src/ui/ProgressBar.js
@@ -10,7 +10,7 @@ function progressBarRate(date_start, date_end) {
   const ms = (new Date(date_end) - new Date(date_start));
   const days = ms / (1000*60*60*24);
   const months = days / 30;
-  const total_seconds_expected = 0.83 * months;
+  const total_seconds_expected = 1.25 * months;
   return 100 / total_seconds_expected;
 }
 


### PR DESCRIPTION
Per @crschmidt's suggestion, we can cut down on data loading overhead by switching to monthly data event files instead of daily.

- Increases displayable range from 8 months of data to 18 months. (30s being a hard cap on API timeout)
- Incorporates @friendchris's data ingestion [scripts](https://github.com/transitmatters/performancedashbackfill) into the repo (adjusted for monthly files and to match the bus upload scripts)
- Updates the bus data upload scripts to output monthly files.

I would encourage everyone to check this out on beta to make sure the new progress bar timing is accurate.

Heads up: While the lambda now serves data 50% faster, local development server is pretty slow, at least on my laptop. My guess is too much concurrency- a single api request is quick, but loading a page (3 simultaneous requests with 5 threads each) creates a bottleneck. Open to suggestions on how to improve here.
