### PR TITLE
Generate a summary json for Thiago to consume + switch to json

### DIFF
--- a/server/.chalice/policy.json
+++ b/server/.chalice/policy.json
@@ -35,7 +35,8 @@
       "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::tm-mbta-performance/Alerts/*",
-        "arn:aws:s3:::tm-mbta-performance/NewTrains/*"
+        "arn:aws:s3:::tm-mbta-performance/statistics/*",
+        "arn:aws:s3:::dashboard.transitmatters.org/static/statistics/*"
       ]
     }
   ]

--- a/server/chalicelib/new_trains.py
+++ b/server/chalicelib/new_trains.py
@@ -1,4 +1,6 @@
+import json
 import sys
+import traceback
 from chalicelib import MbtaPerformanceAPI, s3
 from chalicelib.constants import EVENT_DEPARTURE
 from botocore.exceptions import ClientError
@@ -13,41 +15,74 @@ ROUTE_DEFINITIONS = {
         "core_stations": [70014, 70015]  # Back Bay
     }
 }
+S3_KEY_NEW_TRAINS = "statistics/{}/new_trains.json.gz"  # inside tm-mbta-performance
+S3_KEY_PUBLIC_JSON = "static/statistics/summary.json"  # inside dashboard.transitmatters.org
 
-KEY = "NewTrains/run_counts/{}.csv"
 
-
-def train_runs(route, date):
+def vehicle_label_metrics(route, date) -> dict:
     spec = ROUTE_DEFINITIONS[route]
     api_data = MbtaPerformanceAPI.get_api_data("events", {"stop": spec["core_stations"]}, date)
     events = sum([stop["events"] for stop in api_data], [])
     departures = filter(lambda event: event["event_type"] in EVENT_DEPARTURE, events)
     by_trip_id = {event["trip_id"]: event for event in departures}  # Just in case a single trip gets a DEP and a PRD
-    return list(filter(lambda event: int(event["vehicle_label"]) in spec["labels"], by_trip_id.values()))
+
+    new_len = len(list(filter(
+        lambda event: int(event["vehicle_label"]) in spec["labels"],
+        by_trip_id.values()
+    )))
+    total_len = len(by_trip_id)
+    return {
+        "new_vehicle_trips": new_len,
+        "total_trips": total_len
+    }
 
 
-def update_all(date):
-    for route in ROUTE_DEFINITIONS.keys():
-        print(f"Storing new train runs for {route}...")
-        try:
-            run_count = len(train_runs(route, date))
-            update_statistics_file(route, date, run_count)
-        except Exception:
-            print(f"Unable to store new train run count for route={route}", file=sys.stderr)
-            continue
-
-
-def update_statistics_file(route, date, count):
-    csv_row = "{formatted_date},{count}\n".format(
-        formatted_date=date.strftime("%Y-%m-%d"),
-        count=count
-    )
-    key = KEY.format(route)
+def update_statistics_file(route, date, route_metrics) -> dict:
+    date_str = date.strftime("%Y-%m-%d")
+    key = S3_KEY_NEW_TRAINS.format(route)
     try:
-        data = s3.download(key, compressed=False) + csv_row
+        data = s3.download(key, compressed=True)
+        parsed = json.loads(data)
     except ClientError as ex:
         if ex.response['Error']['Code'] != 'NoSuchKey':
             raise
-        data = "service_date,run_count\n" + csv_row
+        parsed = {}
 
-    s3.upload(key, data.encode(), compress=False)
+    parsed[date_str] = route_metrics
+
+    s3.upload(key, json.dumps(parsed).encode(), compress=True)
+    return parsed
+
+
+def summarize(statistics) -> dict:
+    new_vehicle_trips_max = 0
+    new_vehicle_trips_date = None
+    for date, metrics in statistics.items():
+        if metrics["new_vehicle_trips"] > new_vehicle_trips_max:
+            new_vehicle_trips_max = metrics["new_vehicle_trips"]
+            new_vehicle_trips_date = date
+
+    return {
+        "new_vehicles": {
+            "max": new_vehicle_trips_max,
+            "on_date": new_vehicle_trips_date,
+        }
+    }
+
+
+def update_all(date):
+    summaries = {}
+    for route in ROUTE_DEFINITIONS.keys():
+        print(f"Storing new train runs for {route}...")
+        try:
+            single_day_route_metrics = vehicle_label_metrics(route, date)
+
+            # update_statistics_file(), as a part of storing `date`'s data, returns everything
+            all_days_route_metrics = update_statistics_file(route, date, single_day_route_metrics)
+
+            summaries[route] = summarize(all_days_route_metrics)
+        except Exception:
+            print(f"Unable to store metrics for route={route}", file=sys.stderr)
+            traceback.print_exc()
+            continue
+    s3.upload(S3_KEY_PUBLIC_JSON, json.dumps(summaries).encode(), compress=False, bucket=s3.FRONTEND_BUCKET)

--- a/server/chalicelib/s3.py
+++ b/server/chalicelib/s3.py
@@ -7,13 +7,14 @@ import zlib
 
 from chalicelib import parallel
 
-BUCKET = "tm-mbta-performance"
+DATA_BUCKET = "tm-mbta-performance"
+FRONTEND_BUCKET = "dashboard.transitmatters.org"
 s3 = boto3.client('s3', config=botocore.client.Config(max_pool_connections=15))
 
 
 # General downloading/uploading
-def download(key, encoding="utf8", compressed=True):
-    obj = s3.get_object(Bucket=BUCKET, Key=key)
+def download(key, encoding="utf8", compressed=True, bucket=DATA_BUCKET):
+    obj = s3.get_object(Bucket=bucket, Key=key)
     s3_data = obj["Body"].read()
     if not compressed:
         return s3_data.decode(encoding)
@@ -22,10 +23,10 @@ def download(key, encoding="utf8", compressed=True):
     return decompressed
 
 
-def upload(key, bytes, compress=True):
+def upload(key, bytes, compress=True, bucket=DATA_BUCKET):
     if compress:
         bytes = zlib.compress(bytes)
-    s3.put_object(Bucket=BUCKET, Key=key, Body=bytes)
+    s3.put_object(Bucket=bucket, Key=key, Body=bytes)
 
 
 def is_bus(stop_id):


### PR DESCRIPTION
This PR:

- Switches the new train statistics files from CSV to JSON, which is nicer to work with and easier to consume
- Writes a summary json out to the public bucket so that Thiago can consume it, which will look like:

```
{
  "Red": {
    "new_vehicles": {
      "max": 0,
      "on_date": null
    }
  },
  "Orange": {
    "new_vehicles": {
      "max": 115,
      "on_date": "2022-05-07"
    }
  }
}
```

⚠️ Open question: Do we want to hardcode things like vehicle delivery counts in here as well?