### PR TITLE
Orange line shutdown notice

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -622,14 +622,18 @@ button:disabled,
   font-size: 14px;
 }
 
-.derailment-footer {
+.event-footer {
   padding-left: 4em;
   font-size: 14px;
   display: flex;
   padding-bottom: 10px;
+  flex-flow: column;
+  flex-direction: column;
+  flex-wrap: wrap;
+  align-content: flex-start;
 }
 
-.derailment-footer-text {
+.event-footer-text {
   align-self: center;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { MbtaMajorEvent } from './slowzones/types';
 
 import stations_json from './stations.json';
 
@@ -45,21 +46,36 @@ export const busDateRange = {
 
 export const stations = stations_json;
 
-export const derailments = {
-  Red: {
-    start: '2019-06-11T00:00:00Z',
-    end: '2019-09-21T00:00:00Z',
-    color: 'Red',
-    title: 'Red line derailment',
-    description:
-      'A red line train derailment at JFK/UMass destroyed important signal infrastructure that took months to repair.',
-  },
-  Orange: {
-    start: '2021-03-16T00:00:00Z',
-    end: '2021-04-16T00:00:00Z',
-    color: 'Orange',
-    title: 'Orange line derailment',
-    description:
-      'An orange line train derailment damaged a switch, requiring track replacement. A speed restriction followed in order to give the new track time to settle.',
-  },
+export const majorEvents: { Red: MbtaMajorEvent[]; Orange: MbtaMajorEvent[] } = {
+  Red: [
+    {
+      start: '2019-06-11T00:00:00Z',
+      end: '2019-09-21T00:00:00Z',
+      color: 'Red',
+      title: 'Red line derailment',
+      description:
+        'A red line train derailment at JFK/UMass destroyed important signal infrastructure that took months to repair.',
+      type: 'derailment',
+    },
+  ],
+  Orange: [
+    {
+      start: '2021-03-16T00:00:00Z',
+      end: '2021-04-16T00:00:00Z',
+      color: 'Orange',
+      title: 'Orange line derailment',
+      description:
+        'An orange line train derailment damaged a switch, requiring track replacement. A speed restriction followed in order to give the new track time to settle.',
+      type: 'derailment',
+    },
+    {
+      start: '2022-08-19T00:00:00Z',
+      end: '2022-09-19T00:00:00Z',
+      color: 'Orange',
+      title: 'Orange line shutdown',
+      description:
+        'The orange line was shut down for 30 days to complete deferred maintenance',
+      type: 'shutdown',
+    },
+  ],
 };

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -163,8 +163,7 @@ export const SlowZones = () => {
       )}
       {chartView === 'xrange' && (
         <div className="event-footer">
-          <span className="event-footer-text">⚠️ = Affected by a derailment</span>
-          <span className="event-footer-text">🚧 = Affected by a shutdown</span>
+          <span className="event-footer-text">⚠️ = Affected by a derailment or shutdown</span>
         </div>
       )}
 

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -162,9 +162,9 @@ export const SlowZones = () => {
         />
       )}
       {chartView === 'xrange' && (
-        <div className="derailment-footer">
-          ⚠️
-          <span className="derailment-footer-text">= Affected by a derailment</span>
+        <div className="event-footer">
+          <span className="event-footer-text">⚠️ = Affected by a derailment</span>
+          <span className="event-footer-text">🚧 = Affected by a shutdown</span>
         </div>
       )}
 

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -1,7 +1,7 @@
 import moment, { Moment } from 'moment';
-import { colorsForLine, derailments } from '../constants';
+import { colorsForLine, majorEvents } from '../constants';
 import { lookup_station_by_id } from '../stations';
-import { Direction, SlowZone } from './types';
+import { Day, Direction, SlowZone } from './types';
 
 const ua = window.navigator.userAgent;
 const isMobile = /Android|webOS|iPhone|iPad|BlackBerry|IEMobile|Opera Mini/i.test(ua);
@@ -9,19 +9,19 @@ const textSize = isMobile ? '11' : 14;
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
-const isDuringDerailment = (start: Moment, end: Moment, color: string) => {
+const isDuringMajorEvent = (start: Moment, end: Moment, color: string) => {
   if (color === 'Blue') return false;
 
   if (color === 'Red') {
     return (
-      start.isBetween(moment(derailments.Red.start), moment(derailments.Red.end)) ||
-      end.isBetween(moment(derailments.Red.start), moment(derailments.Red.end))
+      majorEvents.Red.some(event => start.isBetween(moment(event.start), moment(event.end))) ||
+      majorEvents.Red.some(event => end.isBetween(moment(event.start), moment(event.end)))
     );
   }
   if (color === 'Orange') {
     return (
-      start.isBetween(moment(derailments.Orange.start), moment(derailments.Orange.end)) ||
-      end.isBetween(moment(derailments.Orange.start), moment(derailments.Orange.end))
+      majorEvents.Orange.some(event => start.isBetween(moment(event.start), moment(event.end))) ||
+      majorEvents.Orange.some(event => end.isBetween(moment(event.start), moment(event.end)))
     );
   }
 };
@@ -125,7 +125,7 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
           custom: {
             ...d,
             startDate: d.start.utc().valueOf(),
-            isDuringDerailment: isDuringDerailment(d.start, d.end, d.color),
+            isDuringDerailment: isDuringMajorEvent(d.start, d.end, d.color),
           },
         };
       }),
@@ -168,6 +168,14 @@ export const generateXrangeOptions = (
         {
           point: 'orange-derailment-end',
           text: 'Tracks restored',
+        },
+        {
+          point: 'orange-shutdown-start',
+          text: 'Shutdown',
+        },
+        {
+          point: 'orange-shutdown-end',
+          text: 'Service restored',
         },
       ],
     },
@@ -249,27 +257,34 @@ export const generateXrangeOptions = (
 export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
   const RED_LINE = data.map((day: any) => {
     const y = Number((day.Red / 60).toFixed(2));
-    if (day.date === derailments.Red.start) {
+    if (majorEvents.Red.some(event => day.date === event.start && event.type === 'derailment')) {
       return { id: 'red-derailment-start', y };
     }
-    if (day.date === derailments.Red.end) {
+    if (majorEvents.Red.some(event => day.date === event.end && event.type === 'derailment')) {
       return { id: 'red-derailment-end', y };
     } else {
       return y;
     }
   });
-  const BLUE_LINE = data.map((day: any) => Number((day.Blue / 60).toFixed(2)));
-  const ORANGE_LINE = data.map((day: any) => {
+  const BLUE_LINE = data.map((day: Day) => Number((day.Blue / 60).toFixed(2)));
+  const ORANGE_LINE = data.map((day: Day) => {
     const y = Number((day.Orange / 60).toFixed(2));
-    if (day.date === derailments.Orange.start) {
+    if (majorEvents.Orange.some(event => day.date === event.start && event.type === 'derailment')) {
       return { id: 'orange-derailment-start', y };
     }
-    if (day.date === derailments.Orange.end) {
+    if (majorEvents.Orange.some(event => day.date === event.end && event.type === 'derailment')) {
       return { id: 'orange-derailment-end', y };
+    } 
+    if (majorEvents.Orange.some(event => day.date === event.start && event.type === 'shutdown')) {
+      return { id: 'orange-shutdown-start', y };
+    }
+    if (majorEvents.Orange.some(event => day.date === event.end && event.type === 'shutdown')) {
+      return { id: 'orange-shutdown-end', y };
     } else {
       return y;
     }
   });
+  console.log(ORANGE_LINE)
   return [
     selectedLines.includes('Red') && {
       name: 'Red',
@@ -372,6 +387,14 @@ export const generateLineOptions = (
         {
           point: 'orange-derailment-end',
           text: 'Tracks restored',
+        },
+        {
+          point: 'orange-shutdown-start',
+          text: 'Shutdown',
+        },
+        {
+          point: 'orange-shutdown-end',
+          text: 'Service restored',
         },
       ],
     },

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -125,7 +125,7 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
           custom: {
             ...d,
             startDate: d.start.utc().valueOf(),
-            isDuringDerailment: isDuringMajorEvent(d.start, d.end, d.color),
+            isDuringMajorEvent: isDuringMajorEvent(d.start, d.end, d.color),
           },
         };
       }),
@@ -134,7 +134,7 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
         // @ts-expect-error appears this needs a function
         formatter: function () {
           // @ts-expect-error appears that this is always undefined
-          return this.point.custom.isDuringDerailment
+          return this.point.custom.isDuringMajorEvent
             ? // @ts-expect-error appears that this is always undefined
               `${this.point.custom.delay.toFixed(0)} s ⚠️`
             : // @ts-expect-error appears that this is always undefined

--- a/src/slowzones/types.ts
+++ b/src/slowzones/types.ts
@@ -1,4 +1,4 @@
-import { Moment } from "moment";
+import { Moment } from 'moment';
 
 export interface SlowZone {
   service_date: number;
@@ -21,6 +21,25 @@ export interface SlowZone {
   order: number;
 }
 
-export type Direction = "northbound" | "southbound";
+export interface Day {
+  date: string;
+  Blue: number;
+  Orange: number;
+  Red: number;
+  Green: number;
+}
 
-export type ChartView = "line" | "xrange";
+export type Direction = 'northbound' | 'southbound';
+
+export type ChartView = 'line' | 'xrange';
+
+export type MBTAEventType = 'derailment' | 'shutdown';
+
+export interface MbtaMajorEvent {
+  start: string;
+  end: string;
+  color: string;
+  title: string;
+  description: string;
+  type: MBTAEventType;
+}


### PR DESCRIPTION
<img width="1248" alt="Screen Shot 2022-09-15 at 7 49 19 PM" src="https://user-images.githubusercontent.com/9310513/190527798-34697398-8ddc-4ae3-a749-02ac2ad46366.png">

Marks shutdowns on the chart to make it clear that the slow zones didn't just disappear