### PR TITLE
make slowzones line graphs always include zero

### DIFF
--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -332,6 +332,7 @@ export const generateLineOptions = (
         fontSize: textSize,
       },
     },
+    min: 0,
   },
   series: groupByLineDailyTotals(data, selectedLines),
   plotOptions: {


### PR DESCRIPTION
shifting y axis minimums can distort how line graphs are compared

since these graphs are always positive (negative time spent in slow zones sounds really cool actually), we can simply set the minimum y axis to 0, and graphs should be much more visually consistent (at least until we get negative slowzones)

This should resolve #216

Screenshot:
![transitmatters labs time spent in slow zones graph. the y axis begins at zero, even though the data does not include zero](https://user-images.githubusercontent.com/12436574/189036647-6f66e4ce-de2b-40f0-8a4f-93d3b7f2f5cc.png)

