### PR TITLE
Slowzone frontend improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "chart.js": "^2.9.4",
         "classnames": "^2.2.6",
         "concurrently": "^7.0.0",
-        "highcharts": "^9.3.3",
+        "highcharts": "^10.2.1",
         "highcharts-react-official": "^3.1.0",
         "lodash.merge": "^4.6.2",
         "moment": "^2.29.4",
@@ -7818,9 +7818,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz",
-      "integrity": "sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.1.tgz",
+      "integrity": "sha512-4QwLQwWc0XdBHXc2Uy6IJisAUir+sgQIMyFqYZc3BD9iFSFUdllLkRyoed6y33aPb73LAMZE2qLB5SuLqFE/fg=="
     },
     "node_modules/highcharts-react-official": {
       "version": "3.1.0",
@@ -20480,9 +20480,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "highcharts": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz",
-      "integrity": "sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.1.tgz",
+      "integrity": "sha512-4QwLQwWc0XdBHXc2Uy6IJisAUir+sgQIMyFqYZc3BD9iFSFUdllLkRyoed6y33aPb73LAMZE2qLB5SuLqFE/fg=="
     },
     "highcharts-react-official": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "chart.js": "^2.9.4",
     "classnames": "^2.2.6",
     "concurrently": "^7.0.0",
-    "highcharts": "^9.3.3",
+    "highcharts": "^10.2.1",
     "highcharts-react-official": "^3.1.0",
     "lodash.merge": "^4.6.2",
     "moment": "^2.29.4",

--- a/src/App.css
+++ b/src/App.css
@@ -634,7 +634,7 @@ button:disabled,
 }
 
 .event-footer-text {
-  align-self: center;
+  align-self: left;
 }
 
 .accordion > li {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const colorsForLine: Record<string, string> = {
 };
 
 export const getDateThreeMonthsAgo = () => {
-  return moment().subtract(3, 'months').startOf('day');
+  return moment.utc().subtract(3, 'months').startOf('day');
 };
 
 export const TODAY_SERVICE_DATE = () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,36 +46,32 @@ export const busDateRange = {
 
 export const stations = stations_json;
 
-export const majorEvents: { Red: MbtaMajorEvent[]; Orange: MbtaMajorEvent[] } = {
-  Red: [
-    {
-      start: '2019-06-11T00:00:00Z',
-      end: '2019-09-21T00:00:00Z',
-      color: 'Red',
-      title: 'Red line derailment',
-      description:
-        'A red line train derailment at JFK/UMass destroyed important signal infrastructure that took months to repair.',
-      type: 'derailment',
-    },
-  ],
-  Orange: [
-    {
-      start: '2021-03-16T00:00:00Z',
-      end: '2021-04-16T00:00:00Z',
-      color: 'Orange',
-      title: 'Orange line derailment',
-      description:
-        'An orange line train derailment damaged a switch, requiring track replacement. A speed restriction followed in order to give the new track time to settle.',
-      type: 'derailment',
-    },
-    {
-      start: '2022-08-19T00:00:00Z',
-      end: '2022-09-19T00:00:00Z',
-      color: 'Orange',
-      title: 'Orange line shutdown',
-      description:
-        'The orange line was shut down for 30 days to complete deferred maintenance',
-      type: 'shutdown',
-    },
-  ],
+export const majorEvents: Record<string, MbtaMajorEvent> = {
+  RedDerailment: {
+    start: '2019-06-11T00:00:00Z',
+    end: '2019-09-21T00:00:00Z',
+    color: 'Red',
+    title: 'Red line derailment',
+    description:
+      'A red line train derailment at JFK/UMass destroyed important signal infrastructure that took months to repair.',
+    type: 'derailment',
+  },
+  OrangeDerailment: {
+    start: '2021-03-16T00:00:00Z',
+    end: '2021-04-16T00:00:00Z',
+    color: 'Orange',
+    title: 'Orange line derailment',
+    description:
+      'An orange line train derailment damaged a switch, requiring track replacement. A speed restriction followed in order to give the new track time to settle.',
+    type: 'derailment',
+  },
+  OrangeShutdown: {
+    start: '2022-08-19T00:00:00Z',
+    end: '2022-09-19T00:00:00Z',
+    color: 'Orange',
+    title: 'Orange line shutdown',
+    description:
+      'The orange line was shut down for 30 days to complete deferred maintenance',
+    type: 'shutdown',
+  },
 };

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -163,7 +163,8 @@ export const SlowZones = () => {
       )}
       {chartView === 'xrange' && (
         <div className="event-footer">
-          <span className="event-footer-text">⚠️ = Affected by a derailment or shutdown</span>
+          <span className="event-footer-text">⚠️ = Caused by a derailment or shutdown</span>
+          <span className="event-footer-text">🚧 = To be fixed by shutdown</span>
         </div>
       )}
 

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -52,18 +52,18 @@ export const SlowZones = () => {
   const [allSlow, setAllSlow] = useState<any>();
   const [startDate, setStartDate] = useState(() => {
     if (params.get('startDate')) {
-      return moment(params.get('startDate'));
+      return moment.utc(params.get('startDate'));
     } else return getDateThreeMonthsAgo();
   });
   const [endDate, setEndDate] = useState(() => {
     if (params.get('endDate')) {
-      return moment(params.get('endDate'));
+      return moment.utc(params.get('endDate'));
     } else return moment();
   });
 
   const setTotalDelaysOptions = (data: any) => {
     const filteredData = data.filter((d: any) => {
-      return moment(d.date).add(5, 'hours').isBetween(startDate, endDate, undefined, '[]');
+      return moment.utc(d.date).isBetween(startDate, endDate, undefined, '[]');
     });
     const options = generateLineOptions(filteredData, selectedLines, startDate);
     setOptions(options);
@@ -142,11 +142,11 @@ export const SlowZones = () => {
         startDate={startDate}
         endDate={endDate}
         setStartDate={(date: any) => {
-          setStartDate(moment(date));
+          setStartDate(moment.utc(date));
           params.set('startDate', date);
         }}
         setEndDate={(date: any) => {
-          setEndDate(moment(date));
+          setEndDate(moment.utc(date));
           params.set('endDate', date);
         }}
         params={params}

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -165,7 +165,7 @@ export const SlowZones = () => {
         <div className="event-footer">
           <span className="event-footer-text">{`${EMOJI.derailment} = Affected by a derailment`}</span>
           <span className="event-footer-text">{`${EMOJI.construction} = To be fixed by shutdown`}</span>
-          <span className="event-footer-text">{`${EMOJI.shutdown} = Began during shutdown`}</span>
+          <span className="event-footer-text">{`${EMOJI.shutdown} = Began after shutdown`}</span>
         </div>
       )}
 

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -6,7 +6,7 @@ import HighchartsReact from 'highcharts-react-official';
 import xrange from 'highcharts/modules/xrange';
 import exporting from 'highcharts/modules/exporting';
 import annotations from 'highcharts/modules/annotations';
-import { formatSlowZones, generateLineOptions, generateXrangeOptions } from './formattingUtils';
+import { formatSlowZones, generateLineOptions, generateXrangeOptions, EMOJI } from './formattingUtils';
 import { goatcount } from '../analytics';
 import { getDateThreeMonthsAgo } from '../constants';
 import { SlowZoneNav } from './SlowZoneNav';
@@ -163,8 +163,9 @@ export const SlowZones = () => {
       )}
       {chartView === 'xrange' && (
         <div className="event-footer">
-          <span className="event-footer-text">⚠️ = Caused by a derailment or shutdown</span>
-          <span className="event-footer-text">🚧 = To be fixed by shutdown</span>
+          <span className="event-footer-text">{`${EMOJI.derailment} = Affected by a derailment`}</span>
+          <span className="event-footer-text">{`${EMOJI.construction} = To be fixed by shutdown`}</span>
+          <span className="event-footer-text">{`${EMOJI.shutdown} = Began during shutdown`}</span>
         </div>
       )}
 

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -65,7 +65,7 @@ export const SlowZones = () => {
     const filteredData = data.filter((d: any) => {
       return moment.utc(d.date).isBetween(startDate, endDate, undefined, '[]');
     });
-    const options = generateLineOptions(filteredData, selectedLines, startDate);
+    const options = generateLineOptions(filteredData, selectedLines, startDate, endDate);
     setOptions(options);
   };
 
@@ -80,7 +80,7 @@ export const SlowZones = () => {
         d.direction === direction
     );
 
-    const options = generateXrangeOptions(filteredData, direction, startDate);
+    const options = generateXrangeOptions(filteredData, direction, startDate, endDate);
     setOptions(options);
   };
 

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -9,21 +9,27 @@ const textSize = isMobile ? '11' : 14;
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
-const isDuringMajorEvent = (start: Moment, end: Moment, color: string) => {
-  if (color === 'Blue') return false;
+const getFootnoteIcon = (start: Moment, end: Moment, color: string) => {
+  if (color === 'Blue') return '';
 
   if (color === 'Red') {
-    return (
-      majorEvents.Red.some(event => start.isBetween(moment(event.start), moment(event.end), undefined, '[]')) ||
-      majorEvents.Red.some(event => end.isBetween(moment(event.start), moment(event.end), undefined, '[]'))
-    );
+    if (majorEvents.Red.some(event => start.isBetween(moment(event.start), moment(event.end), undefined, '[]'))) {
+      return ` ⚠️`;
+    } else {
+      return '';
+    };
   }
   if (color === 'Orange') {
-    return (
-      majorEvents.Orange.some(event => start.isBetween(moment(event.start), moment(event.end), undefined, '[]')) ||
-      majorEvents.Orange.some(event => end.isBetween(moment(event.start), moment(event.end), undefined, '[]'))
-    );
-  }
+    if (majorEvents.Orange.some(event => start.isBetween(moment(event.start), moment(event.end), undefined, '[]'))) {
+      return ` ⚠️`;
+    } else if (majorEvents.Orange.filter(event => event.type === 'shutdown').some(event => 
+        moment(event.start).isBetween(start, end))
+    ) {
+      return ` 🚧`
+    } else {
+      return '';
+    }
+  };
 };
 
 const capitalize = (s: string) => {
@@ -125,7 +131,7 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
           custom: {
             ...d,
             startDate: d.start.utc().valueOf(),
-            isDuringMajorEvent: isDuringMajorEvent(d.start, d.end, d.color),
+            tooltipFootnote: getFootnoteIcon(d.start, d.end, d.color),
           },
         };
       }),
@@ -134,11 +140,7 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
         // @ts-expect-error appears this needs a function
         formatter: function () {
           // @ts-expect-error appears that this is always undefined
-          return this.point.custom.isDuringMajorEvent
-            ? // @ts-expect-error appears that this is always undefined
-              `${this.point.custom.delay.toFixed(0)} s ⚠️`
-            : // @ts-expect-error appears that this is always undefined
-              `${this.point.custom.delay.toFixed(0)} s`;
+          return `${this.point.custom.delay.toFixed(0)} s${this.point.custom.tooltipFootnote}`;
         },
       },
     };
@@ -296,7 +298,6 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
       return y;
     }
   });
-  console.log(ORANGE_LINE)
   return [
     selectedLines.includes('Red') && {
       name: 'Red',

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -14,14 +14,14 @@ const isDuringMajorEvent = (start: Moment, end: Moment, color: string) => {
 
   if (color === 'Red') {
     return (
-      majorEvents.Red.some(event => start.isBetween(moment(event.start), moment(event.end))) ||
-      majorEvents.Red.some(event => end.isBetween(moment(event.start), moment(event.end)))
+      majorEvents.Red.some(event => start.isBetween(moment(event.start), moment(event.end), undefined, '[]')) ||
+      majorEvents.Red.some(event => end.isBetween(moment(event.start), moment(event.end), undefined, '[]'))
     );
   }
   if (color === 'Orange') {
     return (
-      majorEvents.Orange.some(event => start.isBetween(moment(event.start), moment(event.end))) ||
-      majorEvents.Orange.some(event => end.isBetween(moment(event.start), moment(event.end)))
+      majorEvents.Orange.some(event => start.isBetween(moment(event.start), moment(event.end), undefined, '[]')) ||
+      majorEvents.Orange.some(event => end.isBetween(moment(event.start), moment(event.end), undefined, '[]'))
     );
   }
 };

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -334,6 +334,10 @@ export const generateLineOptions = (
         fontSize: textSize,
       },
     },
+    dateTimeLabelFormats: {
+      day: '%e %b',
+      week: '%e %b',
+    },
   },
   yAxis: {
     title: {
@@ -359,7 +363,7 @@ export const generateLineOptions = (
   },
   tooltip: {
     formatter: function (this: any) {
-      return `<div><span style="font-size: 10px">${moment(this.point.x).format(
+      return `<div><span style="font-size: 10px">${moment.utc(this.point.x).format(
         'MMMM Do YYYY'
       )}</span><br/> <span style="color:${this.point.color}">●</span> ${
         this.point.series.name

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -148,7 +148,8 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
 export const generateXrangeOptions = (
   data: SlowZone[],
   direction: Direction,
-  startDate: Moment
+  startDate: Moment,
+  endDate: Moment
 ): any => ({
   annotations: [
     {
@@ -205,6 +206,17 @@ export const generateXrangeOptions = (
         fontSize: textSize,
       },
     },
+    min: startDate.valueOf(),
+    max: endDate.valueOf(),
+    dateTimeLabelFormats: {
+      day: '%e %b',
+      week: '%e %b',
+    },
+    plotLines: [{
+      width: 2,
+      zIndex: 5,
+      value: moment().startOf('day').subtract(28, 'hours').valueOf(),
+    }],
   },
   legend: {
     enabled: false,
@@ -307,7 +319,8 @@ export const groupByLineDailyTotals = (data: any, selectedLines: string[]) => {
 export const generateLineOptions = (
   data: SlowZone[],
   selectedLines: string[],
-  startDate: Moment
+  startDate: Moment,
+  endDate: Moment,
 ): any => ({
   exporting: {
     csv: {
@@ -329,6 +342,8 @@ export const generateLineOptions = (
         fontSize: textSize,
       },
     },
+    min: startDate.valueOf(),
+    max: endDate.valueOf(),
     labels: {
       style: {
         fontSize: textSize,

--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -1,3 +1,4 @@
+import { SeriesOptionsType } from 'highcharts';
 import moment, { Moment } from 'moment';
 import { colorsForLine, majorEvents } from '../constants';
 import { lookup_station_by_id } from '../stations';
@@ -5,7 +6,7 @@ import { Day, Direction, SlowZone } from './types';
 
 const ua = window.navigator.userAgent;
 const isMobile = /Android|webOS|iPhone|iPad|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-const textSize = isMobile ? '11' : 14;
+const textSize = isMobile ? '11' : '14';
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
@@ -124,7 +125,7 @@ export const getRoutes = (data: SlowZone[], direction: Direction) => {
 };
 
 // Xrange options
-export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Direction) => {
+export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Direction): SeriesOptionsType[] => {
   const routes = getRoutes(data, direciton);
   const groupedByLine = groupByLine(data);
   return Object.entries(groupedByLine).map((line) => {
@@ -132,6 +133,7 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
     return {
       name: name,
       color: colorsForLine[line[0]],
+      type: 'xrange',
       data: data.map((d) => {
         return {
           x: d.start.isBefore(startDate) ? startDate.utc().valueOf() : d.start.utc().valueOf(),
@@ -146,7 +148,6 @@ export const generateXrangeSeries = (data: any, startDate: Moment, direciton: Di
       }),
       dataLabels: {
         enabled: true,
-        // @ts-expect-error appears this needs a function
         formatter: function () {
           // @ts-expect-error appears that this is always undefined
           return `${this.point.custom.delay.toFixed(0)} s${this.point.custom.tooltipFootnote}`;
@@ -206,6 +207,7 @@ export const generateXrangeOptions = (
   },
   xAxis: {
     type: 'datetime',
+    top: 40,
     title: {
       text: 'Date',
       style: {
@@ -232,18 +234,17 @@ export const generateXrangeOptions = (
       {
         color: colorsForLine.Orange,
         width: 2,
-        dashStyle: 'dot',
+        dashStyle: 'Dot',
         zIndex: 3,
         value: moment.utc(majorEvents.OrangeShutdown.start).valueOf(),
-        label: 'Orange line shutdown begins'
+        label: { text: 'Orange line shutdown', align: 'left', rotation: 0 }
       },
       {
         color: colorsForLine.Orange,
         width: 2,
-        dashStyle: 'dot',
+        dashStyle: 'Dot',
         zIndex: 3,
         value: moment.utc(majorEvents.OrangeShutdown.end).valueOf(),
-        label: 'Orange line shutdown ends'
       }
     ],
   },

--- a/src/slowzones/types.ts
+++ b/src/slowzones/types.ts
@@ -33,7 +33,7 @@ export type Direction = 'northbound' | 'southbound';
 
 export type ChartView = 'line' | 'xrange';
 
-export type MBTAEventType = 'derailment' | 'shutdown';
+export type MbtaEventType = 'derailment' | 'shutdown';
 
 export interface MbtaMajorEvent {
   start: string;
@@ -41,5 +41,5 @@ export interface MbtaMajorEvent {
   color: string;
   title: string;
   description: string;
-  type: MBTAEventType;
+  type: MbtaEventType;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8498946/193729213-fb7fa833-b0d9-4dee-ad57-816c0b9e00da.png)
 ### Added:
- Vertical line on yesterday's date to help indicate which SZs are current vs fixed recently
- Caution icons to SZs created by the recent shutdown (by closing the range on the date comparison)
- Construction icons to the "shutdown six" slowzones that should have been fixed.

### Also:
- Fixed line-chart bug where data points were not aligned with tick marks due to timezones.
- Fixed gantt bug where min and max didn't actually limit the chart range.