### PR TITLE
Added CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @austinjpaul @mathcolo @idreyn @friendchris @nathan-weinberg @idreyn @Smilerk


### PR DESCRIPTION
Occurred to me it would make sense if we had a CODEOWNERS file so folks could be auto-tagged for review.

Did this based off top repo contributors active in TM Labs. Feel free to ping me on Slack if you want to be removed from the file.