### PR TITLE
add year to xLabel in aggregate charts

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -31,6 +31,8 @@ const prettyDate = (dateString, with_dow) => {
                         options);
 }
 
+const dateYear = (dateString) => {return dateString.split("-")[0]}
+
 const departure_from_normal_string = (metric, benchmark) => {
   const ratio = metric / benchmark;
   if (!isFinite(ratio) || ratio <= 1.25) {
@@ -317,7 +319,11 @@ const AggregateByDate = (props) => {
       xMin={new Date(`${props.startDate}T00:00:00`)}
       xMax={new Date(`${props.endDate}T00:00:00`)}
       fillColor={"rgba(191,200,214,0.5)"}
-      xLabel=""
+      xLabel={
+        dateYear(props.startDate) === dateYear(props.endDate) ?
+          dateYear(props.startDate) :
+          `${dateYear(props.startDate)} – ${dateYear(props.endDate)}`
+        }
     />
   )
 }

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -31,7 +31,11 @@ const prettyDate = (dateString, with_dow) => {
                         options);
 }
 
-const dateYear = (dateString) => {return dateString.split("-")[0]}
+const yearLabel = (date1, date2) => {
+  const y1 = date1.split("-")[0];
+  const y2 = date2.split("-")[0];
+  return (y1 === y2) ? y1 : `${y1} – ${y2}`;
+}
 
 const departure_from_normal_string = (metric, benchmark) => {
   const ratio = metric / benchmark;
@@ -319,11 +323,7 @@ const AggregateByDate = (props) => {
       xMin={new Date(`${props.startDate}T00:00:00`)}
       xMax={new Date(`${props.endDate}T00:00:00`)}
       fillColor={"rgba(191,200,214,0.5)"}
-      xLabel={
-        dateYear(props.startDate) === dateYear(props.endDate) ?
-          dateYear(props.startDate) :
-          `${dateYear(props.startDate)} – ${dateYear(props.endDate)}`
-        }
+      xLabel={yearLabel(props.startDate, props.endDate)}
     />
   )
 }


### PR DESCRIPTION
Adding years to label the X-axis of our aggregate chart (so that screenshots on twitter can get full context).
[anyone can review-- i'm just picking people arbitrarily]

![image](https://user-images.githubusercontent.com/8498946/166399540-c2472e58-250e-40f3-9b34-52001298655f.png)

