### PR TITLE
Adding eslint warn for prettier and formatting typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,14 +24,15 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: 'module',
   },
-  plugins: ['react', 'react-hooks', '@typescript-eslint', 'prettier'],
+  plugins: ['react', 'react-hooks', '@typescript-eslint', 'import', 'prettier'],
   rules: {
-    'prettier/prettier': 'off', // TODO: Change to Warn
+    'prettier/prettier': 'warn',
     'react/prop-types': 'off', // TODO: Turn on or move to TS
     'react/no-unescaped-entities': 'off',
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-explicit-any': 'off', // TODO: After full TS migration, change to warn or error
     '@typescript-eslint/ban-ts-comment': 'warn',
+    'import/no-default-export': 'warn',
   },
   settings: {
     react: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^5.32.0",
         "eslint": "^8.21.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/parser": "^5.32.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/alerts/AlertBar.tsx
+++ b/src/alerts/AlertBar.tsx
@@ -5,7 +5,6 @@ import 'tippy.js/dist/tippy.css'; // optional
 import { LegendAlerts } from './LegendAlerts';
 import { Alert } from './types';
 
-
 function chartTimeframe(start_date: string) {
   // Set alert-bar interval to be 5:30am today to 1am tomorrow.
   const today = `${start_date}T00:00:00`;
@@ -15,7 +14,7 @@ function chartTimeframe(start_date: string) {
 
   const high = new Date(today);
   high.setDate(high.getDate() + 1);
-  high.setHours(1,0);
+  high.setHours(1, 0);
 
   return [low, high];
 }
@@ -27,26 +26,25 @@ interface BoxSectionProps {
   border: boolean;
 }
 
-const BoxSection: React.FC<BoxSectionProps> = ({title, width, left, border}) => {
-  const toBorderOrNotToBorder = border ? "0.1px solid white" : undefined
+const BoxSection: React.FC<BoxSectionProps> = ({ title, width, left, border }) => {
+  const toBorderOrNotToBorder = border ? '0.1px solid white' : undefined;
   return (
     <Tippy content={title}>
-      <div className="incident-section" style={
-        {
-          "width": `${width}%`,
-          "height": "100%",
-          "float": "left",
-          "position": "absolute",
-          "left": `${left}%`,
-          "borderLeft": toBorderOrNotToBorder,
-          "borderRight": toBorderOrNotToBorder,
-        }
-      }>
-      </div>
+      <div
+        className="incident-section"
+        style={{
+          width: `${width}%`,
+          height: '100%',
+          float: 'left',
+          position: 'absolute',
+          left: `${left}%`,
+          borderLeft: toBorderOrNotToBorder,
+          borderRight: toBorderOrNotToBorder,
+        }}
+      ></div>
     </Tippy>
-
   );
-}
+};
 
 interface AlertBarProps {
   alerts: Alert[];
@@ -55,39 +53,42 @@ interface AlertBarProps {
   isHidden: boolean;
 }
 
-export const AlertBar: React.FC<AlertBarProps> = ({alerts, today, isLoading, isHidden}) => {
+export const AlertBar: React.FC<AlertBarProps> = ({ alerts, today, isLoading, isHidden }) => {
   const renderBoxes = () => {
     if (isLoading) {
       return null;
     }
 
     if (!alerts) {
-      return <div>Unable to retrieve this day's MBTA incidents.</div>
+      return <div>Unable to retrieve this day's MBTA incidents.</div>;
     }
 
     const [start, end] = chartTimeframe(today);
-    const duration = (end.getTime() - start.getTime());
-
+    const duration = end.getTime() - start.getTime();
 
     const boxes = [];
     let idx = 0;
     for (const alert of alerts) {
       const alert_start = Math.max(start.getTime(), new Date(alert.valid_from).getTime());
       const alert_end = Math.min(end.getTime(), new Date(alert.valid_to).getTime());
-      const width = (alert_end - alert_start) / duration * 100;
+      const width = ((alert_end - alert_start) / duration) * 100;
 
-      const left_pos = (alert_start - start.getTime()) / (duration) * 100;
-      const tooltip = `${new Date(alert.valid_from).toLocaleTimeString('en-US')} - ${new Date(alert.valid_to).toLocaleTimeString('en-US')}\n${alert.text}`;
+      const left_pos = ((alert_start - start.getTime()) / duration) * 100;
+      const tooltip = `${new Date(alert.valid_from).toLocaleTimeString('en-US')} - ${new Date(
+        alert.valid_to
+      ).toLocaleTimeString('en-US')}\n${alert.text}`;
 
-      boxes.push(<BoxSection title={tooltip} border={true} width={width} left={left_pos} key={idx} />);
+      boxes.push(
+        <BoxSection title={tooltip} border={true} width={width} left={left_pos} key={idx} />
+      );
       ++idx;
     }
 
     if (boxes.length > 0) {
       return boxes;
     }
-    return <div>No MBTA incidents on this day.</div>
-  }
+    return <div>No MBTA incidents on this day.</div>;
+  };
 
   return (
     <div className={classNames('alerts-wrapper', isHidden && 'hidden')}>
@@ -100,4 +101,4 @@ export const AlertBar: React.FC<AlertBarProps> = ({alerts, today, isLoading, isH
       </div>
     </div>
   );
-}
+};

--- a/src/alerts/AlertFilter.ts
+++ b/src/alerts/AlertFilter.ts
@@ -1,20 +1,20 @@
-import { Alert } from "./types";
+import { Alert } from './types';
 
 const known = [
   /[Uu]p to ([0-9]+) min/, // "Up to 15 minutes"
-  /([0-9]+) min/,          // "15 minutes"
-  /[A-Za-z]+ speeds/,     // "Reduced speeds"
+  /([0-9]+) min/, // "15 minutes"
+  /[A-Za-z]+ speeds/, // "Reduced speeds"
   /delay/,
   /notice/,
-  /[Ss]huttle/,  // might want to worry about this one...
+  /[Ss]huttle/, // might want to worry about this one...
 ];
 
 // TODO: audit this. Like, list all the alerts
 // to see what filters are actually accurate
 const anti = [
   / stop .* move /i, // "The stop X will permanently move to Y"
-  /temporary stop/
-]
+  /temporary stop/,
+];
 
 /**
  * Given an alert object, findMatch returns a boolean with whether or not the alert is a known format
@@ -26,5 +26,5 @@ export const findMatch = (alert: Alert) => {
   if (anti.some((exp) => text.match(exp))) {
     return false;
   }
-  return known.some((exp) => text.match(exp))
-}
+  return known.some((exp) => text.match(exp));
+};

--- a/src/alerts/LegendAlerts.tsx
+++ b/src/alerts/LegendAlerts.tsx
@@ -9,4 +9,4 @@ export const LegendAlerts: React.FC = () => {
       </p>
     </div>
   );
-}
+};

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,7 +1,9 @@
 import { PRODUCTION } from './constants';
 
 declare global {
-  interface Window { goatcounter: any; }
+  interface Window {
+    goatcounter: any;
+  }
 }
 
 export function goatcount() {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,601 +1,652 @@
-import moment from "moment";
+import moment from 'moment';
 
-export const PRODUCTION = "dashboard.transitmatters.org";
+export const PRODUCTION = 'dashboard.transitmatters.org';
 const FRONTEND_TO_BACKEND_MAP = new Map([
-	[PRODUCTION, "https://dashboard-api2.transitmatters.org"],
-	[
-	  "dashboard-beta.transitmatters.org",
-	  "https://dashboard-api-beta.transitmatters.org",
-	],
-  ]);
+  [PRODUCTION, 'https://dashboard-api2.transitmatters.org'],
+  ['dashboard-beta.transitmatters.org', 'https://dashboard-api-beta.transitmatters.org'],
+]);
 
 // Fetch the absolute location of the API to load from; fallback to "" which
 // results in a relative path for local development (which is proxied to python on tcp/5000 via react-scripts magic)
-export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname) || "";
+export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP.get(window.location.hostname) || '';
 
-export const colorsForLine: Record<string, string>= {
-	Red: '#da291c',
-	Orange: '#ed8b00',
-	Blue: '#003da5',
-	Green: '#00834d',
-	bus: '#ffc72c',
+export const colorsForLine: Record<string, string> = {
+  Red: '#da291c',
+  Orange: '#ed8b00',
+  Blue: '#003da5',
+  Green: '#00834d',
+  bus: '#ffc72c',
 };
 
 export const getDateThreeMonthsAgo = () => {
-	return moment().subtract(3, 'months').startOf('day')
-}
+  return moment().subtract(3, 'months').startOf('day');
+};
 
 export const TODAY_SERVICE_DATE = () => {
-	// toISOString returns in UTC.
-	// I want "3am Eastern", which is UTC-07:00.
-	// and when DST ends and it's actually 4am EST, that's fine too.
-	const d = new Date();
-	d.setHours(d.getHours() - 7);
-	return d.toISOString().split("T")[0];
-}
+  // toISOString returns in UTC.
+  // I want "3am Eastern", which is UTC-07:00.
+  // and when DST ends and it's actually 4am EST, that's fine too.
+  const d = new Date();
+  d.setHours(d.getHours() - 7);
+  return d.toISOString().split('T')[0];
+};
 
 export const trainDateRange = {
-	minDate: "2016-01-15",
-	maxDate: "today"
+  minDate: '2016-01-15',
+  maxDate: 'today',
 };
 
 export const busDateRange = {
-	minDate: "2018-08-01",
-	maxDate: "2022-06-30"
+  minDate: '2018-08-01',
+  maxDate: '2022-06-30',
 };
 
 export const stations = {
-	"Red": {
-		"type": "rapidtransit",
-		"direction": {
-			"0": "northbound",
-			"1": "southbound"
-		},
-		"stations": [
-			{
-				"stop_name": "Alewife",
-				"branches": ["A", "B"],
-				"station": "place-alfcl",
-				"order": 1,
-				"stops": {
-					"0": ["70061"],
-					"1": ["70061"]
-				}
-			}, {
-				"stop_name": "Davis",
-				"branches": ["A", "B"],
-				"station": "place-davis",
-				"order": 2,
-				"stops": {
-					"0": ["70064"],
-					"1": ["70063"]
-				}
-			}, {
-				"stop_name": "Porter",
-				"branches": ["A", "B"],
-				"station": "place-portr",
-				"order": 3,
-				"stops": {
-					"0": ["70066"],
-					"1": ["70065"]
-				}
-			}, {
-				"stop_name": "Harvard",
-				"branches": ["A", "B"],
-				"station": "place-harsq",
-				"order": 4,
-				"stops": {
-					"0": ["70068"],
-					"1": ["70067"]
-				}
-			}, {
-				"stop_name": "Central",
-				"branches": ["A", "B"],
-				"station": "place-cntsq",
-				"order": 5,
-				"stops": {
-					"0": ["70070"],
-					"1": ["70069"]
-				}
-			}, {
-				"stop_name": "Kendall/MIT",
-				"branches": ["A", "B"],
-				"station": "place-knncl",
-				"order": 6,
-				"stops": {
-					"0": ["70072"],
-					"1": ["70071"]
-				}
-			}, {
-				"stop_name": "Charles/MGH",
-				"branches": ["A", "B"],
-				"station": "place-chmnl",
-				"order": 7,
-				"stops": {
-					"0": ["70074"],
-					"1": ["70073"]
-				}
-			}, {
-				"stop_name": "Park Street",
-				"branches": ["A", "B"],
-				"station": "place-pktrm",
-				"order": 8,
-				"stops": {
-					"0": ["70076"],
-					"1": ["70075"]
-				}
-			}, {
-				"stop_name": "Downtown Crossing",
-				"branches": ["A", "B"],
-				"station": "place-dwnxg",
-				"order": 9,
-				"stops": {
-					"0": ["70078"],
-					"1": ["70077"]
-				}
-			}, {
-				"stop_name": "South Station",
-				"branches": ["A", "B"],
-				"station": "place-sstat",
-				"order": 10,
-				"stops": {
-					"0": ["70080"],
-					"1": ["70079"]
-				}
-			}, {
-				"stop_name": "Broadway",
-				"branches": ["A", "B"],
-				"station": "place-brdwy",
-				"order": 11,
-				"stops": {
-					"0": ["70082"],
-					"1": ["70081"]
-				}
-			}, {
-				"stop_name": "Andrew",
-				"branches": ["A", "B"],
-				"station": "place-andrw",
-				"order": 12,
-				"stops": {
-					"0": ["70084"],
-					"1": ["70083"]
-				}
-			}, {
-				"stop_name": "JFK/UMass (Ashmont)",
-				"branches": ["A"],
-				"station": "place-jfk",
-				"order": 101,
-				"stops": {
-					"0": ["70086"],
-					"1": ["70085"]
-				}
-			}, {
-				"stop_name": "Savin Hill",
-				"branches": ["A"],
-				"station": "place-shmnl",
-				"order": 102,
-				"stops": {
-					"0": ["70088"],
-					"1": ["70087"]
-				}
-			}, {
-				"stop_name": "Fields Corner",
-				"branches": ["A"],
-				"station": "place-fldcr",
-				"order": 103,
-				"stops": {
-					"0": ["70090"],
-					"1": ["70089"]
-				}
-			}, {
-				"stop_name": "Shawmut",
-				"branches": ["A"],
-				"station": "place-smmnl",
-				"order": 104,
-				"stops": {
-					"0": ["70092"],
-					"1": ["70091"]
-				}
-			}, {
-				"stop_name": "Ashmont",
-				"branches": ["A"],
-				"station": "place-asmnl",
-				"order": 105,
-				"stops": {
-					"0": ["70094"],
-					"1": ["70093"]
-				}
-			}, {
-				"stop_name": "JFK/UMass (Braintree)",
-				"branches": ["B"],
-				"station": "place-jfk",
-				"order": 201,
-				"stops": {
-					"0": ["70096"],
-					"1": ["70095"]
-				}
-			}, {
-				"stop_name": "North Quincy",
-				"branches": ["B"],
-				"station": "place-nqncy",
-				"order": 202,
-				"stops": {
-					"0": ["70098"],
-					"1": ["70097"]
-				}
-			}, {
-				"stop_name": "Quincy Center",
-				"branches": ["B"],
-				"station": "place-qnctr",
-				"order": 203,
-				"stops": {
-					"0": ["70102"],
-					"1": ["70101"]
-				}
-			}, {
-				"stop_name": "Quincy Adams",
-				"branches": ["B"],
-				"station": "place-qamnl",
-				"order": 204,
-				"stops": {
-					"0": ["70104"],
-					"1": ["70103"]
-				}
-			}, {
-				"stop_name": "Braintree",
-				"branches": ["B"],
-				"station": "place-brntn",
-				"order": 205,
-				"stops": {
-					"0": ["70105"],
-					"1": ["70105"]
-				}
-			}
-		]
-	},
-	"Orange": {
-		"type": "rapidtransit",
-		"direction": {
-			"0": "northbound",
-			"1": "southbound"
-		},
-		"stations": [
-			{
-				"stop_name": "Oak Grove",
-				"branches": null,
-				"station": "place-ogmnl",
-				"order": 1,
-				"stops": {
-					"0": ["70036"],
-					"1": ["70036"]
-				}
-			}, {
-				"stop_name": "Malden Center",
-				"branches": null,
-				"station": "place-mlmnl",
-				"order": 2,
-				"stops": {
-					"0": ["70035"],
-					"1": ["70034"]
-				}
-			}, {
-				"stop_name": "Wellington",
-				"branches": null,
-				"station": "place-welln",
-				"order": 3,
-				"stops": {
-					"0": ["70033"],
-					"1": ["70032"]
-				}
-			}, {
-				"stop_name": "Assembly",
-				"branches": null,
-				"station": "place-astao",
-				"order": 4,
-				"stops": {
-					"0": ["70279"],
-					"1": ["70278"]
-				}
-			}, {
-				"stop_name": "Sullivan Square",
-				"branches": null,
-				"station": "place-sull",
-				"order": 5,
-				"stops": {
-					"0": ["70031"],
-					"1": ["70030"]
-				}
-			}, {
-				"stop_name": "Community College",
-				"branches": null,
-				"station": "place-ccmnl",
-				"order": 6,
-				"stops": {
-					"0": ["70029"],
-					"1": ["70028"]
-				}
-			}, {
-				"stop_name": "North Station",
-				"branches": null,
-				"station": "place-north",
-				"order": 7,
-				"stops": {
-					"0": ["70027"],
-					"1": ["70026"]
-				}
-			}, {
-				"stop_name": "Haymarket",
-				"branches": null,
-				"station": "place-haecl",
-				"order": 8,
-				"stops": {
-					"0": ["70025"],
-					"1": ["70024"]
-				}
-			}, {
-				"stop_name": "State Street",
-				"branches": null,
-				"station": "place-state",
-				"order": 9,
-				"stops": {
-					"0": ["70023"],
-					"1": ["70022"]
-				}
-			}, {
-				"stop_name": "Downtown Crossing",
-				"branches": null,
-				"station": "place-dwnxg",
-				"order": 10,
-				"stops": {
-					"0": ["70021"],
-					"1": ["70020"]
-				}
-			}, {
-				"stop_name": "Chinatown",
-				"branches": null,
-				"station": "place-chncl",
-				"order": 11,
-				"stops": {
-					"0": ["70019"],
-					"1": ["70018"]
-				}
-			}, {
-				"stop_name": "Tufts Medical Center",
-				"branches": null,
-				"station": "place-tumnl",
-				"order": 12,
-				"stops": {
-					"0": ["70017"],
-					"1": ["70016"]
-				}
-			}, {
-				"stop_name": "Back Bay",
-				"branches": null,
-				"station": "place-bbsta",
-				"order": 13,
-				"stops": {
-					"0": ["70015"],
-					"1": ["70014"]
-				}
-			}, {
-				"stop_name": "Massachusetts Avenue",
-				"branches": null,
-				"station": "place-masta",
-				"order": 14,
-				"stops": {
-					"0": ["70013"],
-					"1": ["70012"]
-				}
-			}, {
-				"stop_name": "Ruggles",
-				"branches": null,
-				"station": "place-rugg",
-				"order": 15,
-				"stops": {
-					"0": ["70011"],
-					"1": ["70010"]
-				}
-			}, {
-				"stop_name": "Roxbury Crossing",
-				"branches": null,
-				"station": "place-rcmnl",
-				"order": 16,
-				"stops": {
-					"0": ["70009"],
-					"1": ["70008"]
-				}
-			}, {
-				"stop_name": "Jackson Square",
-				"branches": null,
-				"station": "place-jaksn",
-				"order": 17,
-				"stops": {
-					"0": ["70007"],
-					"1": ["70006"]
-				}
-			}, {
-				"stop_name": "Stony Brook",
-				"branches": null,
-				"station": "place-sbmnl",
-				"order": 18,
-				"stops": {
-					"0": ["70005"],
-					"1": ["70004"]
-				}
-			}, {
-				"stop_name": "Green Street",
-				"branches": null,
-				"station": "place-grnst",
-				"order": 19,
-				"stops": {
-					"0": ["70003"],
-					"1": ["70002"]
-				}
-			}, {
-				"stop_name": "Forest Hills",
-				"branches": null,
-				"station": "place-forhl",
-				"order": 20,
-				"stops": {
-					"0": ["70001"],
-					"1": ["70001"]
-				}
-			}
-		]
-	},
-	"Blue": {
-		"type": "rapidtransit",
-		"direction": {
-			"0": "northbound",
-			"1": "southbound"
-		},
-		"stations": [
-			{
-				"stop_name": "Wonderland",
-				"branches": null,
-				"station": "place-wondl",
-				"order": 1,
-				"stops": {
-					"0": ["70060"],
-					"1": ["70059"]
-				}
-			}, {
-				"stop_name": "Revere Beach",
-				"branches": null,
-				"station": "place-rbmnl",
-				"order": 2,
-				"stops": {
-					"0": ["70058"],
-					"1": ["70057"]
-				}
-			}, {
-				"stop_name": "Beachmont",
-				"branches": null,
-				"station": "place-bmmnl",
-				"order": 3,
-				"stops": {
-					"0": ["70056"],
-					"1": ["70055"]
-				}
-			}, {
-				"stop_name": "Suffolk Downs",
-				"branches": null,
-				"station": "place-sdmnl",
-				"order": 4,
-				"stops": {
-					"0": ["70054"],
-					"1": ["70053"]
-				}
-			}, {
-				"stop_name": "Orient Heights",
-				"branches": null,
-				"station": "place-orhte",
-				"order": 5,
-				"stops": {
-					"0": ["70052"],
-					"1": ["70051"]
-				}
-			}, {
-				"stop_name": "Wood Island",
-				"branches": null,
-				"station": "place-wimnl",
-				"order": 6,
-				"stops": {
-					"0": ["70050"],
-					"1": ["70049"]
-				}
-			}, {
-				"stop_name": "Airport",
-				"branches": null,
-				"station": "place-aport",
-				"order": 7,
-				"stops": {
-					"0": ["70048"],
-					"1": ["70047"]
-				}
-			}, {
-				"stop_name": "Maverick",
-				"branches": null,
-				"station": "place-mvbcl",
-				"order": 8,
-				"stops": {
-					"0": ["70046"],
-					"1": ["70045"]
-				}
-			}, {
-				"stop_name": "Aquarium",
-				"branches": null,
-				"station": "place-aqucl",
-				"order": 9,
-				"stops": {
-					"0": ["70044"],
-					"1": ["70043"]
-				}
-			}, {
-				"stop_name": "State Street",
-				"branches": null,
-				"station": "place-state",
-				"order": 10,
-				"stops": {
-					"0": ["70042"],
-					"1": ["70041"]
-				}
-			}, {
-				"stop_name": "Government Center",
-				"branches": null,
-				"station": "place-gover",
-				"order": 11,
-				"stops": {
-					"0": ["70040"],
-					"1": ["70039"]
-				}
-			}, {
-				"stop_name": "Bowdoin",
-				"branches": null,
-				"station": "place-bomnl",
-				"order": 12,
-				"stops": {
-					"0": ["70038"],
-					"1": ["70838"]
-				}
-			}
-		]
-	},
-	"Green": {
-		"type": "rapidtransit",
-		"direction": {
-			"0": "eastbound",
-			"1": "westbound"
-		},
-		"stations": [
-			{
-				"stop_name": "Blandford Street",
-				"branches": ["B"],
-				"station": "place-bland",
-				"order": 101,
-				"stops": {
-					"0": ["70148"],
-					"1": ["70149"]
-				}
-			}, {
-				"stop_name": "Boston University East",
-				"branches": ["B"],
-				"station": "place-buest",
-				"order": 102,
-				"stops": {
-					"0": ["70146"],
-					"1": ["70147"]
-				}
-			}, {
-				"stop_name": "Boston University Central",
-				"branches": ["B"],
-				"station": "place-bucen",
-				"order": 103,
-				"stops": {
-					"0": ["70144"],
-					"1": ["70145"]
-				}
-			}, /* {
+  Red: {
+    type: 'rapidtransit',
+    direction: {
+      '0': 'northbound',
+      '1': 'southbound',
+    },
+    stations: [
+      {
+        stop_name: 'Alewife',
+        branches: ['A', 'B'],
+        station: 'place-alfcl',
+        order: 1,
+        stops: {
+          '0': ['70061'],
+          '1': ['70061'],
+        },
+      },
+      {
+        stop_name: 'Davis',
+        branches: ['A', 'B'],
+        station: 'place-davis',
+        order: 2,
+        stops: {
+          '0': ['70064'],
+          '1': ['70063'],
+        },
+      },
+      {
+        stop_name: 'Porter',
+        branches: ['A', 'B'],
+        station: 'place-portr',
+        order: 3,
+        stops: {
+          '0': ['70066'],
+          '1': ['70065'],
+        },
+      },
+      {
+        stop_name: 'Harvard',
+        branches: ['A', 'B'],
+        station: 'place-harsq',
+        order: 4,
+        stops: {
+          '0': ['70068'],
+          '1': ['70067'],
+        },
+      },
+      {
+        stop_name: 'Central',
+        branches: ['A', 'B'],
+        station: 'place-cntsq',
+        order: 5,
+        stops: {
+          '0': ['70070'],
+          '1': ['70069'],
+        },
+      },
+      {
+        stop_name: 'Kendall/MIT',
+        branches: ['A', 'B'],
+        station: 'place-knncl',
+        order: 6,
+        stops: {
+          '0': ['70072'],
+          '1': ['70071'],
+        },
+      },
+      {
+        stop_name: 'Charles/MGH',
+        branches: ['A', 'B'],
+        station: 'place-chmnl',
+        order: 7,
+        stops: {
+          '0': ['70074'],
+          '1': ['70073'],
+        },
+      },
+      {
+        stop_name: 'Park Street',
+        branches: ['A', 'B'],
+        station: 'place-pktrm',
+        order: 8,
+        stops: {
+          '0': ['70076'],
+          '1': ['70075'],
+        },
+      },
+      {
+        stop_name: 'Downtown Crossing',
+        branches: ['A', 'B'],
+        station: 'place-dwnxg',
+        order: 9,
+        stops: {
+          '0': ['70078'],
+          '1': ['70077'],
+        },
+      },
+      {
+        stop_name: 'South Station',
+        branches: ['A', 'B'],
+        station: 'place-sstat',
+        order: 10,
+        stops: {
+          '0': ['70080'],
+          '1': ['70079'],
+        },
+      },
+      {
+        stop_name: 'Broadway',
+        branches: ['A', 'B'],
+        station: 'place-brdwy',
+        order: 11,
+        stops: {
+          '0': ['70082'],
+          '1': ['70081'],
+        },
+      },
+      {
+        stop_name: 'Andrew',
+        branches: ['A', 'B'],
+        station: 'place-andrw',
+        order: 12,
+        stops: {
+          '0': ['70084'],
+          '1': ['70083'],
+        },
+      },
+      {
+        stop_name: 'JFK/UMass (Ashmont)',
+        branches: ['A'],
+        station: 'place-jfk',
+        order: 101,
+        stops: {
+          '0': ['70086'],
+          '1': ['70085'],
+        },
+      },
+      {
+        stop_name: 'Savin Hill',
+        branches: ['A'],
+        station: 'place-shmnl',
+        order: 102,
+        stops: {
+          '0': ['70088'],
+          '1': ['70087'],
+        },
+      },
+      {
+        stop_name: 'Fields Corner',
+        branches: ['A'],
+        station: 'place-fldcr',
+        order: 103,
+        stops: {
+          '0': ['70090'],
+          '1': ['70089'],
+        },
+      },
+      {
+        stop_name: 'Shawmut',
+        branches: ['A'],
+        station: 'place-smmnl',
+        order: 104,
+        stops: {
+          '0': ['70092'],
+          '1': ['70091'],
+        },
+      },
+      {
+        stop_name: 'Ashmont',
+        branches: ['A'],
+        station: 'place-asmnl',
+        order: 105,
+        stops: {
+          '0': ['70094'],
+          '1': ['70093'],
+        },
+      },
+      {
+        stop_name: 'JFK/UMass (Braintree)',
+        branches: ['B'],
+        station: 'place-jfk',
+        order: 201,
+        stops: {
+          '0': ['70096'],
+          '1': ['70095'],
+        },
+      },
+      {
+        stop_name: 'North Quincy',
+        branches: ['B'],
+        station: 'place-nqncy',
+        order: 202,
+        stops: {
+          '0': ['70098'],
+          '1': ['70097'],
+        },
+      },
+      {
+        stop_name: 'Quincy Center',
+        branches: ['B'],
+        station: 'place-qnctr',
+        order: 203,
+        stops: {
+          '0': ['70102'],
+          '1': ['70101'],
+        },
+      },
+      {
+        stop_name: 'Quincy Adams',
+        branches: ['B'],
+        station: 'place-qamnl',
+        order: 204,
+        stops: {
+          '0': ['70104'],
+          '1': ['70103'],
+        },
+      },
+      {
+        stop_name: 'Braintree',
+        branches: ['B'],
+        station: 'place-brntn',
+        order: 205,
+        stops: {
+          '0': ['70105'],
+          '1': ['70105'],
+        },
+      },
+    ],
+  },
+  Orange: {
+    type: 'rapidtransit',
+    direction: {
+      '0': 'northbound',
+      '1': 'southbound',
+    },
+    stations: [
+      {
+        stop_name: 'Oak Grove',
+        branches: null,
+        station: 'place-ogmnl',
+        order: 1,
+        stops: {
+          '0': ['70036'],
+          '1': ['70036'],
+        },
+      },
+      {
+        stop_name: 'Malden Center',
+        branches: null,
+        station: 'place-mlmnl',
+        order: 2,
+        stops: {
+          '0': ['70035'],
+          '1': ['70034'],
+        },
+      },
+      {
+        stop_name: 'Wellington',
+        branches: null,
+        station: 'place-welln',
+        order: 3,
+        stops: {
+          '0': ['70033'],
+          '1': ['70032'],
+        },
+      },
+      {
+        stop_name: 'Assembly',
+        branches: null,
+        station: 'place-astao',
+        order: 4,
+        stops: {
+          '0': ['70279'],
+          '1': ['70278'],
+        },
+      },
+      {
+        stop_name: 'Sullivan Square',
+        branches: null,
+        station: 'place-sull',
+        order: 5,
+        stops: {
+          '0': ['70031'],
+          '1': ['70030'],
+        },
+      },
+      {
+        stop_name: 'Community College',
+        branches: null,
+        station: 'place-ccmnl',
+        order: 6,
+        stops: {
+          '0': ['70029'],
+          '1': ['70028'],
+        },
+      },
+      {
+        stop_name: 'North Station',
+        branches: null,
+        station: 'place-north',
+        order: 7,
+        stops: {
+          '0': ['70027'],
+          '1': ['70026'],
+        },
+      },
+      {
+        stop_name: 'Haymarket',
+        branches: null,
+        station: 'place-haecl',
+        order: 8,
+        stops: {
+          '0': ['70025'],
+          '1': ['70024'],
+        },
+      },
+      {
+        stop_name: 'State Street',
+        branches: null,
+        station: 'place-state',
+        order: 9,
+        stops: {
+          '0': ['70023'],
+          '1': ['70022'],
+        },
+      },
+      {
+        stop_name: 'Downtown Crossing',
+        branches: null,
+        station: 'place-dwnxg',
+        order: 10,
+        stops: {
+          '0': ['70021'],
+          '1': ['70020'],
+        },
+      },
+      {
+        stop_name: 'Chinatown',
+        branches: null,
+        station: 'place-chncl',
+        order: 11,
+        stops: {
+          '0': ['70019'],
+          '1': ['70018'],
+        },
+      },
+      {
+        stop_name: 'Tufts Medical Center',
+        branches: null,
+        station: 'place-tumnl',
+        order: 12,
+        stops: {
+          '0': ['70017'],
+          '1': ['70016'],
+        },
+      },
+      {
+        stop_name: 'Back Bay',
+        branches: null,
+        station: 'place-bbsta',
+        order: 13,
+        stops: {
+          '0': ['70015'],
+          '1': ['70014'],
+        },
+      },
+      {
+        stop_name: 'Massachusetts Avenue',
+        branches: null,
+        station: 'place-masta',
+        order: 14,
+        stops: {
+          '0': ['70013'],
+          '1': ['70012'],
+        },
+      },
+      {
+        stop_name: 'Ruggles',
+        branches: null,
+        station: 'place-rugg',
+        order: 15,
+        stops: {
+          '0': ['70011'],
+          '1': ['70010'],
+        },
+      },
+      {
+        stop_name: 'Roxbury Crossing',
+        branches: null,
+        station: 'place-rcmnl',
+        order: 16,
+        stops: {
+          '0': ['70009'],
+          '1': ['70008'],
+        },
+      },
+      {
+        stop_name: 'Jackson Square',
+        branches: null,
+        station: 'place-jaksn',
+        order: 17,
+        stops: {
+          '0': ['70007'],
+          '1': ['70006'],
+        },
+      },
+      {
+        stop_name: 'Stony Brook',
+        branches: null,
+        station: 'place-sbmnl',
+        order: 18,
+        stops: {
+          '0': ['70005'],
+          '1': ['70004'],
+        },
+      },
+      {
+        stop_name: 'Green Street',
+        branches: null,
+        station: 'place-grnst',
+        order: 19,
+        stops: {
+          '0': ['70003'],
+          '1': ['70002'],
+        },
+      },
+      {
+        stop_name: 'Forest Hills',
+        branches: null,
+        station: 'place-forhl',
+        order: 20,
+        stops: {
+          '0': ['70001'],
+          '1': ['70001'],
+        },
+      },
+    ],
+  },
+  Blue: {
+    type: 'rapidtransit',
+    direction: {
+      '0': 'northbound',
+      '1': 'southbound',
+    },
+    stations: [
+      {
+        stop_name: 'Wonderland',
+        branches: null,
+        station: 'place-wondl',
+        order: 1,
+        stops: {
+          '0': ['70060'],
+          '1': ['70059'],
+        },
+      },
+      {
+        stop_name: 'Revere Beach',
+        branches: null,
+        station: 'place-rbmnl',
+        order: 2,
+        stops: {
+          '0': ['70058'],
+          '1': ['70057'],
+        },
+      },
+      {
+        stop_name: 'Beachmont',
+        branches: null,
+        station: 'place-bmmnl',
+        order: 3,
+        stops: {
+          '0': ['70056'],
+          '1': ['70055'],
+        },
+      },
+      {
+        stop_name: 'Suffolk Downs',
+        branches: null,
+        station: 'place-sdmnl',
+        order: 4,
+        stops: {
+          '0': ['70054'],
+          '1': ['70053'],
+        },
+      },
+      {
+        stop_name: 'Orient Heights',
+        branches: null,
+        station: 'place-orhte',
+        order: 5,
+        stops: {
+          '0': ['70052'],
+          '1': ['70051'],
+        },
+      },
+      {
+        stop_name: 'Wood Island',
+        branches: null,
+        station: 'place-wimnl',
+        order: 6,
+        stops: {
+          '0': ['70050'],
+          '1': ['70049'],
+        },
+      },
+      {
+        stop_name: 'Airport',
+        branches: null,
+        station: 'place-aport',
+        order: 7,
+        stops: {
+          '0': ['70048'],
+          '1': ['70047'],
+        },
+      },
+      {
+        stop_name: 'Maverick',
+        branches: null,
+        station: 'place-mvbcl',
+        order: 8,
+        stops: {
+          '0': ['70046'],
+          '1': ['70045'],
+        },
+      },
+      {
+        stop_name: 'Aquarium',
+        branches: null,
+        station: 'place-aqucl',
+        order: 9,
+        stops: {
+          '0': ['70044'],
+          '1': ['70043'],
+        },
+      },
+      {
+        stop_name: 'State Street',
+        branches: null,
+        station: 'place-state',
+        order: 10,
+        stops: {
+          '0': ['70042'],
+          '1': ['70041'],
+        },
+      },
+      {
+        stop_name: 'Government Center',
+        branches: null,
+        station: 'place-gover',
+        order: 11,
+        stops: {
+          '0': ['70040'],
+          '1': ['70039'],
+        },
+      },
+      {
+        stop_name: 'Bowdoin',
+        branches: null,
+        station: 'place-bomnl',
+        order: 12,
+        stops: {
+          '0': ['70038'],
+          '1': ['70838'],
+        },
+      },
+    ],
+  },
+  Green: {
+    type: 'rapidtransit',
+    direction: {
+      '0': 'eastbound',
+      '1': 'westbound',
+    },
+    stations: [
+      {
+        stop_name: 'Blandford Street',
+        branches: ['B'],
+        station: 'place-bland',
+        order: 101,
+        stops: {
+          '0': ['70148'],
+          '1': ['70149'],
+        },
+      },
+      {
+        stop_name: 'Boston University East',
+        branches: ['B'],
+        station: 'place-buest',
+        order: 102,
+        stops: {
+          '0': ['70146'],
+          '1': ['70147'],
+        },
+      },
+      {
+        stop_name: 'Boston University Central',
+        branches: ['B'],
+        station: 'place-bucen',
+        order: 103,
+        stops: {
+          '0': ['70144'],
+          '1': ['70145'],
+        },
+      },
+      /* {
 				"stop_name": "Boston University West",
 				"branches": ["B"],
 				"station": "place-buwst",
@@ -632,539 +683,598 @@ export const stations = {
 					"1": ["70137"]
 				}
 			}, */ {
-				"stop_name": "Amory Street",
-				"branches": ["B"],
-				"station": "place-amory",
-				"order": 105,
-				"stops": {
-					"0": ["170140"],
-					"1": ["170141"]
-				}
-			}, {
-				"stop_name": "Babcock Street",
-				"branches": ["B"],
-				"station": "place-babck",
-				"order": 107,
-				"stops": {
-					"0": ["170136"],
-					"1": ["170137"]
-				}
-			}, {
-				"stop_name": "Packards Corner",
-				"branches": ["B"],
-				"station": "place-brico",
-				"order": 108,
-				"stops": {
-					"0": ["70134"],
-					"1": ["70135"]
-				}
-			}, {
-				"stop_name": "Harvard Avenue",
-				"branches": ["B"],
-				"station": "place-harvd",
-				"order": 109,
-				"stops": {
-					"0": ["70130"],
-					"1": ["70131"]
-				}
-			}, {
-				"stop_name": "Griggs Street",
-				"branches": ["B"],
-				"station": "place-grigg",
-				"order": 110,
-				"stops": {
-					"0": ["70128"],
-					"1": ["70129"]
-				}
-			}, {
-				"stop_name": "Allston Street",
-				"branches": ["B"],
-				"station": "place-alsgr",
-				"order": 111,
-				"stops": {
-					"0": ["70126"],
-					"1": ["70127"]
-				}
-			}, {
-				"stop_name": "Warren Street",
-				"branches": ["B"],
-				"station": "place-wrnst",
-				"order": 112,
-				"stops": {
-					"0": ["70124"],
-					"1": ["70125"]
-				}
-			}, {
-				"stop_name": "Washington Street",
-				"branches": ["B"],
-				"station": "place-wascm",
-				"order": 113,
-				"stops": {
-					"0": ["70120"],
-					"1": ["70121"]
-				}
-			}, {
-				"stop_name": "Sutherland Road",
-				"branches": ["B"],
-				"station": "place-sthld",
-				"order": 114,
-				"stops": {
-					"0": ["70116"],
-					"1": ["70117"]
-				}
-			}, {
-				"stop_name": "Chiswick Road",
-				"branches": ["B"],
-				"station": "place-chswk",
-				"order": 115,
-				"stops": {
-					"0": ["70114"],
-					"1": ["70115"]
-				}
-			}, {
-				"stop_name": "Chestnut Hill Avenue",
-				"branches": ["B"],
-				"station": "place-chill",
-				"order": 116,
-				"stops": {
-					"0": ["70112"],
-					"1": ["70113"]
-				}
-			}, {
-				"stop_name": "South Street",
-				"branches": ["B"],
-				"station": "place-sougr",
-				"order": 117,
-				"stops": {
-					"0": ["70110"],
-					"1": ["70111"]
-				}
-			}, {
-				"stop_name": "Boston College",
-				"branches": ["B"],
-				"station": "place-lake",
-				"order": 118,
-				"stops": {
-					"0": ["70106"],
-					"1": ["70107"]
-				}
-			}, {
-				"stop_name": "Kenmore",
-				"branches": ["B", "C", "D"],
-				"station": "place-kencl",
-				disabled: true,
-				"order": 12,
-				"stops": {
-					"0": ["70150", "71150"],
-					"1": ["70151", "71151"]
-				}
-			}, {
-				"stop_name": "Hynes",
-				"branches": ["B", "C", "D"],
-				"station": "place-hymnl",
-				"order": 11,
-				"stops": {
-					"0": ["70152"],
-					"1": ["70153"]
-				}
-			}, {
-				"stop_name": "Park Street",
-				"branches": ["B", "C", "D", "E"],
-				"station": "place-pktrm",
-				disabled: true,
-				"order": 7,
-				"stops": {
-					"0": ["70200"],
-					"1": ["70196", "70197", "70198", "70199"]
-				}
-			}, {
-				"stop_name": "Boylston",
-				"branches": ["B", "C", "D", "E"],
-				"station": "place-boyls",
-				"order": 8,
-				"stops": {
-					"0": ["70158"],
-					"1": ["70159"]
-				}
-			}, {
-				"stop_name": "Arlington",
-				"branches": ["B", "C", "D", "E"],
-				"station": "place-armnl",
-				"order": 9,
-				"stops": {
-					"0": ["70156"],
-					"1": ["70157"]
-				}
-			}, {
-				"stop_name": "Copley",
-				"branches": ["B", "C", "D", "E"],
-				"station": "place-coecl",
-				"order": 10,
-				"stops": {
-					"0": ["70154"],
-					"1": ["70155"]
-				}
-			}, {
-				"stop_name": "Cleveland Circle",
-				"branches": ["C"],
-				"station": "place-clmnl",
-				"order": 213,
-				"stops": {
-					"0": ["70238"],
-					"1": ["70237"]
-				}
-			}, {
-				"stop_name": "Englewood Avenue",
-				"branches": ["C"],
-				"station": "place-engav",
-				"order": 212,
-				"stops": {
-					"0": ["70236"],
-					"1": ["70235"]
-				}
-			}, {
-				"stop_name": "Dean Road",
-				"branches": ["C"],
-				"station": "place-denrd",
-				"order": 211,
-				"stops": {
-					"0": ["70234"],
-					"1": ["70233"]
-				}
-			}, {
-				"stop_name": "Tappan Street",
-				"branches": ["C"],
-				"station": "place-tapst",
-				"order": 210,
-				"stops": {
-					"0": ["70232"],
-					"1": ["70231"]
-				}
-			}, {
-				"stop_name": "Washington Square",
-				"branches": ["C"],
-				"station": "place-bcnwa",
-				"order": 209,
-				"stops": {
-					"0": ["70230"],
-					"1": ["70229"]
-				}
-			}, {
-				"stop_name": "Fairbanks Street",
-				"branches": ["C"],
-				"station": "place-fbkst",
-				"order": 208,
-				"stops": {
-					"0": ["70228"],
-					"1": ["70227"]
-				}
-			}, {
-				"stop_name": "Brandon Hall",
-				"branches": ["C"],
-				"station": "place-bndhl",
-				"order": 207,
-				"stops": {
-					"0": ["70226"],
-					"1": ["70225"]
-				}
-			}, {
-				"stop_name": "Summit Avenue",
-				"branches": ["C"],
-				"station": "place-sumav",
-				"order": 206,
-				"stops": {
-					"0": ["70224"],
-					"1": ["70223"]
-				}
-			}, {
-				"stop_name": "Coolidge Corner",
-				"branches": ["C"],
-				"station": "place-cool",
-				"order": 205,
-				"stops": {
-					"0": ["70220"],
-					"1": ["70219"]
-				}
-			}, {
-				"stop_name": "Saint Paul Street (C)",
-				"branches": ["C"],
-				"station": "place-stpul",
-				"order": 204,
-				"stops": {
-					"0": ["70218"],
-					"1": ["70217"]
-				}
-			}, {
-				"stop_name": "Kent Street",
-				"branches": ["C"],
-				"station": "place-kntst",
-				"order": 203,
-				"stops": {
-					"0": ["70216"],
-					"1": ["70215"]
-				}
-			}, {
-				"stop_name": "Hawes Street",
-				"branches": ["C"],
-				"station": "place-hwsst",
-				"order": 202,
-				"stops": {
-					"0": ["70214"],
-					"1": ["70213"]
-				}
-			}, {
-				"stop_name": "Saint Marys Street",
-				"branches": ["C"],
-				"station": "place-smary",
-				"order": 201,
-				"stops": {
-					"0": ["70212"],
-					"1": ["70211"]
-				}
-			}, {
-				"stop_name": "Government Center",
-				"branches": ["C", "D", "E"],
-				"station": "place-gover",
-				"order": 6,
-				"stops": {
-					"0": ["70201"],
-					"1": ["70202"]
-				}
-			}, {
-				"stop_name": "North Station",
-				"branches": ["C", "E"],
-				"station": "place-north",
-				"order": 4,
-				"stops": {
-					"0": ["70205"],
-					"1": ["70206"]
-				}
-			}, {
-				"stop_name": "Haymarket",
-				"branches": ["C", "E"],
-				"station": "place-haecl",
-				"order": 5,
-				"stops": {
-					"0": ["70203"],
-					"1": ["70204"]
-				}
-			}, {
-				"stop_name": "Fenway",
-				"branches": ["D"],
-				"station": "place-fenwy",
-				"order": 301,
-				"stops": {
-					"0": ["70186"],
-					"1": ["70187"]
-				}
-			}, {
-				"stop_name": "Longwood",
-				"branches": ["D"],
-				"station": "place-longw",
-				"order": 302,
-				"stops": {
-					"0": ["70182"],
-					"1": ["70183"]
-				}
-			}, {
-				"stop_name": "Brookline Village",
-				"branches": ["D"],
-				"station": "place-bvmnl",
-				"order": 303,
-				"stops": {
-					"0": ["70180"],
-					"1": ["70181"]
-				}
-			}, {
-				"stop_name": "Brookline Hills",
-				"branches": ["D"],
-				"station": "place-brkhl",
-				"order": 304,
-				"stops": {
-					"0": ["70178"],
-					"1": ["70179"]
-				}
-			}, {
-				"stop_name": "Beaconsfield",
-				"branches": ["D"],
-				"station": "place-bcnfd",
-				"order": 305,
-				"stops": {
-					"0": ["70176"],
-					"1": ["70177"]
-				}
-			}, {
-				"stop_name": "Reservoir",
-				"branches": ["D"],
-				"station": "place-rsmnl",
-				"order": 306,
-				"stops": {
-					"0": ["70174"],
-					"1": ["70175"]
-				}
-			}, {
-				"stop_name": "Chestnut Hill",
-				"branches": ["D"],
-				"station": "place-chhil",
-				"order": 307,
-				"stops": {
-					"0": ["70172"],
-					"1": ["70173"]
-				}
-			}, {
-				"stop_name": "Newton Centre",
-				"branches": ["D"],
-				"station": "place-newto",
-				"order": 308,
-				"stops": {
-					"0": ["70170"],
-					"1": ["70171"]
-				}
-			}, {
-				"stop_name": "Newton Highlands",
-				"branches": ["D"],
-				"station": "place-newtn",
-				"order": 309,
-				"stops": {
-					"0": ["70168"],
-					"1": ["70169"]
-				}
-			}, {
-				"stop_name": "Eliot",
-				"branches": ["D"],
-				"station": "place-eliot",
-				"order": 310,
-				"stops": {
-					"0": ["70166"],
-					"1": ["70167"]
-				}
-			}, {
-				"stop_name": "Waban",
-				"branches": ["D"],
-				"station": "place-waban",
-				"order": 311,
-				"stops": {
-					"0": ["70164"],
-					"1": ["70165"]
-				}
-			}, {
-				"stop_name": "Woodland",
-				"branches": ["D"],
-				"station": "place-woodl",
-				"order": 312,
-				"stops": {
-					"0": ["70162"],
-					"1": ["70163"]
-				}
-			}, {
-				"stop_name": "Riverside",
-				"branches": ["D"],
-				"station": "place-river",
-				"order": 313,
-				"stops": {
-					"0": ["70160"],
-					"1": ["70161"]
-				}
-			}, {
-				"stop_name": "Heath Street",
-				"branches": ["E"],
-				"station": "place-hsmnl",
-				"order": 411,
-				"stops": {
-					"0": ["70260"],
-					"1": ["70260"]
-				}
-			}, {
-				"stop_name": "Back of the Hill",
-				"branches": ["E"],
-				"station": "place-bckhl",
-				"order": 410,
-				"stops": {
-					"0": ["70258"],
-					"1": ["70257"]
-				}
-			}, {
-				"stop_name": "Riverway",
-				"branches": ["E"],
-				"station": "place-rvrwy",
-				"order": 409,
-				"stops": {
-					"0": ["70256"],
-					"1": ["70255"]
-				}
-			}, {
-				"stop_name": "Mission Park",
-				"branches": ["E"],
-				"station": "place-mispk",
-				"order": 408,
-				"stops": {
-					"0": ["70254"],
-					"1": ["70253"]
-				}
-			}, {
-				"stop_name": "Fenwood Road",
-				"branches": ["E"],
-				"station": "place-fenwd",
-				"order": 407,
-				"stops": {
-					"0": ["70252"],
-					"1": ["70251"]
-				}
-			}, {
-				"stop_name": "Brigham Circle",
-				"branches": ["E"],
-				"station": "place-brmnl",
-				"order": 406,
-				"stops": {
-					"0": ["70250"],
-					"1": ["70249"]
-				}
-			}, {
-				"stop_name": "Longwood Medical Area",
-				"branches": ["E"],
-				"station": "place-lngmd",
-				"order": 405,
-				"stops": {
-					"0": ["70248"],
-					"1": ["70247"]
-				}
-			}, {
-				"stop_name": "Museum of Fine Arts",
-				"branches": ["E"],
-				"station": "place-mfa",
-				"order": 404,
-				"stops": {
-					"0": ["70246"],
-					"1": ["70245"]
-				}
-			}, {
-				"stop_name": "Northeastern University",
-				"branches": ["E"],
-				"station": "place-nuniv",
-				"order": 403,
-				"stops": {
-					"0": ["70244"],
-					"1": ["70243"]
-				}
-			}, {
-				"stop_name": "Symphony",
-				"branches": ["E"],
-				"station": "place-symcl",
-				"order": 402,
-				"stops": {
-					"0": ["70242"],
-					"1": ["70241"]
-				}
-			}, {
-				"stop_name": "Prudential",
-				"branches": ["E"],
-				"station": "place-prmnl",
-				"order": 401,
-				"stops": {
-					"0": ["70240"],
-					"1": ["70239"]
-				}
-			}, /* {
+        stop_name: 'Amory Street',
+        branches: ['B'],
+        station: 'place-amory',
+        order: 105,
+        stops: {
+          '0': ['170140'],
+          '1': ['170141'],
+        },
+      },
+      {
+        stop_name: 'Babcock Street',
+        branches: ['B'],
+        station: 'place-babck',
+        order: 107,
+        stops: {
+          '0': ['170136'],
+          '1': ['170137'],
+        },
+      },
+      {
+        stop_name: 'Packards Corner',
+        branches: ['B'],
+        station: 'place-brico',
+        order: 108,
+        stops: {
+          '0': ['70134'],
+          '1': ['70135'],
+        },
+      },
+      {
+        stop_name: 'Harvard Avenue',
+        branches: ['B'],
+        station: 'place-harvd',
+        order: 109,
+        stops: {
+          '0': ['70130'],
+          '1': ['70131'],
+        },
+      },
+      {
+        stop_name: 'Griggs Street',
+        branches: ['B'],
+        station: 'place-grigg',
+        order: 110,
+        stops: {
+          '0': ['70128'],
+          '1': ['70129'],
+        },
+      },
+      {
+        stop_name: 'Allston Street',
+        branches: ['B'],
+        station: 'place-alsgr',
+        order: 111,
+        stops: {
+          '0': ['70126'],
+          '1': ['70127'],
+        },
+      },
+      {
+        stop_name: 'Warren Street',
+        branches: ['B'],
+        station: 'place-wrnst',
+        order: 112,
+        stops: {
+          '0': ['70124'],
+          '1': ['70125'],
+        },
+      },
+      {
+        stop_name: 'Washington Street',
+        branches: ['B'],
+        station: 'place-wascm',
+        order: 113,
+        stops: {
+          '0': ['70120'],
+          '1': ['70121'],
+        },
+      },
+      {
+        stop_name: 'Sutherland Road',
+        branches: ['B'],
+        station: 'place-sthld',
+        order: 114,
+        stops: {
+          '0': ['70116'],
+          '1': ['70117'],
+        },
+      },
+      {
+        stop_name: 'Chiswick Road',
+        branches: ['B'],
+        station: 'place-chswk',
+        order: 115,
+        stops: {
+          '0': ['70114'],
+          '1': ['70115'],
+        },
+      },
+      {
+        stop_name: 'Chestnut Hill Avenue',
+        branches: ['B'],
+        station: 'place-chill',
+        order: 116,
+        stops: {
+          '0': ['70112'],
+          '1': ['70113'],
+        },
+      },
+      {
+        stop_name: 'South Street',
+        branches: ['B'],
+        station: 'place-sougr',
+        order: 117,
+        stops: {
+          '0': ['70110'],
+          '1': ['70111'],
+        },
+      },
+      {
+        stop_name: 'Boston College',
+        branches: ['B'],
+        station: 'place-lake',
+        order: 118,
+        stops: {
+          '0': ['70106'],
+          '1': ['70107'],
+        },
+      },
+      {
+        stop_name: 'Kenmore',
+        branches: ['B', 'C', 'D'],
+        station: 'place-kencl',
+        disabled: true,
+        order: 12,
+        stops: {
+          '0': ['70150', '71150'],
+          '1': ['70151', '71151'],
+        },
+      },
+      {
+        stop_name: 'Hynes',
+        branches: ['B', 'C', 'D'],
+        station: 'place-hymnl',
+        order: 11,
+        stops: {
+          '0': ['70152'],
+          '1': ['70153'],
+        },
+      },
+      {
+        stop_name: 'Park Street',
+        branches: ['B', 'C', 'D', 'E'],
+        station: 'place-pktrm',
+        disabled: true,
+        order: 7,
+        stops: {
+          '0': ['70200'],
+          '1': ['70196', '70197', '70198', '70199'],
+        },
+      },
+      {
+        stop_name: 'Boylston',
+        branches: ['B', 'C', 'D', 'E'],
+        station: 'place-boyls',
+        order: 8,
+        stops: {
+          '0': ['70158'],
+          '1': ['70159'],
+        },
+      },
+      {
+        stop_name: 'Arlington',
+        branches: ['B', 'C', 'D', 'E'],
+        station: 'place-armnl',
+        order: 9,
+        stops: {
+          '0': ['70156'],
+          '1': ['70157'],
+        },
+      },
+      {
+        stop_name: 'Copley',
+        branches: ['B', 'C', 'D', 'E'],
+        station: 'place-coecl',
+        order: 10,
+        stops: {
+          '0': ['70154'],
+          '1': ['70155'],
+        },
+      },
+      {
+        stop_name: 'Cleveland Circle',
+        branches: ['C'],
+        station: 'place-clmnl',
+        order: 213,
+        stops: {
+          '0': ['70238'],
+          '1': ['70237'],
+        },
+      },
+      {
+        stop_name: 'Englewood Avenue',
+        branches: ['C'],
+        station: 'place-engav',
+        order: 212,
+        stops: {
+          '0': ['70236'],
+          '1': ['70235'],
+        },
+      },
+      {
+        stop_name: 'Dean Road',
+        branches: ['C'],
+        station: 'place-denrd',
+        order: 211,
+        stops: {
+          '0': ['70234'],
+          '1': ['70233'],
+        },
+      },
+      {
+        stop_name: 'Tappan Street',
+        branches: ['C'],
+        station: 'place-tapst',
+        order: 210,
+        stops: {
+          '0': ['70232'],
+          '1': ['70231'],
+        },
+      },
+      {
+        stop_name: 'Washington Square',
+        branches: ['C'],
+        station: 'place-bcnwa',
+        order: 209,
+        stops: {
+          '0': ['70230'],
+          '1': ['70229'],
+        },
+      },
+      {
+        stop_name: 'Fairbanks Street',
+        branches: ['C'],
+        station: 'place-fbkst',
+        order: 208,
+        stops: {
+          '0': ['70228'],
+          '1': ['70227'],
+        },
+      },
+      {
+        stop_name: 'Brandon Hall',
+        branches: ['C'],
+        station: 'place-bndhl',
+        order: 207,
+        stops: {
+          '0': ['70226'],
+          '1': ['70225'],
+        },
+      },
+      {
+        stop_name: 'Summit Avenue',
+        branches: ['C'],
+        station: 'place-sumav',
+        order: 206,
+        stops: {
+          '0': ['70224'],
+          '1': ['70223'],
+        },
+      },
+      {
+        stop_name: 'Coolidge Corner',
+        branches: ['C'],
+        station: 'place-cool',
+        order: 205,
+        stops: {
+          '0': ['70220'],
+          '1': ['70219'],
+        },
+      },
+      {
+        stop_name: 'Saint Paul Street (C)',
+        branches: ['C'],
+        station: 'place-stpul',
+        order: 204,
+        stops: {
+          '0': ['70218'],
+          '1': ['70217'],
+        },
+      },
+      {
+        stop_name: 'Kent Street',
+        branches: ['C'],
+        station: 'place-kntst',
+        order: 203,
+        stops: {
+          '0': ['70216'],
+          '1': ['70215'],
+        },
+      },
+      {
+        stop_name: 'Hawes Street',
+        branches: ['C'],
+        station: 'place-hwsst',
+        order: 202,
+        stops: {
+          '0': ['70214'],
+          '1': ['70213'],
+        },
+      },
+      {
+        stop_name: 'Saint Marys Street',
+        branches: ['C'],
+        station: 'place-smary',
+        order: 201,
+        stops: {
+          '0': ['70212'],
+          '1': ['70211'],
+        },
+      },
+      {
+        stop_name: 'Government Center',
+        branches: ['C', 'D', 'E'],
+        station: 'place-gover',
+        order: 6,
+        stops: {
+          '0': ['70201'],
+          '1': ['70202'],
+        },
+      },
+      {
+        stop_name: 'North Station',
+        branches: ['C', 'E'],
+        station: 'place-north',
+        order: 4,
+        stops: {
+          '0': ['70205'],
+          '1': ['70206'],
+        },
+      },
+      {
+        stop_name: 'Haymarket',
+        branches: ['C', 'E'],
+        station: 'place-haecl',
+        order: 5,
+        stops: {
+          '0': ['70203'],
+          '1': ['70204'],
+        },
+      },
+      {
+        stop_name: 'Fenway',
+        branches: ['D'],
+        station: 'place-fenwy',
+        order: 301,
+        stops: {
+          '0': ['70186'],
+          '1': ['70187'],
+        },
+      },
+      {
+        stop_name: 'Longwood',
+        branches: ['D'],
+        station: 'place-longw',
+        order: 302,
+        stops: {
+          '0': ['70182'],
+          '1': ['70183'],
+        },
+      },
+      {
+        stop_name: 'Brookline Village',
+        branches: ['D'],
+        station: 'place-bvmnl',
+        order: 303,
+        stops: {
+          '0': ['70180'],
+          '1': ['70181'],
+        },
+      },
+      {
+        stop_name: 'Brookline Hills',
+        branches: ['D'],
+        station: 'place-brkhl',
+        order: 304,
+        stops: {
+          '0': ['70178'],
+          '1': ['70179'],
+        },
+      },
+      {
+        stop_name: 'Beaconsfield',
+        branches: ['D'],
+        station: 'place-bcnfd',
+        order: 305,
+        stops: {
+          '0': ['70176'],
+          '1': ['70177'],
+        },
+      },
+      {
+        stop_name: 'Reservoir',
+        branches: ['D'],
+        station: 'place-rsmnl',
+        order: 306,
+        stops: {
+          '0': ['70174'],
+          '1': ['70175'],
+        },
+      },
+      {
+        stop_name: 'Chestnut Hill',
+        branches: ['D'],
+        station: 'place-chhil',
+        order: 307,
+        stops: {
+          '0': ['70172'],
+          '1': ['70173'],
+        },
+      },
+      {
+        stop_name: 'Newton Centre',
+        branches: ['D'],
+        station: 'place-newto',
+        order: 308,
+        stops: {
+          '0': ['70170'],
+          '1': ['70171'],
+        },
+      },
+      {
+        stop_name: 'Newton Highlands',
+        branches: ['D'],
+        station: 'place-newtn',
+        order: 309,
+        stops: {
+          '0': ['70168'],
+          '1': ['70169'],
+        },
+      },
+      {
+        stop_name: 'Eliot',
+        branches: ['D'],
+        station: 'place-eliot',
+        order: 310,
+        stops: {
+          '0': ['70166'],
+          '1': ['70167'],
+        },
+      },
+      {
+        stop_name: 'Waban',
+        branches: ['D'],
+        station: 'place-waban',
+        order: 311,
+        stops: {
+          '0': ['70164'],
+          '1': ['70165'],
+        },
+      },
+      {
+        stop_name: 'Woodland',
+        branches: ['D'],
+        station: 'place-woodl',
+        order: 312,
+        stops: {
+          '0': ['70162'],
+          '1': ['70163'],
+        },
+      },
+      {
+        stop_name: 'Riverside',
+        branches: ['D'],
+        station: 'place-river',
+        order: 313,
+        stops: {
+          '0': ['70160'],
+          '1': ['70161'],
+        },
+      },
+      {
+        stop_name: 'Heath Street',
+        branches: ['E'],
+        station: 'place-hsmnl',
+        order: 411,
+        stops: {
+          '0': ['70260'],
+          '1': ['70260'],
+        },
+      },
+      {
+        stop_name: 'Back of the Hill',
+        branches: ['E'],
+        station: 'place-bckhl',
+        order: 410,
+        stops: {
+          '0': ['70258'],
+          '1': ['70257'],
+        },
+      },
+      {
+        stop_name: 'Riverway',
+        branches: ['E'],
+        station: 'place-rvrwy',
+        order: 409,
+        stops: {
+          '0': ['70256'],
+          '1': ['70255'],
+        },
+      },
+      {
+        stop_name: 'Mission Park',
+        branches: ['E'],
+        station: 'place-mispk',
+        order: 408,
+        stops: {
+          '0': ['70254'],
+          '1': ['70253'],
+        },
+      },
+      {
+        stop_name: 'Fenwood Road',
+        branches: ['E'],
+        station: 'place-fenwd',
+        order: 407,
+        stops: {
+          '0': ['70252'],
+          '1': ['70251'],
+        },
+      },
+      {
+        stop_name: 'Brigham Circle',
+        branches: ['E'],
+        station: 'place-brmnl',
+        order: 406,
+        stops: {
+          '0': ['70250'],
+          '1': ['70249'],
+        },
+      },
+      {
+        stop_name: 'Longwood Medical Area',
+        branches: ['E'],
+        station: 'place-lngmd',
+        order: 405,
+        stops: {
+          '0': ['70248'],
+          '1': ['70247'],
+        },
+      },
+      {
+        stop_name: 'Museum of Fine Arts',
+        branches: ['E'],
+        station: 'place-mfa',
+        order: 404,
+        stops: {
+          '0': ['70246'],
+          '1': ['70245'],
+        },
+      },
+      {
+        stop_name: 'Northeastern University',
+        branches: ['E'],
+        station: 'place-nuniv',
+        order: 403,
+        stops: {
+          '0': ['70244'],
+          '1': ['70243'],
+        },
+      },
+      {
+        stop_name: 'Symphony',
+        branches: ['E'],
+        station: 'place-symcl',
+        order: 402,
+        stops: {
+          '0': ['70242'],
+          '1': ['70241'],
+        },
+      },
+      {
+        stop_name: 'Prudential',
+        branches: ['E'],
+        station: 'place-prmnl',
+        order: 401,
+        stops: {
+          '0': ['70240'],
+          '1': ['70239'],
+        },
+      },
+      /* {
 				"stop_name": "Lechmere",
 				"branches": ["E"],
 				"station": "place-lech",
@@ -1173,53 +1283,55 @@ export const stations = {
 					"0": ["70209"],
 					"1": ["70210"]
 				}
-			}, */{
-				"stop_name": "Lechmere",
-				"branches": ["E"],
-				"station": "place-lech",
-				"order": 2,
-				"stops": {
-					"0": ["70501"],
-					"1": ["70502"]
-				}
-			},{
-				"stop_name": "Union Square",
-				"branches": ["E"],
-				"station": "place-unsqu",
-				"order": 1,
-				"stops": {
-					"0": ["70503"],
-					"1": ["70504"]
-				}
-			},{
-				"stop_name": "Science Park",
-				"branches": ["E"],
-				"station": "place-spmnl",
-				"order": 3,
-				"stops": {
-					"0": ["70207"],
-					"1": ["70208"]
-				}
-			}
-		]
-	}
+			}, */ {
+        stop_name: 'Lechmere',
+        branches: ['E'],
+        station: 'place-lech',
+        order: 2,
+        stops: {
+          '0': ['70501'],
+          '1': ['70502'],
+        },
+      },
+      {
+        stop_name: 'Union Square',
+        branches: ['E'],
+        station: 'place-unsqu',
+        order: 1,
+        stops: {
+          '0': ['70503'],
+          '1': ['70504'],
+        },
+      },
+      {
+        stop_name: 'Science Park',
+        branches: ['E'],
+        station: 'place-spmnl',
+        order: 3,
+        stops: {
+          '0': ['70207'],
+          '1': ['70208'],
+        },
+      },
+    ],
+  },
 };
 
 export const derailments = {
   Red: {
-    start: "2019-06-11T00:00:00Z",
-    end: "2019-09-21T00:00:00Z",
-    color: "Red",
-    title: "Red line derailment",
+    start: '2019-06-11T00:00:00Z',
+    end: '2019-09-21T00:00:00Z',
+    color: 'Red',
+    title: 'Red line derailment',
     description:
-      "A red line train derailment at JFK/UMass destroyed important signal infrastructure that took months to repair.",
+      'A red line train derailment at JFK/UMass destroyed important signal infrastructure that took months to repair.',
   },
   Orange: {
-    start: "2021-03-16T00:00:00Z",
-    end: "2021-04-16T00:00:00Z",
-    color: "Orange",
-    title: "Orange line derailment",
+    start: '2021-03-16T00:00:00Z',
+    end: '2021-04-16T00:00:00Z',
+    color: 'Orange',
+    title: 'Orange line derailment',
     description:
-      "An orange line train derailment damaged a switch, requiring track replacement. A speed restriction followed in order to give the new track time to settle.",
+      'An orange line train derailment damaged a switch, requiring track replacement. A speed restriction followed in order to give the new track time to settle.',
   },
 };

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -1,10 +1,10 @@
-import classNames from "classnames";
-import DatePicker from "../inputs/date";
-import { optionsForSelect } from "./SlowZones";
-import { ChartView, Direction } from "./types";
-import { getDateThreeMonthsAgo, trainDateRange } from "../constants";
-import moment, { Moment } from "moment";
-import { useMemo } from "react";
+import classNames from 'classnames';
+import DatePicker from '../inputs/date';
+import { optionsForSelect } from './SlowZones';
+import { ChartView, Direction } from './types';
+import { getDateThreeMonthsAgo, trainDateRange } from '../constants';
+import moment, { Moment } from 'moment';
+import { useMemo } from 'react';
 
 interface SlowZoneNavProps {
   chartView: ChartView;
@@ -20,7 +20,7 @@ interface SlowZoneNavProps {
   params: URLSearchParams;
 }
 
-const SlowZoneNav = ({
+export const SlowZoneNav = ({
   chartView,
   setChartView,
   direction,
@@ -39,16 +39,14 @@ const SlowZoneNav = ({
   const clear = () => {
     const threeMonthsAgo = getDateThreeMonthsAgo();
     setStartDate(threeMonthsAgo);
-    params.set("startDate", threeMonthsAgo.format("YYYY-MM-DD"));
-    const EOD = moment().endOf("day");
-    params.set("endDate", EOD.format("YYYY-MM-DD"));
+    params.set('startDate', threeMonthsAgo.format('YYYY-MM-DD'));
+    const EOD = moment().endOf('day');
+    params.set('endDate', EOD.format('YYYY-MM-DD'));
     setEndDate(EOD);
   };
 
-  const startMoment = useMemo(() => startDate.format("YYYY-MM-DD"), [
-    startDate,
-  ]);
-  const endMoment = useMemo(() => endDate.format("YYYY-MM-DD"), [endDate]);
+  const startMoment = useMemo(() => startDate.format('YYYY-MM-DD'), [startDate]);
+  const endMoment = useMemo(() => endDate.format('YYYY-MM-DD'), [endDate]);
 
   return (
     <div className="station-configuration-wrapper">
@@ -56,10 +54,7 @@ const SlowZoneNav = ({
         <div className="line-toggle">
           <div className="option mode">
             {optionsForSelect().map((opt) => (
-              <div
-                key={opt.value}
-                className={classNames("button-toggle", opt.value)}
-              >
+              <div key={opt.value} className={classNames('button-toggle', opt.value)}>
                 <label>
                   <input
                     type="checkbox"
@@ -76,28 +71,24 @@ const SlowZoneNav = ({
         </div>
         <div className="chart-toggle">
           <div className="option option-mode">
-            <span className="switch-label slowzones-switch-label">
-              Total slow time
-            </span>
+            <span className="switch-label slowzones-switch-label">Total slow time</span>
             <label className="option switch">
               <input
                 type="checkbox"
-                checked={chartView === "xrange"}
+                checked={chartView === 'xrange'}
                 onChange={() => {
-                  if (chartView === "line") {
-                    setChartView("xrange");
-                    params.set("chartView", "xrange");
+                  if (chartView === 'line') {
+                    setChartView('xrange');
+                    params.set('chartView', 'xrange');
                   } else {
-                    setChartView("line");
-                    params.set("chartView", "line");
+                    setChartView('line');
+                    params.set('chartView', 'line');
                   }
                 }}
               />
               <span className="slider"></span>
             </label>
-            <span className="switch-label slowzones-switch-label">
-              Line segments
-            </span>
+            <span className="switch-label slowzones-switch-label">Line segments</span>
           </div>
         </div>
         <div className="direction-toggle">
@@ -105,22 +96,22 @@ const SlowZoneNav = ({
             className="option option-mode"
             style={{
               // Disable the northbound/southbound slider in "total slow time" mode
-              opacity: chartView === "xrange" ? 1.0 : 0.5,
-              pointerEvents: chartView === "xrange" ? "auto" : "none",
+              opacity: chartView === 'xrange' ? 1.0 : 0.5,
+              pointerEvents: chartView === 'xrange' ? 'auto' : 'none',
             }}
           >
             <span className="switch-label">Southbound</span>
             <label className="option switch">
               <input
                 type="checkbox"
-                checked={direction === "northbound"}
+                checked={direction === 'northbound'}
                 onChange={() => {
-                  if (direction === "northbound") {
-                    setDireciton("southbound");
-                    params.set("direction", "southbound");
+                  if (direction === 'northbound') {
+                    setDireciton('southbound');
+                    params.set('direction', 'southbound');
                   } else {
-                    setDireciton("northbound");
-                    params.set("direction", "northbound");
+                    setDireciton('northbound');
+                    params.set('direction', 'northbound');
                   }
                 }}
               />
@@ -154,5 +145,3 @@ const SlowZoneNav = ({
     </div>
   );
 };
-
-export default SlowZoneNav;

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -1,21 +1,17 @@
-import { useEffect, useMemo, useState } from "react";
-import { ChartView, Direction, SlowZone } from "./types";
-import { Link, useHistory, useLocation } from "react-router-dom";
-import Highcharts from "highcharts";
-import HighchartsReact from "highcharts-react-official";
-import xrange from "highcharts/modules/xrange";
-import exporting from "highcharts/modules/exporting";
-import annotations from "highcharts/modules/annotations";
-import {
-  formatSlowZones,
-  generateLineOptions,
-  generateXrangeOptions,
-} from "./formattingUtils";
-import { goatcount } from "../analytics";
-import { getDateThreeMonthsAgo } from "../constants";
-import SlowZoneNav from "./SlowZoneNav";
-import { line_name, subway_lines } from "../stations";
-import moment from "moment";
+import { useEffect, useMemo, useState } from 'react';
+import { ChartView, Direction, SlowZone } from './types';
+import { Link, useHistory, useLocation } from 'react-router-dom';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import xrange from 'highcharts/modules/xrange';
+import exporting from 'highcharts/modules/exporting';
+import annotations from 'highcharts/modules/annotations';
+import { formatSlowZones, generateLineOptions, generateXrangeOptions } from './formattingUtils';
+import { goatcount } from '../analytics';
+import { getDateThreeMonthsAgo } from '../constants';
+import { SlowZoneNav } from './SlowZoneNav';
+import { line_name, subway_lines } from '../stations';
+import moment from 'moment';
 
 xrange(Highcharts);
 exporting(Highcharts);
@@ -27,7 +23,7 @@ export const optionsForSelect = () => {
     return {
       value: line,
       label: line_name(line),
-      disabled: line_name(line) === "Green Line",
+      disabled: line_name(line) === 'Green Line',
     };
   });
 };
@@ -39,37 +35,35 @@ function useQuery() {
 }
 
 export const SlowZones = () => {
-  document.title = "Data Dashboard - Slow zones";
+  document.title = 'Data Dashboard - Slow zones';
   const params = useQuery();
   const history = useHistory();
   const [options, setOptions] = useState<Highcharts.Options>();
   const [chartView, setChartView] = useState<ChartView>(
-    (params.get("chartView") as ChartView) || "line"
+    (params.get('chartView') as ChartView) || 'line'
   );
   const [direction, setDirection] = useState<Direction>(
-    (params.get("direction") as Direction) || "southbound"
+    (params.get('direction') as Direction) || 'southbound'
   );
   const [selectedLines, setSelectedLines] = useState<any[]>(
-    params.get("selectedLines")?.split(",") || ["Red", "Orange", "Blue"]
+    params.get('selectedLines')?.split(',') || ['Red', 'Orange', 'Blue']
   );
   const [totalDelays, setTotalDelays] = useState<any>();
   const [allSlow, setAllSlow] = useState<any>();
   const [startDate, setStartDate] = useState(() => {
-    if (params.get("startDate")) {
-      return moment(params.get("startDate"));
+    if (params.get('startDate')) {
+      return moment(params.get('startDate'));
     } else return getDateThreeMonthsAgo();
   });
   const [endDate, setEndDate] = useState(() => {
-    if (params.get("endDate")) {
-      return moment(params.get("endDate"));
+    if (params.get('endDate')) {
+      return moment(params.get('endDate'));
     } else return moment();
   });
 
   const setTotalDelaysOptions = (data: any) => {
     const filteredData = data.filter((d: any) => {
-      return moment(d.date)
-        .add(5, "hours")
-        .isBetween(startDate, endDate, undefined, "[]");
+      return moment(d.date).add(5, 'hours').isBetween(startDate, endDate, undefined, '[]');
     });
     const options = generateLineOptions(filteredData, selectedLines, startDate);
     setOptions(options);
@@ -79,8 +73,8 @@ export const SlowZones = () => {
     const formattedData = formatSlowZones(data);
     const filteredData = formattedData.filter(
       (d: SlowZone) =>
-        (d.start.isBetween(startDate, endDate, undefined, "[]") ||
-          d.end.isBetween(startDate, endDate, undefined, "[]") ||
+        (d.start.isBetween(startDate, endDate, undefined, '[]') ||
+          d.end.isBetween(startDate, endDate, undefined, '[]') ||
           (d.start.isBefore(startDate) && d.end.isAfter(endDate))) &&
         selectedLines.includes(d.color) &&
         d.direction === direction
@@ -95,15 +89,12 @@ export const SlowZones = () => {
 
     goatcount();
 
-    if (chartView === "line") {
+    if (chartView === 'line') {
       if (totalDelays) {
         // We only want to fetch each dataset once
         setTotalDelaysOptions(totalDelays);
       } else {
-        const url = new URL(
-          `/static/slowzones/delay_totals.json`,
-          window.location.origin
-        );
+        const url = new URL(`/static/slowzones/delay_totals.json`, window.location.origin);
         fetch(url.toString())
           .then((resp) => resp.json())
           .then((data) => {
@@ -115,10 +106,7 @@ export const SlowZones = () => {
       if (allSlow) {
         setAllSlowOptions(allSlow);
       } else {
-        const url = new URL(
-          `/static/slowzones/all_slow.json`,
-          window.location.origin
-        );
+        const url = new URL(`/static/slowzones/all_slow.json`, window.location.origin);
         fetch(url.toString())
           .then((resp) => resp.json())
           .then((data) => {
@@ -134,11 +122,11 @@ export const SlowZones = () => {
     if (selectedLines.includes(line)) {
       const filteredLines = selectedLines.filter((value) => value !== line);
       setSelectedLines(filteredLines);
-      params.set("selectedLines", filteredLines.join(","));
+      params.set('selectedLines', filteredLines.join(','));
     } else {
       const lines = [...selectedLines, line];
       setSelectedLines(lines);
-      params.set("selectedLines", lines.join(","));
+      params.set('selectedLines', lines.join(','));
     }
   };
 
@@ -155,30 +143,28 @@ export const SlowZones = () => {
         endDate={endDate}
         setStartDate={(date: any) => {
           setStartDate(moment(date));
-          params.set("startDate", date);
+          params.set('startDate', date);
         }}
         setEndDate={(date: any) => {
           setEndDate(moment(date));
-          params.set("endDate", date);
+          params.set('endDate', date);
         }}
         params={params}
       />
       {options && (
         <HighchartsReact
           containerProps={{
-            style: { "min-height": "83vh", paddingTop: "1em" },
+            style: { 'min-height': '83vh', paddingTop: '1em' },
           }}
           options={options}
           highcharts={Highcharts}
           immutable={true}
         />
       )}
-      {chartView === "xrange" && (
+      {chartView === 'xrange' && (
         <div className="derailment-footer">
           ⚠️
-          <span className="derailment-footer-text">
-            = Affected by a derailment
-          </span>
+          <span className="derailment-footer-text">= Affected by a derailment</span>
         </div>
       )}
 
@@ -189,9 +175,9 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              This is a tool to help find and track slow zones. That is, areas
-              where trains have lower-than-usual speeds due to track conditions,
-              signal issues, or other infrastructure problems.
+              This is a tool to help find and track slow zones. That is, areas where trains have
+              lower-than-usual speeds due to track conditions, signal issues, or other
+              infrastructure problems.
             </p>
           </div>
         </li>
@@ -201,12 +187,11 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              We look at the daily median travel time + dwell time for each
-              segment along a route. Whenever that trip time is at least 10%
-              slower than the baseline for 3 or more days in a row, it gets
-              flagged as a slow zone. Currently, our baseline is the median
-              value in our data, which goes back to 2016. It’s not a perfect
-              system, but various algorithmic improvements are in the works.
+              We look at the daily median travel time + dwell time for each segment along a route.
+              Whenever that trip time is at least 10% slower than the baseline for 3 or more days in
+              a row, it gets flagged as a slow zone. Currently, our baseline is the median value in
+              our data, which goes back to 2016. It’s not a perfect system, but various algorithmic
+              improvements are in the works.
             </p>
           </div>
         </li>
@@ -216,10 +201,9 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              The line graph sums all the slow zone delays by color. In other
-              words, it shows the amount of delay time due to slow zones on
-              one round trip of each route. The numbers are approximate due to
-              averaging.
+              The line graph sums all the slow zone delays by color. In other words, it shows the
+              amount of delay time due to slow zones on one round trip of each route. The numbers
+              are approximate due to averaging.
             </p>
           </div>
         </li>
@@ -229,10 +213,9 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              ReactJS + HighchartsJS and Highcharts Gantt from 
+              ReactJS + HighchartsJS and Highcharts Gantt from
               <a href="highcharts.com"> Highcharts</a> <br />
-              See our <Link to="/opensource"> Attribution</Link> page for more
-              information.
+              See our <Link to="/opensource"> Attribution</Link> page for more information.
             </p>
           </div>
         </li>
@@ -242,12 +225,11 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              There’s power in data, but it’s only useful when you can tell a
-              story. Slow zones are a nice story to tell: they tie our
-              observable results to a cause. With so much data available, it can
-              be difficult to find the interesting bits. So we’ve built this
-              tool to help us locate and track this type of issue (slow zones),
-              and monitor the severity over time.
+              There’s power in data, but it’s only useful when you can tell a story. Slow zones are
+              a nice story to tell: they tie our observable results to a cause. With so much data
+              available, it can be difficult to find the interesting bits. So we’ve built this tool
+              to help us locate and track this type of issue (slow zones), and monitor the severity
+              over time.
             </p>
           </div>
         </li>
@@ -257,8 +239,8 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              Share it. Bring the data to public meetings. Pressure the T to do
-              better, but also give them credit where it’s due.
+              Share it. Bring the data to public meetings. Pressure the T to do better, but also
+              give them credit where it’s due.
             </p>
           </div>
         </li>
@@ -268,9 +250,8 @@ export const SlowZones = () => {
           </a>
           <div className="accordion-text">
             <p>
-              Due to variable traffic, much of the Green Line doesn’t have
-              consistent enough trip times to measure. As for the main trunk and
-              the D line? Coming “soon”.
+              Due to variable traffic, much of the Green Line doesn’t have consistent enough trip
+              times to measure. As for the main trunk and the D line? Coming “soon”.
             </p>
           </div>
         </li>

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -1,36 +1,27 @@
-import moment, { Moment } from "moment";
-import { colorsForLine, derailments } from "../constants";
-import { lookup_station_by_id } from "../stations";
-import { Direction, SlowZone } from "./types";
+import moment, { Moment } from 'moment';
+import { colorsForLine, derailments } from '../constants';
+import { lookup_station_by_id } from '../stations';
+import { Direction, SlowZone } from './types';
 
 const ua = window.navigator.userAgent;
 const isMobile = /Android|webOS|iPhone|iPad|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-const textSize = isMobile ? '11' : 14
+const textSize = isMobile ? '11' : 14;
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
 const isDuringDerailment = (start: Moment, end: Moment, color: string) => {
-  if (color === "Blue") return false;
+  if (color === 'Blue') return false;
 
-  if (color === "Red") {
+  if (color === 'Red') {
     return (
-      start.isBetween(
-        moment(derailments.Red.start),
-        moment(derailments.Red.end)
-      ) ||
+      start.isBetween(moment(derailments.Red.start), moment(derailments.Red.end)) ||
       end.isBetween(moment(derailments.Red.start), moment(derailments.Red.end))
     );
   }
-  if (color === "Orange") {
+  if (color === 'Orange') {
     return (
-      start.isBetween(
-        moment(derailments.Orange.start),
-        moment(derailments.Orange.end)
-      ) ||
-      end.isBetween(
-        moment(derailments.Orange.start),
-        moment(derailments.Orange.end)
-      )
+      start.isBetween(moment(derailments.Orange.start), moment(derailments.Orange.end)) ||
+      end.isBetween(moment(derailments.Orange.start), moment(derailments.Orange.end))
     );
   }
 };
@@ -40,14 +31,14 @@ const capitalize = (s: string) => {
 };
 
 const getDashUrl = (d: any) => {
-  const dateDiff = moment(d.custom.startDate).diff(d.x2, "months");
+  const dateDiff = moment(d.custom.startDate).diff(d.x2, 'months');
   let then;
   if (dateDiff <= -18) {
-    then = moment(d.x2).subtract(18, "months").toISOString().split("T")[0];
+    then = moment(d.x2).subtract(18, 'months').toISOString().split('T')[0];
   } else {
     then = new Date(d.custom.startDate);
     then.setDate(then.getDate() - 14); // two weeks of baseline for comparison
-    then = then.toISOString().split("T")[0];
+    then = then.toISOString().split('T')[0];
   }
 
   let now: any = new Date(d.x2);
@@ -56,7 +47,7 @@ const getDashUrl = (d: any) => {
   if (today < now) {
     now = today;
   }
-  now = now.toISOString().split("T")[0];
+  now = now.toISOString().split('T')[0];
 
   return `https://dashboard.transitmatters.org/rapidtransit?config=${d.custom.color},${d.custom.fr_id},${d.custom.to_id},${then},${now}`;
 };
@@ -64,7 +55,7 @@ const getDashUrl = (d: any) => {
 const getDirection = (to: any, from: any) => {
   const toOrder = to.order;
   const fromOrder = from.order;
-  return toOrder > fromOrder ? "southbound" : "northbound";
+  return toOrder > fromOrder ? 'southbound' : 'northbound';
 };
 
 // Data formatting & cleanup
@@ -80,7 +71,7 @@ export const formatSlowZones = (data: any) =>
       from: from.stop_name,
       to: to.stop_name,
       uid: +x.id,
-      id: from.stop_name + "-" + to.stop_name,
+      id: from.stop_name + '-' + to.stop_name,
       delay: +x.delay,
       duration: +x.duration,
       color: x.color,
@@ -110,9 +101,7 @@ export const getRoutes = (data: SlowZone[], direction: Direction) => {
   // group by line, sort by order , flatten, get ids, filter out duplicates
   const routes = Object.values(groupByLine(data))
     .map((sz: SlowZone[]) =>
-      sz.sort((a, b) =>
-        direction === "southbound" ? a.order - b.order : b.order - a.order
-      )
+      sz.sort((a, b) => (direction === 'southbound' ? a.order - b.order : b.order - a.order))
     )
     .flat()
     .map((sz: SlowZone) => sz.id);
@@ -120,11 +109,7 @@ export const getRoutes = (data: SlowZone[], direction: Direction) => {
 };
 
 // Xrange options
-export const generateXrangeSeries = (
-  data: any,
-  startDate: Moment,
-  direciton: Direction
-) => {
+export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Direction) => {
   const routes = getRoutes(data, direciton);
   const groupedByLine = groupByLine(data);
   return Object.entries(groupedByLine).map((line) => {
@@ -134,9 +119,7 @@ export const generateXrangeSeries = (
       color: colorsForLine[line[0]],
       data: data.map((d) => {
         return {
-          x: d.start.isBefore(startDate)
-            ? startDate.utc().valueOf()
-            : d.start.utc().valueOf(),
+          x: d.start.isBefore(startDate) ? startDate.utc().valueOf() : d.start.utc().valueOf(),
           x2: d.end.utc().valueOf(),
           y: routes.indexOf(d.id),
           custom: {
@@ -170,26 +153,26 @@ export const generateXrangeOptions = (
     {
       labels: [
         {
-          point: "red-derailment-start",
-          text: "Derailment",
+          point: 'red-derailment-start',
+          text: 'Derailment',
         },
         {
-          point: "red-derailment-end",
-          text: "Signals restored",
+          point: 'red-derailment-end',
+          text: 'Signals restored',
         },
         {
-          point: "orange-derailment-start",
-          text: "Derailment",
+          point: 'orange-derailment-start',
+          text: 'Derailment',
         },
         {
-          point: "orange-derailment-end",
-          text: "Tracks restored",
+          point: 'orange-derailment-end',
+          text: 'Tracks restored',
         },
       ],
     },
   ],
   chart: {
-    type: "xrange",
+    type: 'xrange',
   },
   credits: {
     enabled: false,
@@ -197,13 +180,13 @@ export const generateXrangeOptions = (
   title: {
     text: `${capitalize(direction)} slow zones`,
     style: {
-      fontSize: "24px",
+      fontSize: '24px',
     },
   },
   xAxis: {
-    type: "datetime",
+    type: 'datetime',
     title: {
-      text: "Date",
+      text: 'Date',
       style: {
         fontSize: textSize,
       },
@@ -218,9 +201,9 @@ export const generateXrangeOptions = (
     enabled: false,
   },
   yAxis: {
-    type: "category",
+    type: 'category',
     title: {
-      text: "Line Segments",
+      text: 'Line Segments',
       style: {
         fontSize: textSize,
       },
@@ -235,21 +218,21 @@ export const generateXrangeOptions = (
   },
   tooltip: {
     formatter: function (this: any) {
-      return `<div><span style="font-size: 10px">${moment(
-        this.point.custom.startDate
-      ).utc().format("MMMM Do YYYY")} - ${moment(this.point.x2).utc().format(
-        "MMMM Do YYYY"
-      )}</span><br/> <span style="color:${this.point.color}">●</span> ${
+      return `<div><span style="font-size: 10px">${moment(this.point.custom.startDate)
+        .utc()
+        .format('MMMM Do YYYY')} - ${moment(this.point.x2)
+        .utc()
+        .format('MMMM Do YYYY')}</span><br/> <span style="color:${this.point.color}">●</span> ${
         this.point.series.name
       }: <b>${this.point.yCategory}</b><br/></div>`;
     },
   },
   plotOptions: {
     series: {
-      cursor: "pointer",
+      cursor: 'pointer',
       events: {
         click: function (event: any) {
-          window.open(getDashUrl(event.point), "_blank");
+          window.open(getDashUrl(event.point), '_blank');
         },
       },
       grouping: false,
@@ -267,10 +250,10 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
   const RED_LINE = data.map((day: any) => {
     const y = Number((day.Red / 60).toFixed(2));
     if (day.date === derailments.Red.start) {
-      return { id: "red-derailment-start", y };
+      return { id: 'red-derailment-start', y };
     }
     if (day.date === derailments.Red.end) {
-      return { id: "red-derailment-end", y };
+      return { id: 'red-derailment-end', y };
     } else {
       return y;
     }
@@ -279,28 +262,28 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
   const ORANGE_LINE = data.map((day: any) => {
     const y = Number((day.Orange / 60).toFixed(2));
     if (day.date === derailments.Orange.start) {
-      return { id: "orange-derailment-start", y };
+      return { id: 'orange-derailment-start', y };
     }
     if (day.date === derailments.Orange.end) {
-      return { id: "orange-derailment-end", y };
+      return { id: 'orange-derailment-end', y };
     } else {
       return y;
     }
   });
   return [
-    selectedLines.includes("Red") && {
-      name: "Red",
-      color: colorsForLine["Red"],
+    selectedLines.includes('Red') && {
+      name: 'Red',
+      color: colorsForLine['Red'],
       data: RED_LINE,
     },
-    selectedLines.includes("Blue") && {
-      name: "Blue",
-      color: colorsForLine["Blue"],
+    selectedLines.includes('Blue') && {
+      name: 'Blue',
+      color: colorsForLine['Blue'],
       data: BLUE_LINE,
     },
-    selectedLines.includes("Orange") && {
-      name: "Orange",
-      color: colorsForLine["Orange"],
+    selectedLines.includes('Orange') && {
+      name: 'Orange',
+      color: colorsForLine['Orange'],
       data: ORANGE_LINE,
     },
   ];
@@ -313,20 +296,20 @@ export const generateLineOptions = (
 ): any => ({
   exporting: {
     csv: {
-      itemDelimiter: ";",
+      itemDelimiter: ';',
     },
   },
   credits: { enabled: false },
   title: {
     text: `Time spent in slow zones`,
     style: {
-      fontSize: "24px",
+      fontSize: '24px',
     },
   },
   xAxis: {
-    type: "datetime",
+    type: 'datetime',
     title: {
-      text: "Date",
+      text: 'Date',
       style: {
         fontSize: textSize,
       },
@@ -339,7 +322,7 @@ export const generateLineOptions = (
   },
   yAxis: {
     title: {
-      text: "Slow time per day (minutes)",
+      text: 'Slow time per day (minutes)',
       style: {
         fontSize: textSize,
       },
@@ -361,7 +344,7 @@ export const generateLineOptions = (
   tooltip: {
     formatter: function (this: any) {
       return `<div><span style="font-size: 10px">${moment(this.point.x).format(
-        "MMMM Do YYYY"
+        'MMMM Do YYYY'
       )}</span><br/> <span style="color:${this.point.color}">●</span> ${
         this.point.series.name
       }: <b>${this.point.y}</b><br/></div>`;
@@ -374,20 +357,20 @@ export const generateLineOptions = (
     {
       labels: [
         {
-          point: "red-derailment-start",
-          text: "Derailment",
+          point: 'red-derailment-start',
+          text: 'Derailment',
         },
         {
-          point: "red-derailment-end",
-          text: "Signals restored",
+          point: 'red-derailment-end',
+          text: 'Signals restored',
         },
         {
-          point: "orange-derailment-start",
-          text: "Derailment",
+          point: 'orange-derailment-start',
+          text: 'Derailment',
         },
         {
-          point: "orange-derailment-end",
-          text: "Tracks restored",
+          point: 'orange-derailment-end',
+          text: 'Tracks restored',
         },
       ],
     },


### PR DESCRIPTION
# Motivation

Enforce Eslint rules on files in the repo to get us to a consistent code style

# Changes

- Turn on `prettier` to warn
- Enforce prettier style on Typescript files (leaving alone Javascript for now, those can updated as touched)
- Adds eslint warn for default exports