### PR TITLE
color subway travel and headway legends

### DIFF
--- a/src/charts/legend.css
+++ b/src/charts/legend.css
@@ -1,16 +1,15 @@
 .on-time {
-    background-color: #64b96a
+    background-color: #64b96a !important
 }
 
 .twenty-five-percent {
-    background-color: #f5ed00
+    background-color: #f5ed00 !important
 }
 
 .fifty-percent {
-    background-color: #c33149
-
+    background-color: #c33149 !important
 }
 
 .hundred-percent {
-    background-color: #bb5cc1
+    background-color: #bb5cc1 !important
 }


### PR DESCRIPTION
in the css for the legend on the subway Travel Times and headways graphs, both `.legend-dot` and the on-time/percentage class selectors have the same precedence. when I load the page (chrome on linux), this results in the key all being colored with `#bbb`, since `.legend-dot` is apparently loaded later, which isn't really a helpful key.

this commit solves this naively by adding `!important` to the `background-color`s for the on-time/percentage classes, so they'll be used regardless of the order css files are loaded.
