### PR TITLE
Adding eslint import plugin for future enforcement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: 'module',
   },
-  plugins: ['react', 'react-hooks', '@typescript-eslint', 'prettier'],
+  plugins: ['react', 'react-hooks', '@typescript-eslint', 'import', 'prettier'],
   rules: {
     'prettier/prettier': 'off', // TODO: Change to Warn
     'react/prop-types': 'off', // TODO: Turn on or move to TS
@@ -32,6 +32,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-explicit-any': 'off', // TODO: After full TS migration, change to warn or error
     '@typescript-eslint/ban-ts-comment': 'warn',
+    'import/no-default-export': 'off',
   },
   settings: {
     react: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^5.32.0",
         "eslint": "^8.21.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/parser": "^5.32.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
# Motivation

We had discussed removing default exports, this adds the plugin to allow enforcement

I turned it off for now as it would require editing quite a few files, we can turn it on after a slow migration as to not cause a bunch of issues with builds