### PR TITLE
Rankings comparison proof-of-concept

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -21,6 +21,21 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "blessed"
 version = "1.19.1"
 description = "Easy, practical library for making terminal apps, by providing an elegant, well-documented interface to Colors, Keyboard input, and screen Positioning capabilities."
@@ -51,7 +66,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.23.53"
+version = "1.23.54"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -67,11 +82,11 @@ crt = ["awscrt (==0.12.5)"]
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "chalice"
@@ -97,7 +112,7 @@ event-file-poller = ["watchdog (==0.9.0)"]
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.11"
+version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -108,20 +123,20 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.3"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -139,8 +154,30 @@ pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
+name = "google"
+version = "3.0.0"
+description = "Python bindings to the Google search engine."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+beautifulsoup4 = "*"
+
+[[package]]
+name = "gtfs-realtime-bindings"
+version = "0.0.7"
+description = "Python classes generated from the GTFS-realtime protocol buffer specification."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+protobuf = "*"
+
+[[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -148,7 +185,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "inquirer"
-version = "2.9.1"
+version = "2.10.0"
 description = "Collection of common interactive command line user interfaces, based on Inquirer.js"
 category = "dev"
 optional = false
@@ -157,11 +194,11 @@ python-versions = ">=3.7"
 [package.dependencies]
 blessed = ">=1.19.0"
 python-editor = ">=1.0.4"
-readchar = ">=2.0.1"
+readchar = ">=3.0.6"
 
 [[package]]
 name = "jinxed"
-version = "1.1.0"
+version = "1.2.0"
 description = "Jinxed Terminal Library"
 category = "dev"
 optional = false
@@ -220,16 +257,36 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
+
+[[package]]
+name = "protobuf"
+version = "3.20.3"
+description = "Protocol Buffers"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "protobuf3-to-dict"
+version = "0.1.5"
+description = "Ben Hodgson: A teeny Python library for creating Python dicts from protocol buffers and the reverse. Useful as an intermediate step before serialisation (e.g. to JSON). Kapor: upgrade it to PB3 and PY3, rename it to protobuf3-to-dict"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+protobuf = ">=2.3.0"
+six = "*"
 
 [[package]]
 name = "pycodestyle"
@@ -238,6 +295,21 @@ description = "Python style guide checker"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pydantic"
+version = "1.10.2"
+description = "Data validation and settings management using python type hints"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pyflakes"
@@ -284,11 +356,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "readchar"
-version = "3.0.5"
-description = "Utilities to read single characters and key-strokes"
+version = "4.0.3"
+description = "Library to easily read single chars and key strokes"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
@@ -310,7 +382,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "s3transfer"
-version = "0.5.1"
+version = "0.5.2"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
 optional = false
@@ -331,16 +403,52 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "underground"
+version = "0.3.0"
+description = "Utilities for NYC's realtime MTA data feeds."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = ">=7.0"
+google = ">=2.0"
+gtfs-realtime-bindings = ">=0.0.6"
+protobuf3-to-dict = ">=0.1.5"
+pydantic = ">=0.31.1"
+pytz = ">=2019.2"
+requests = ">=2.22"
+
+[package.extras]
+dev = ["requests-mock (>=1.7.0)", "codecov (>=2.0)", "pytest-cov (>=2.8)", "black (>=19.10b0)", "tox (>=3.13)", "pytest (>=5.0)"]
+
+[[package]]
 name = "urllib3"
-version = "1.26.8"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -354,7 +462,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "388c8fa59bbed52b71d59fdf048ec05aa6999b052d4cd3a5f79730e5cf897e98"
+content-hash = "3166bc019d2d32bab5bc47041540b0fbd26ef55d0842dee81fd913cbe988458e"
 
 [metadata.files]
 ansicon = [
@@ -365,6 +473,10 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
+]
 blessed = [
     {file = "blessed-1.19.1-py2.py3-none-any.whl", hash = "sha256:63b8554ae2e0e7f43749b6715c734cc8f3883010a809bf16790102563e6cf25b"},
     {file = "blessed-1.19.1.tar.gz", hash = "sha256:9a0d099695bf621d4680dd6c73f6ad547f6a3442fbdbe80c4b1daa1edbc492fc"},
@@ -374,44 +486,51 @@ boto3 = [
     {file = "boto3-1.20.46.tar.gz", hash = "sha256:d7effba509d7298ef49316ba2da7a2ea115f2a7ff691f875f6354666663cf386"},
 ]
 botocore = [
-    {file = "botocore-1.23.53-py3-none-any.whl", hash = "sha256:a97834aee61177e11618348ed8fe1963c37f319af628e6f875f1e0fbd587a9ec"},
-    {file = "botocore-1.23.53.tar.gz", hash = "sha256:7a628bc8bb2573fbc77709c9e7a02061b750f6ebb8e961562de658eda98e140d"},
+    {file = "botocore-1.23.54-py3-none-any.whl", hash = "sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e"},
+    {file = "botocore-1.23.54.tar.gz", hash = "sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb"},
 ]
 certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+    {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
+    {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
 ]
 chalice = [
     {file = "chalice-1.26.6-py3-none-any.whl", hash = "sha256:eeacdbe8979a13420870c3dd1647e2152727ccc8b6a58e53ddab4d1f93ff63c1"},
     {file = "chalice-1.26.6.tar.gz", hash = "sha256:ad89eb648c6ab3976190385ab423d4e790b9d5e8449a5cde47b392d63599ff43"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
-    {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
-    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
+google = [
+    {file = "google-3.0.0-py2.py3-none-any.whl", hash = "sha256:889cf695f84e4ae2c55fbc0cfdaf4c1e729417fa52ab1db0485202ba173e4935"},
+    {file = "google-3.0.0.tar.gz", hash = "sha256:143530122ee5130509ad5e989f0512f7cb218b2d4eddbafbad40fd10e8d8ccbe"},
+]
+gtfs-realtime-bindings = [
+    {file = "gtfs-realtime-bindings-0.0.7.zip", hash = "sha256:8534cee8d2ec9d5bfa5ff1276b5ef3b990412f5f028899098977de67a03a5bed"},
+]
 idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 inquirer = [
-    {file = "inquirer-2.9.1-py3-none-any.whl", hash = "sha256:f50876f5073c8c5fc482b44b8ef4e9720061498abeb352f62b5c94cacf0e43e2"},
-    {file = "inquirer-2.9.1.tar.gz", hash = "sha256:65f0a8eaa8bcabd7ec65771c9f872bb2700753c23bbe8b8ff12efd264a9dbf5d"},
+    {file = "inquirer-2.10.0-py3-none-any.whl", hash = "sha256:e49f6e37132eedda31c860fe36b19726f34f6d45f7d1bfb9bfb87169da0826f8"},
+    {file = "inquirer-2.10.0.tar.gz", hash = "sha256:d6bef9df4d0049fb93ed4e1c1df852e48287331d21e46ed6163b8b2290fc5cb5"},
 ]
 jinxed = [
-    {file = "jinxed-1.1.0-py2.py3-none-any.whl", hash = "sha256:6a61ccf963c16aa885304f27e6e5693783676897cea0c7f223270c8b8e78baf8"},
-    {file = "jinxed-1.1.0.tar.gz", hash = "sha256:d8f1731f134e9e6b04d95095845ae6c10eb15cb223a5f0cabdea87d4a279c305"},
+    {file = "jinxed-1.2.0-py2.py3-none-any.whl", hash = "sha256:cfc2b2e4e3b4326954d546ba6d6b9a7a796ddcb0aef8d03161d005177eb0d48b"},
+    {file = "jinxed-1.2.0.tar.gz", hash = "sha256:032acda92d5c57cd216033cbbd53de731e6ed50deb63eb4781336ca55f72cda5"},
 ]
 jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
@@ -476,9 +595,74 @@ pandas = [
     {file = "pandas-1.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:23c04dab11f3c6359cfa7afa83d3d054a8f8c283d773451184d98119ef54da97"},
     {file = "pandas-1.4.0.tar.gz", hash = "sha256:cdd76254c7f0a1583bd4e4781fb450d0ebf392e10d3f12e92c95575942e37df5"},
 ]
+protobuf = [
+    {file = "protobuf-3.20.3-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:f4bd856d702e5b0d96a00ec6b307b0f51c1982c2bf9c0052cf9019e9a544ba99"},
+    {file = "protobuf-3.20.3-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9aae4406ea63d825636cc11ffb34ad3379335803216ee3a856787bcf5ccc751e"},
+    {file = "protobuf-3.20.3-cp310-cp310-win32.whl", hash = "sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c"},
+    {file = "protobuf-3.20.3-cp310-cp310-win_amd64.whl", hash = "sha256:67a3598f0a2dcbc58d02dd1928544e7d88f764b47d4a286202913f0b2801c2e7"},
+    {file = "protobuf-3.20.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:899dc660cd599d7352d6f10d83c95df430a38b410c1b66b407a6b29265d66469"},
+    {file = "protobuf-3.20.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e64857f395505ebf3d2569935506ae0dfc4a15cb80dc25261176c784662cdcc4"},
+    {file = "protobuf-3.20.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d9e4432ff660d67d775c66ac42a67cf2453c27cb4d738fc22cb53b5d84c135d4"},
+    {file = "protobuf-3.20.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:74480f79a023f90dc6e18febbf7b8bac7508420f2006fabd512013c0c238f454"},
+    {file = "protobuf-3.20.3-cp37-cp37m-win32.whl", hash = "sha256:b6cc7ba72a8850621bfec987cb72623e703b7fe2b9127a161ce61e61558ad905"},
+    {file = "protobuf-3.20.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8c0c984a1b8fef4086329ff8dd19ac77576b384079247c770f29cc8ce3afa06c"},
+    {file = "protobuf-3.20.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:de78575669dddf6099a8a0f46a27e82a1783c557ccc38ee620ed8cc96d3be7d7"},
+    {file = "protobuf-3.20.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f4c42102bc82a51108e449cbb32b19b180022941c727bac0cfd50170341f16ee"},
+    {file = "protobuf-3.20.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:44246bab5dd4b7fbd3c0c80b6f16686808fab0e4aca819ade6e8d294a29c7050"},
+    {file = "protobuf-3.20.3-cp38-cp38-win32.whl", hash = "sha256:c02ce36ec760252242a33967d51c289fd0e1c0e6e5cc9397e2279177716add86"},
+    {file = "protobuf-3.20.3-cp38-cp38-win_amd64.whl", hash = "sha256:447d43819997825d4e71bf5769d869b968ce96848b6479397e29fc24c4a5dfe9"},
+    {file = "protobuf-3.20.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:398a9e0c3eaceb34ec1aee71894ca3299605fa8e761544934378bbc6c97de23b"},
+    {file = "protobuf-3.20.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf01b5720be110540be4286e791db73f84a2b721072a3711efff6c324cdf074b"},
+    {file = "protobuf-3.20.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:daa564862dd0d39c00f8086f88700fdbe8bc717e993a21e90711acfed02f2402"},
+    {file = "protobuf-3.20.3-cp39-cp39-win32.whl", hash = "sha256:819559cafa1a373b7096a482b504ae8a857c89593cf3a25af743ac9ecbd23480"},
+    {file = "protobuf-3.20.3-cp39-cp39-win_amd64.whl", hash = "sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7"},
+    {file = "protobuf-3.20.3-py2.py3-none-any.whl", hash = "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db"},
+    {file = "protobuf-3.20.3.tar.gz", hash = "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"},
+]
+protobuf3-to-dict = [
+    {file = "protobuf3-to-dict-0.1.5.tar.gz", hash = "sha256:1e42c25b5afb5868e3a9b1962811077e492c17557f9c66f0fe40d821375d2b5a"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+pydantic = [
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
+    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
+    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
+    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
+    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
+    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
+    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
+    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
@@ -507,6 +691,13 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -535,24 +726,36 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 readchar = [
-    {file = "readchar-3.0.5-py3-none-any.whl", hash = "sha256:4c31210edfdf3e706d042c58feba2e8b6d5768b7f37002c5579fc473552f8fbb"},
-    {file = "readchar-3.0.5.tar.gz", hash = "sha256:d1f5b71e98c37b7f3b695fba9db978ab84f4f8a0ed879653d83e1d90a4c482c0"},
+    {file = "readchar-4.0.3-py3-none-any.whl", hash = "sha256:3d4351c563aba4ae7d4e0b821a234d48bc748f45b74e3f38b50cba3857b57acb"},
+    {file = "readchar-4.0.3.tar.gz", hash = "sha256:1d920d0e9ab76ec5d42192a68d15af2562663b5dfbf4a67cf9eba520e1ca57e6"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 s3transfer = [
-    {file = "s3transfer-0.5.1-py3-none-any.whl", hash = "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f"},
-    {file = "s3transfer-0.5.1.tar.gz", hash = "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"},
+    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
+    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
+soupsieve = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+underground = [
+    {file = "underground-0.3.0-py3-none-any.whl", hash = "sha256:0af088b7c32bb8bdb050da21ac9bec68c8ccc3233dc35e7443edf2fe870d9219"},
+    {file = "underground-0.3.0.tar.gz", hash = "sha256:4a568589fded967e6cf2e2894418f955ba0ea31afac3660b57c2ab12c99bf8ee"},
+]
 urllib3 = [
-    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
-    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -13,6 +13,8 @@ pytz = "2021.3"
 boto3 = "1.20.46"
 numpy = "1.22.1"
 pandas = "1.4.0"
+underground = "0.3.0"
+protobuf = "3.20.3"
 
 [tool.poetry.dev-dependencies]
 chalice = "1.26.6"

--- a/server/rankings/feed_nrqw.json
+++ b/server/rankings/feed_nrqw.json
@@ -1,0 +1,16238 @@
+{
+  "header": { "gtfs_realtime_version": "1.0", "timestamp": 1665419268 },
+  "entity": [
+    {
+      "id": "000001N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "059735_N..N",
+          "start_time": "09:57:21",
+          "start_date": "20221010",
+          "route_id": "N"
+        }
+      }
+    },
+    {
+      "id": "000002N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "059735_N..N",
+          "start_time": "09:57:21",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 15,
+        "current_status": 1,
+        "timestamp": 1665414213,
+        "stop_id": "R17N"
+      }
+    },
+    {
+      "id": "000003N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "065550_N..S",
+          "start_time": "10:55:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        }
+      }
+    },
+    {
+      "id": "000004N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "065550_N..S",
+          "start_time": "10:55:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 6,
+        "current_status": 1,
+        "timestamp": 1665414688,
+        "stop_id": "R09S"
+      }
+    },
+    {
+      "id": "000005N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "065715_N..N",
+          "start_time": "10:57:09",
+          "start_date": "20221010",
+          "route_id": "N"
+        }
+      }
+    },
+    {
+      "id": "000006N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "065715_N..N",
+          "start_time": "10:57:09",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 28,
+        "current_status": 1,
+        "timestamp": 1665419201,
+        "stop_id": "R01N"
+      }
+    },
+    {
+      "id": "000007N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "062936_N..N",
+          "start_time": "10:29:22",
+          "start_date": "20221010",
+          "route_id": "N"
+        }
+      }
+    },
+    {
+      "id": "000008N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "062936_N..N",
+          "start_time": "10:29:22",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 37,
+        "current_status": 1,
+        "timestamp": 1665418776,
+        "stop_id": "R01N"
+      }
+    },
+    {
+      "id": "000009N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "066900_N..N",
+          "start_time": "11:09:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419241 },
+            "departure": { "time": 1665419241 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665419353 },
+            "departure": { "time": 1665419353 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665419413 },
+            "departure": { "time": 1665419413 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665419533 },
+            "departure": { "time": 1665419533 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000010N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "066900_N..N",
+          "start_time": "11:09:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 25,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R05N"
+      }
+    },
+    {
+      "id": "000011N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "067800_N..N",
+          "start_time": "11:18:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419310 },
+            "departure": { "time": 1665419310 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665419430 },
+            "departure": { "time": 1665419430 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665419580 },
+            "departure": { "time": 1665419580 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665419670 },
+            "departure": { "time": 1665419670 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665419760 },
+            "departure": { "time": 1665419760 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665419880 },
+            "departure": { "time": 1665419880 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665419940 },
+            "departure": { "time": 1665419940 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665420060 },
+            "departure": { "time": 1665420060 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000012N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "067800_N..N",
+          "start_time": "11:18:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 20,
+        "current_status": 1,
+        "timestamp": 1665419238,
+        "stop_id": "R11N"
+      }
+    },
+    {
+      "id": "000013N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "068900_N..S",
+          "start_time": "11:29:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665419528 },
+            "departure": { "time": 1665419528 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665419618 },
+            "departure": { "time": 1665419618 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665419708 },
+            "departure": { "time": 1665419708 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665419948 },
+            "departure": { "time": 1665419948 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665420488 },
+            "departure": { "time": 1665420488 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000014N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "068900_N..S",
+          "start_time": "11:29:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 19,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "N02S"
+      }
+    },
+    {
+      "id": "000015N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "068661_N..N",
+          "start_time": "11:26:37",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665419408 },
+            "departure": { "time": 1665419408 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665419643 },
+            "departure": { "time": 1665419643 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665419918 },
+            "departure": { "time": 1665419918 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665420008 },
+            "departure": { "time": 1665420008 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665420188 },
+            "departure": { "time": 1665420188 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665420308 },
+            "departure": { "time": 1665420308 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000016N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "068661_N..N",
+          "start_time": "11:26:37",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 18,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R14N"
+      }
+    },
+    {
+      "id": "000017N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "069950_N..S",
+          "start_time": "11:39:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419251 },
+            "departure": { "time": 1665419251 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665419431 },
+            "departure": { "time": 1665419431 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665419611 },
+            "departure": { "time": 1665419611 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665419701 },
+            "departure": { "time": 1665419701 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665419821 },
+            "departure": { "time": 1665419821 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665419911 },
+            "departure": { "time": 1665419911 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665420001 },
+            "departure": { "time": 1665420001 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665420091 },
+            "departure": { "time": 1665420091 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665420211 },
+            "departure": { "time": 1665420211 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665420331 },
+            "departure": { "time": 1665420331 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665420511 },
+            "departure": { "time": 1665420511 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665420871 },
+            "departure": { "time": 1665420871 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000018N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "069950_N..S",
+          "start_time": "11:39:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 17,
+        "current_status": 1,
+        "timestamp": 1665419251,
+        "stop_id": "R36S"
+      }
+    },
+    {
+      "id": "000019N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070500_W..S",
+          "start_time": "11:45:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665419338 },
+            "departure": { "time": 1665419338 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665419458 },
+            "departure": { "time": 1665419458 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000020N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070500_W..S",
+          "start_time": "11:45:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 21,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R25S"
+      }
+    },
+    {
+      "id": "000021N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070100_W..N",
+          "start_time": "11:41:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        }
+      }
+    },
+    {
+      "id": "000022N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070100_W..N",
+          "start_time": "11:41:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 12,
+        "current_status": 1,
+        "timestamp": 1665418203,
+        "stop_id": "R15N"
+      }
+    },
+    {
+      "id": "000023N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "069650_N..N",
+          "start_time": "11:36:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665419428 },
+            "departure": { "time": 1665419428 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665419548 },
+            "departure": { "time": 1665419548 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419668 },
+            "departure": { "time": 1665419668 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665419788 },
+            "departure": { "time": 1665419788 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419938 },
+            "departure": { "time": 1665419938 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665420028 },
+            "departure": { "time": 1665420028 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665420183 },
+            "departure": { "time": 1665420183 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420298 },
+            "departure": { "time": 1665420298 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665420448 },
+            "departure": { "time": 1665420448 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665420538 },
+            "departure": { "time": 1665420538 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665420628 },
+            "departure": { "time": 1665420628 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665420748 },
+            "departure": { "time": 1665420748 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665420808 },
+            "departure": { "time": 1665420808 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665420928 },
+            "departure": { "time": 1665420928 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000024N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "069650_N..N",
+          "start_time": "11:36:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 14,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R20N"
+      }
+    },
+    {
+      "id": "000025N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071000_N..S",
+          "start_time": "11:50:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419681 },
+            "departure": { "time": 1665419681 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665420041 },
+            "departure": { "time": 1665420041 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665420251 },
+            "departure": { "time": 1665420251 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665420431 },
+            "departure": { "time": 1665420431 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665420521 },
+            "departure": { "time": 1665420521 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665420641 },
+            "departure": { "time": 1665420641 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665420731 },
+            "departure": { "time": 1665420731 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665420821 },
+            "departure": { "time": 1665420821 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665420911 },
+            "departure": { "time": 1665420911 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665421031 },
+            "departure": { "time": 1665421031 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665421151 },
+            "departure": { "time": 1665421151 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665421331 },
+            "departure": { "time": 1665421331 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665421691 },
+            "departure": { "time": 1665421691 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000026N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071000_N..S",
+          "start_time": "11:50:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 15,
+        "current_status": 1,
+        "timestamp": 1665419148,
+        "stop_id": "Q01S"
+      }
+    },
+    {
+      "id": "000027N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070601_N..N",
+          "start_time": "11:46:01",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419250 },
+            "departure": { "time": 1665419250 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665419490 },
+            "departure": { "time": 1665419490 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665419670 },
+            "departure": { "time": 1665419670 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665420030 },
+            "departure": { "time": 1665420030 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665420180 },
+            "departure": { "time": 1665420180 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665420270 },
+            "departure": { "time": 1665420270 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420540 },
+            "departure": { "time": 1665420540 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665420870 },
+            "departure": { "time": 1665420870 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665420990 },
+            "departure": { "time": 1665420990 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000028N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070601_N..N",
+          "start_time": "11:46:01",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 13,
+        "current_status": 1,
+        "timestamp": 1665419250,
+        "stop_id": "Q01N"
+      }
+    },
+    {
+      "id": "000029N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071500_W..S",
+          "start_time": "11:55:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419246 },
+            "departure": { "time": 1665419246 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665419331 },
+            "departure": { "time": 1665419331 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665419481 },
+            "departure": { "time": 1665419481 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665419616 },
+            "departure": { "time": 1665419616 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665419811 },
+            "departure": { "time": 1665419811 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665419931 },
+            "departure": { "time": 1665419931 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665420021 },
+            "departure": { "time": 1665420021 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665420141 },
+            "departure": { "time": 1665420141 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000030N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071500_W..S",
+          "start_time": "11:55:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 16,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R20S"
+      }
+    },
+    {
+      "id": "000031N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071700_W..N",
+          "start_time": "11:57:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665419493 },
+            "departure": { "time": 1665419493 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665419738 },
+            "departure": { "time": 1665419738 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665419918 },
+            "departure": { "time": 1665419918 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665420038 },
+            "departure": { "time": 1665420038 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665420098 },
+            "departure": { "time": 1665420098 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665420218 },
+            "departure": { "time": 1665420218 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000032N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071700_W..N",
+          "start_time": "11:57:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 14,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R13N"
+      }
+    },
+    {
+      "id": "000033N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071950_N..S",
+          "start_time": "11:59:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419248 },
+            "departure": { "time": 1665419248 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665419488 },
+            "departure": { "time": 1665419488 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665420148 },
+            "departure": { "time": 1665420148 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665420508 },
+            "departure": { "time": 1665420508 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665420718 },
+            "departure": { "time": 1665420718 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665420898 },
+            "departure": { "time": 1665420898 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665420988 },
+            "departure": { "time": 1665420988 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665421108 },
+            "departure": { "time": 1665421108 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665421198 },
+            "departure": { "time": 1665421198 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665421288 },
+            "departure": { "time": 1665421288 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665421378 },
+            "departure": { "time": 1665421378 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665421498 },
+            "departure": { "time": 1665421498 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665421618 },
+            "departure": { "time": 1665421618 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665421798 },
+            "departure": { "time": 1665421798 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665422158 },
+            "departure": { "time": 1665422158 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000034N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071950_N..S",
+          "start_time": "11:59:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 14,
+        "current_status": 1,
+        "timestamp": 1665419248,
+        "stop_id": "R20S"
+      }
+    },
+    {
+      "id": "000035N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072041_N..N",
+          "start_time": "12:00:25",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419443 },
+            "departure": { "time": 1665419443 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665420103 },
+            "departure": { "time": 1665420103 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665420343 },
+            "departure": { "time": 1665420343 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420523 },
+            "departure": { "time": 1665420523 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420643 },
+            "departure": { "time": 1665420643 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665420763 },
+            "departure": { "time": 1665420763 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665420883 },
+            "departure": { "time": 1665420883 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421033 },
+            "departure": { "time": 1665421033 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665421123 },
+            "departure": { "time": 1665421123 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665421383 },
+            "departure": { "time": 1665421383 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665421393 },
+            "departure": { "time": 1665421393 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665421543 },
+            "departure": { "time": 1665421543 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665421633 },
+            "departure": { "time": 1665421633 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665421723 },
+            "departure": { "time": 1665421723 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665421843 },
+            "departure": { "time": 1665421843 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665421903 },
+            "departure": { "time": 1665421903 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665422023 },
+            "departure": { "time": 1665422023 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000036N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072041_N..N",
+          "start_time": "12:00:25",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 11,
+        "current_status": 1,
+        "timestamp": 1665419223,
+        "stop_id": "R36N"
+      }
+    },
+    {
+      "id": "000037N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072808_N..S",
+          "start_time": "12:08:05",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419246 },
+            "departure": { "time": 1665419246 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665419528 },
+            "departure": { "time": 1665419528 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665419648 },
+            "departure": { "time": 1665419648 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420038 },
+            "departure": { "time": 1665420038 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665420698 },
+            "departure": { "time": 1665420698 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665421058 },
+            "departure": { "time": 1665421058 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665421268 },
+            "departure": { "time": 1665421268 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665421448 },
+            "departure": { "time": 1665421448 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665421538 },
+            "departure": { "time": 1665421538 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665421658 },
+            "departure": { "time": 1665421658 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665421748 },
+            "departure": { "time": 1665421748 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665421838 },
+            "departure": { "time": 1665421838 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665421928 },
+            "departure": { "time": 1665421928 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665422048 },
+            "departure": { "time": 1665422048 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665422168 },
+            "departure": { "time": 1665422168 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665422348 },
+            "departure": { "time": 1665422348 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665422708 },
+            "departure": { "time": 1665422708 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000038N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072808_N..S",
+          "start_time": "12:08:05",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 9,
+        "current_status": 1,
+        "timestamp": 1665419246,
+        "stop_id": "R13S"
+      }
+    },
+    {
+      "id": "000039N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072816_N..N",
+          "start_time": "12:08:10",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665419918 },
+            "departure": { "time": 1665419918 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665420578 },
+            "departure": { "time": 1665420578 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665420818 },
+            "departure": { "time": 1665420818 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420998 },
+            "departure": { "time": 1665420998 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665421118 },
+            "departure": { "time": 1665421118 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665421238 },
+            "departure": { "time": 1665421238 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665421358 },
+            "departure": { "time": 1665421358 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421508 },
+            "departure": { "time": 1665421508 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665421598 },
+            "departure": { "time": 1665421598 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665421863 },
+            "departure": { "time": 1665421863 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665421868 },
+            "departure": { "time": 1665421868 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665422018 },
+            "departure": { "time": 1665422018 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665422108 },
+            "departure": { "time": 1665422108 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665422198 },
+            "departure": { "time": 1665422198 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665422318 },
+            "departure": { "time": 1665422318 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665422378 },
+            "departure": { "time": 1665422378 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665422498 },
+            "departure": { "time": 1665422498 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000040N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072816_N..N",
+          "start_time": "12:08:10",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 9,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "N02N"
+      }
+    },
+    {
+      "id": "000041N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073200_W..S",
+          "start_time": "12:12:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665419468 },
+            "departure": { "time": 1665419468 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665419858 },
+            "departure": { "time": 1665419858 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665419948 },
+            "departure": { "time": 1665419948 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665420038 },
+            "departure": { "time": 1665420038 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665420278 },
+            "departure": { "time": 1665420278 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665420413 },
+            "departure": { "time": 1665420413 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665420608 },
+            "departure": { "time": 1665420608 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665420728 },
+            "departure": { "time": 1665420728 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665420818 },
+            "departure": { "time": 1665420818 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665420938 },
+            "departure": { "time": 1665420938 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000042N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073200_W..S",
+          "start_time": "12:12:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 8,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R11S"
+      }
+    },
+    {
+      "id": "000043N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073200_W..N",
+          "start_time": "12:12:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665419326 },
+            "departure": { "time": 1665419326 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419446 },
+            "departure": { "time": 1665419446 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665419566 },
+            "departure": { "time": 1665419566 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419716 },
+            "departure": { "time": 1665419716 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665419806 },
+            "departure": { "time": 1665419806 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665420003 },
+            "departure": { "time": 1665420003 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420076 },
+            "departure": { "time": 1665420076 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665420226 },
+            "departure": { "time": 1665420226 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665420316 },
+            "departure": { "time": 1665420316 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665420406 },
+            "departure": { "time": 1665420406 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665420526 },
+            "departure": { "time": 1665420526 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665420586 },
+            "departure": { "time": 1665420586 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665420706 },
+            "departure": { "time": 1665420706 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000044N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073200_W..N",
+          "start_time": "12:12:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 10,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R17N"
+      }
+    },
+    {
+      "id": "000045N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073750_N..S",
+          "start_time": "12:17:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665419400 },
+            "departure": { "time": 1665419400 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665419550 },
+            "departure": { "time": 1665419550 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665419640 },
+            "departure": { "time": 1665419640 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420000 },
+            "departure": { "time": 1665420000 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420120 },
+            "departure": { "time": 1665420120 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420270 },
+            "departure": { "time": 1665420270 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665421920 },
+            "departure": { "time": 1665421920 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000046N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073750_N..S",
+          "start_time": "12:17:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 5,
+        "current_status": 1,
+        "timestamp": 1665419226,
+        "stop_id": "R08S"
+      }
+    },
+    {
+      "id": "000047N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073756_N..N",
+          "start_time": "12:17:34",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665419408 },
+            "departure": { "time": 1665419408 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665419558 },
+            "departure": { "time": 1665419558 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665419648 },
+            "departure": { "time": 1665419648 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665420098 },
+            "departure": { "time": 1665420098 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665420428 },
+            "departure": { "time": 1665420428 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665421088 },
+            "departure": { "time": 1665421088 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665421328 },
+            "departure": { "time": 1665421328 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665421508 },
+            "departure": { "time": 1665421508 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665421628 },
+            "departure": { "time": 1665421628 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665421748 },
+            "departure": { "time": 1665421748 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665421868 },
+            "departure": { "time": 1665421868 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665422018 },
+            "departure": { "time": 1665422018 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665422108 },
+            "departure": { "time": 1665422108 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665422283 },
+            "departure": { "time": 1665422283 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665422378 },
+            "departure": { "time": 1665422378 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665422528 },
+            "departure": { "time": 1665422528 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665422618 },
+            "departure": { "time": 1665422618 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665422708 },
+            "departure": { "time": 1665422708 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665422828 },
+            "departure": { "time": 1665422828 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665422888 },
+            "departure": { "time": 1665422888 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665423008 },
+            "departure": { "time": 1665423008 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000048N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073756_N..N",
+          "start_time": "12:17:34",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 5,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "N06N"
+      }
+    },
+    {
+      "id": "000049N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074100_W..S",
+          "start_time": "12:21:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665419403 },
+            "departure": { "time": 1665419403 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665419523 },
+            "departure": { "time": 1665419523 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665419673 },
+            "departure": { "time": 1665419673 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665419763 },
+            "departure": { "time": 1665419763 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665419913 },
+            "departure": { "time": 1665419913 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420033 },
+            "departure": { "time": 1665420033 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420123 },
+            "departure": { "time": 1665420123 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420243 },
+            "departure": { "time": 1665420243 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420303 },
+            "departure": { "time": 1665420303 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665420393 },
+            "departure": { "time": 1665420393 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665420483 },
+            "departure": { "time": 1665420483 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420573 },
+            "departure": { "time": 1665420573 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665420723 },
+            "departure": { "time": 1665420723 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665420858 },
+            "departure": { "time": 1665420858 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665421053 },
+            "departure": { "time": 1665421053 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665421173 },
+            "departure": { "time": 1665421173 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665421263 },
+            "departure": { "time": 1665421263 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665421383 },
+            "departure": { "time": 1665421383 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000050N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074100_W..S",
+          "start_time": "12:21:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 5,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R08S"
+      }
+    },
+    {
+      "id": "000051N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074200_W..N",
+          "start_time": "12:22:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665419408 },
+            "departure": { "time": 1665419408 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665419558 },
+            "departure": { "time": 1665419558 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665419648 },
+            "departure": { "time": 1665419648 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665419738 },
+            "departure": { "time": 1665419738 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665419888 },
+            "departure": { "time": 1665419888 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420008 },
+            "departure": { "time": 1665420008 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665420248 },
+            "departure": { "time": 1665420248 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665420398 },
+            "departure": { "time": 1665420398 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665420488 },
+            "departure": { "time": 1665420488 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665420723 },
+            "departure": { "time": 1665420723 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420758 },
+            "departure": { "time": 1665420758 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665420908 },
+            "departure": { "time": 1665420908 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665420998 },
+            "departure": { "time": 1665420998 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665421088 },
+            "departure": { "time": 1665421088 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665421208 },
+            "departure": { "time": 1665421208 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665421268 },
+            "departure": { "time": 1665421268 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665421388 },
+            "departure": { "time": 1665421388 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000052N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074200_W..N",
+          "start_time": "12:22:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "current_stop_sequence": 3,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R24N"
+      }
+    },
+    {
+      "id": "000053N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075000_N..N",
+          "start_time": "12:30:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419400 },
+            "departure": { "time": 1665419400 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665419700 },
+            "departure": { "time": 1665419700 },
+            "stop_id": "N10N"
+          },
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "N09N"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "N08N"
+          },
+          {
+            "arrival": { "time": 1665420030 },
+            "departure": { "time": 1665420030 },
+            "stop_id": "N07N"
+          },
+          {
+            "arrival": { "time": 1665420120 },
+            "departure": { "time": 1665420120 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665420300 },
+            "departure": { "time": 1665420300 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665420450 },
+            "departure": { "time": 1665420450 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665420540 },
+            "departure": { "time": 1665420540 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665420720 },
+            "departure": { "time": 1665420720 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665420990 },
+            "departure": { "time": 1665420990 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665423150 },
+            "departure": { "time": 1665423150 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665423270 },
+            "departure": { "time": 1665423270 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000054N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075000_N..N",
+          "start_time": "12:30:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665419400,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000055N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075050_W..S",
+          "start_time": "12:30:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419430 },
+            "departure": { "time": 1665419430 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665419550 },
+            "departure": { "time": 1665419550 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665419610 },
+            "departure": { "time": 1665419610 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665419730 },
+            "departure": { "time": 1665419730 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665419820 },
+            "departure": { "time": 1665419820 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665420060 },
+            "departure": { "time": 1665420060 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665420180 },
+            "departure": { "time": 1665420180 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665420570 },
+            "departure": { "time": 1665420570 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420900 },
+            "departure": { "time": 1665420900 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420960 },
+            "departure": { "time": 1665420960 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665421140 },
+            "departure": { "time": 1665421140 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665421380 },
+            "departure": { "time": 1665421380 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665421515 },
+            "departure": { "time": 1665421515 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665421920 },
+            "departure": { "time": 1665421920 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665422040 },
+            "departure": { "time": 1665422040 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000056N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075050_W..S",
+          "start_time": "12:30:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665419430,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000057N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075200_W..S",
+          "start_time": "12:32:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419520 },
+            "departure": { "time": 1665419520 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665419770 },
+            "departure": { "time": 1665419770 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665419890 },
+            "departure": { "time": 1665419890 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665420010 },
+            "departure": { "time": 1665420010 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665420260 },
+            "departure": { "time": 1665420260 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420375 },
+            "departure": { "time": 1665420375 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420465 },
+            "departure": { "time": 1665420465 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420555 },
+            "departure": { "time": 1665420555 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420636 },
+            "departure": { "time": 1665420636 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665420708 },
+            "departure": { "time": 1665420708 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665420792 },
+            "departure": { "time": 1665420792 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420870 },
+            "departure": { "time": 1665420870 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665420966 },
+            "departure": { "time": 1665420966 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665421312 },
+            "departure": { "time": 1665421312 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665421408 },
+            "departure": { "time": 1665421408 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665421510 },
+            "departure": { "time": 1665421510 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000058N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075200_W..S",
+          "start_time": "12:32:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665419520,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000059N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075250_W..N",
+          "start_time": "12:32:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419550 },
+            "departure": { "time": 1665419550 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665419670 },
+            "departure": { "time": 1665419670 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665419730 },
+            "departure": { "time": 1665419730 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665419850 },
+            "departure": { "time": 1665419850 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665420000 },
+            "departure": { "time": 1665420000 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665420090 },
+            "departure": { "time": 1665420090 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665420240 },
+            "departure": { "time": 1665420240 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665420570 },
+            "departure": { "time": 1665420570 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421080 },
+            "departure": { "time": 1665421080 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665421440 },
+            "departure": { "time": 1665421440 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665421680 },
+            "departure": { "time": 1665421680 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665422070 },
+            "departure": { "time": 1665422070 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000060N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075250_W..N",
+          "start_time": "12:32:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665419550,
+        "stop_id": "R27N"
+      }
+    },
+    {
+      "id": "000061N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074581_N..S",
+          "start_time": "12:25:49",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419251 },
+            "departure": { "time": 1665419251 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665419341 },
+            "departure": { "time": 1665419341 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665419431 },
+            "departure": { "time": 1665419431 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665419521 },
+            "departure": { "time": 1665419521 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665419671 },
+            "departure": { "time": 1665419671 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665419823 },
+            "departure": { "time": 1665419823 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665419941 },
+            "departure": { "time": 1665419941 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665420031 },
+            "departure": { "time": 1665420031 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665420181 },
+            "departure": { "time": 1665420181 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420301 },
+            "departure": { "time": 1665420301 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420391 },
+            "departure": { "time": 1665420391 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420511 },
+            "departure": { "time": 1665420511 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420661 },
+            "departure": { "time": 1665420661 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420901 },
+            "departure": { "time": 1665420901 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665421561 },
+            "departure": { "time": 1665421561 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665421921 },
+            "departure": { "time": 1665421921 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665422131 },
+            "departure": { "time": 1665422131 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665422311 },
+            "departure": { "time": 1665422311 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665422401 },
+            "departure": { "time": 1665422401 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665422521 },
+            "departure": { "time": 1665422521 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665422611 },
+            "departure": { "time": 1665422611 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665422701 },
+            "departure": { "time": 1665422701 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665422791 },
+            "departure": { "time": 1665422791 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665422911 },
+            "departure": { "time": 1665422911 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665423031 },
+            "departure": { "time": 1665423031 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665423211 },
+            "departure": { "time": 1665423211 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665423571 },
+            "departure": { "time": 1665423571 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000062N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074581_N..S",
+          "start_time": "12:25:49",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "current_stop_sequence": 2,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R04S"
+      }
+    },
+    {
+      "id": "000063N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075550_N..S",
+          "start_time": "12:35:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419730 },
+            "departure": { "time": 1665419730 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665419850 },
+            "departure": { "time": 1665419850 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665420030 },
+            "departure": { "time": 1665420030 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665420120 },
+            "departure": { "time": 1665420120 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665420360 },
+            "departure": { "time": 1665420360 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665420480 },
+            "departure": { "time": 1665420480 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665420720 },
+            "departure": { "time": 1665420720 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665420870 },
+            "departure": { "time": 1665420870 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420990 },
+            "departure": { "time": 1665420990 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665421080 },
+            "departure": { "time": 1665421080 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665423390 },
+            "departure": { "time": 1665423390 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000064N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075550_N..S",
+          "start_time": "12:35:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665419730,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000065N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076200_N..N",
+          "start_time": "12:42:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420120 },
+            "departure": { "time": 1665420120 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "N10N"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "N09N"
+          },
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "N08N"
+          },
+          {
+            "arrival": { "time": 1665420750 },
+            "departure": { "time": 1665420750 },
+            "stop_id": "N07N"
+          },
+          {
+            "arrival": { "time": 1665420840 },
+            "departure": { "time": 1665420840 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665421440 },
+            "departure": { "time": 1665421440 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665422040 },
+            "departure": { "time": 1665422040 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423120 },
+            "departure": { "time": 1665423120 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665423870 },
+            "departure": { "time": 1665423870 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665424140 },
+            "departure": { "time": 1665424140 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000066N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076200_N..N",
+          "start_time": "12:42:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665420120,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000067N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076050_W..S",
+          "start_time": "12:40:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420030 },
+            "departure": { "time": 1665420030 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665420150 },
+            "departure": { "time": 1665420150 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665420660 },
+            "departure": { "time": 1665420660 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421290 },
+            "departure": { "time": 1665421290 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665421380 },
+            "departure": { "time": 1665421380 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665421560 },
+            "departure": { "time": 1665421560 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665422115 },
+            "departure": { "time": 1665422115 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000068N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076050_W..S",
+          "start_time": "12:40:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665420030,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000069N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076200_W..N",
+          "start_time": "12:42:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420120 },
+            "departure": { "time": 1665420120 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665420240 },
+            "departure": { "time": 1665420240 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665420300 },
+            "departure": { "time": 1665420300 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665420570 },
+            "departure": { "time": 1665420570 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665420660 },
+            "departure": { "time": 1665420660 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665420900 },
+            "departure": { "time": 1665420900 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420990 },
+            "departure": { "time": 1665420990 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665421080 },
+            "departure": { "time": 1665421080 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665421140 },
+            "departure": { "time": 1665421140 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665421380 },
+            "departure": { "time": 1665421380 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665422160 },
+            "departure": { "time": 1665422160 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000070N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076200_W..N",
+          "start_time": "12:42:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665420120,
+        "stop_id": "R27N"
+      }
+    },
+    {
+      "id": "000071N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076550_N..S",
+          "start_time": "12:45:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665420450 },
+            "departure": { "time": 1665420450 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665420720 },
+            "departure": { "time": 1665420720 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665420960 },
+            "departure": { "time": 1665420960 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665421080 },
+            "departure": { "time": 1665421080 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665421680 },
+            "departure": { "time": 1665421680 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421800 },
+            "departure": { "time": 1665421800 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000072N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076550_N..S",
+          "start_time": "12:45:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665420330,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000073N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077400_N..N",
+          "start_time": "12:54:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420840 },
+            "departure": { "time": 1665420840 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665421140 },
+            "departure": { "time": 1665421140 },
+            "stop_id": "N10N"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "N09N"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "N08N"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "N07N"
+          },
+          {
+            "arrival": { "time": 1665421560 },
+            "departure": { "time": 1665421560 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665422160 },
+            "departure": { "time": 1665422160 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665425160 },
+            "departure": { "time": 1665425160 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665425220 },
+            "departure": { "time": 1665425220 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665425340 },
+            "departure": { "time": 1665425340 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000074N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077400_N..N",
+          "start_time": "12:54:00",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665420840,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000075N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077050_W..S",
+          "start_time": "12:50:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665420750 },
+            "departure": { "time": 1665420750 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665421380 },
+            "departure": { "time": 1665421380 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422160 },
+            "departure": { "time": 1665422160 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665422715 },
+            "departure": { "time": 1665422715 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665423120 },
+            "departure": { "time": 1665423120 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000076N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077050_W..S",
+          "start_time": "12:50:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665420630,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000077N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077550_N..S",
+          "start_time": "12:55:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665421410 },
+            "departure": { "time": 1665421410 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665421560 },
+            "departure": { "time": 1665421560 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665421680 },
+            "departure": { "time": 1665421680 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665421920 },
+            "departure": { "time": 1665421920 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665422070 },
+            "departure": { "time": 1665422070 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665422280 },
+            "departure": { "time": 1665422280 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422550 },
+            "departure": { "time": 1665422550 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665424020 },
+            "departure": { "time": 1665424020 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665424290 },
+            "departure": { "time": 1665424290 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665424920 },
+            "departure": { "time": 1665424920 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665425460 },
+            "departure": { "time": 1665425460 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000078N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077550_N..S",
+          "start_time": "12:55:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665420930,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000079N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078050_W..S",
+          "start_time": "13:00:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665421410 },
+            "departure": { "time": 1665421410 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665422370 },
+            "departure": { "time": 1665422370 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665423315 },
+            "departure": { "time": 1665423315 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000080N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078050_W..S",
+          "start_time": "13:00:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665421230,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000081N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078200_W..N",
+          "start_time": "13:02:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665421440 },
+            "departure": { "time": 1665421440 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665422280 },
+            "departure": { "time": 1665422280 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000082N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078200_W..N",
+          "start_time": "13:02:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665421320,
+        "stop_id": "R27N"
+      }
+    },
+    {
+      "id": "000083N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078550_N..S",
+          "start_time": "13:05:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665421920 },
+            "departure": { "time": 1665421920 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665422160 },
+            "departure": { "time": 1665422160 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665422280 },
+            "departure": { "time": 1665422280 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665422880 },
+            "departure": { "time": 1665422880 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423150 },
+            "departure": { "time": 1665423150 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423390 },
+            "departure": { "time": 1665423390 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665424890 },
+            "departure": { "time": 1665424890 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665425010 },
+            "departure": { "time": 1665425010 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665425280 },
+            "departure": { "time": 1665425280 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665425400 },
+            "departure": { "time": 1665425400 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665425520 },
+            "departure": { "time": 1665425520 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665426060 },
+            "departure": { "time": 1665426060 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000084N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078550_N..S",
+          "start_time": "13:05:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665421530,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000085N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078650_N..N",
+          "start_time": "13:06:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "N10N"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "N09N"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "N08N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "N07N"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665424170 },
+            "departure": { "time": 1665424170 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665424830 },
+            "departure": { "time": 1665424830 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665425340 },
+            "departure": { "time": 1665425340 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665425460 },
+            "departure": { "time": 1665425460 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665425790 },
+            "departure": { "time": 1665425790 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665425910 },
+            "departure": { "time": 1665425910 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665425970 },
+            "departure": { "time": 1665425970 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665426090 },
+            "departure": { "time": 1665426090 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000086N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078650_N..N",
+          "start_time": "13:06:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665421590,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000087N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079050_W..S",
+          "start_time": "13:10:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665423915 },
+            "departure": { "time": 1665423915 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000088N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079050_W..S",
+          "start_time": "13:10:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665421830,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000089N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079200_W..N",
+          "start_time": "13:12:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421920 },
+            "departure": { "time": 1665421920 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665422040 },
+            "departure": { "time": 1665422040 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665422370 },
+            "departure": { "time": 1665422370 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665422880 },
+            "departure": { "time": 1665422880 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665424140 },
+            "departure": { "time": 1665424140 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000090N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079200_W..N",
+          "start_time": "13:12:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665421920,
+        "stop_id": "R27N"
+      }
+    },
+    {
+      "id": "000091N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079550_N..S",
+          "start_time": "13:15:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665422880 },
+            "departure": { "time": 1665422880 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665423120 },
+            "departure": { "time": 1665423120 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665423270 },
+            "departure": { "time": 1665423270 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423390 },
+            "departure": { "time": 1665423390 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665425010 },
+            "departure": { "time": 1665425010 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665425220 },
+            "departure": { "time": 1665425220 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665425400 },
+            "departure": { "time": 1665425400 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665425490 },
+            "departure": { "time": 1665425490 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665425790 },
+            "departure": { "time": 1665425790 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665425880 },
+            "departure": { "time": 1665425880 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665426000 },
+            "departure": { "time": 1665426000 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665426120 },
+            "departure": { "time": 1665426120 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665426300 },
+            "departure": { "time": 1665426300 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665426660 },
+            "departure": { "time": 1665426660 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000092N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079550_N..S",
+          "start_time": "13:15:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665422130,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000093N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079650_N..N",
+          "start_time": "13:16:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "N10N"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "N09N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "N08N"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "N07N"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665424770 },
+            "departure": { "time": 1665424770 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665425010 },
+            "departure": { "time": 1665425010 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665425310 },
+            "departure": { "time": 1665425310 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665425430 },
+            "departure": { "time": 1665425430 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665425550 },
+            "departure": { "time": 1665425550 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665425790 },
+            "departure": { "time": 1665425790 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665425940 },
+            "departure": { "time": 1665425940 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665426060 },
+            "departure": { "time": 1665426060 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665426210 },
+            "departure": { "time": 1665426210 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665426300 },
+            "departure": { "time": 1665426300 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665426390 },
+            "departure": { "time": 1665426390 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665426510 },
+            "departure": { "time": 1665426510 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665426570 },
+            "departure": { "time": 1665426570 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665426690 },
+            "departure": { "time": 1665426690 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000094N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079650_N..N",
+          "start_time": "13:16:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665422190,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000095N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080050_W..S",
+          "start_time": "13:20:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665422550 },
+            "departure": { "time": 1665422550 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665423570 },
+            "departure": { "time": 1665423570 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665424140 },
+            "departure": { "time": 1665424140 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665424515 },
+            "departure": { "time": 1665424515 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665424830 },
+            "departure": { "time": 1665424830 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665424920 },
+            "departure": { "time": 1665424920 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R27S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000096N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080050_W..S",
+          "start_time": "13:20:30",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665422430,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000097N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080200_W..N",
+          "start_time": "13:22:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423390 },
+            "departure": { "time": 1665423390 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665424140 },
+            "departure": { "time": 1665424140 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665424290 },
+            "departure": { "time": 1665424290 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665424740 },
+            "departure": { "time": 1665424740 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665424920 },
+            "departure": { "time": 1665424920 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000098N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080200_W..N",
+          "start_time": "13:22:00",
+          "start_date": "20221010",
+          "route_id": "W"
+        },
+        "timestamp": 1665422520,
+        "stop_id": "R27N"
+      }
+    },
+    {
+      "id": "000099N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080650_N..N",
+          "start_time": "13:26:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "N10N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "N09N"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "N08N"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "N07N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "N06N"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "N05N"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "N04N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "N03N"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "N02N"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665425370 },
+            "departure": { "time": 1665425370 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665425790 },
+            "departure": { "time": 1665425790 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665425910 },
+            "departure": { "time": 1665425910 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665426030 },
+            "departure": { "time": 1665426030 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665426150 },
+            "departure": { "time": 1665426150 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665426300 },
+            "departure": { "time": 1665426300 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665426390 },
+            "departure": { "time": 1665426390 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665426540 },
+            "departure": { "time": 1665426540 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665426660 },
+            "departure": { "time": 1665426660 },
+            "stop_id": "R09N"
+          },
+          {
+            "arrival": { "time": 1665426810 },
+            "departure": { "time": 1665426810 },
+            "stop_id": "R08N"
+          },
+          {
+            "arrival": { "time": 1665426900 },
+            "departure": { "time": 1665426900 },
+            "stop_id": "R06N"
+          },
+          {
+            "arrival": { "time": 1665426990 },
+            "departure": { "time": 1665426990 },
+            "stop_id": "R05N"
+          },
+          {
+            "arrival": { "time": 1665427110 },
+            "departure": { "time": 1665427110 },
+            "stop_id": "R04N"
+          },
+          {
+            "arrival": { "time": 1665427170 },
+            "departure": { "time": 1665427170 },
+            "stop_id": "R03N"
+          },
+          {
+            "arrival": { "time": 1665427290 },
+            "departure": { "time": 1665427290 },
+            "stop_id": "R01N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000100N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080650_N..N",
+          "start_time": "13:26:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665422790,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000101N",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080550_N..S",
+          "start_time": "13:25:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "R01S"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "R03S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R04S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "R05S"
+          },
+          {
+            "arrival": { "time": 1665423120 },
+            "departure": { "time": 1665423120 },
+            "stop_id": "R06S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R08S"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R09S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665423870 },
+            "departure": { "time": 1665423870 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665425250 },
+            "departure": { "time": 1665425250 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665425820 },
+            "departure": { "time": 1665425820 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665426000 },
+            "departure": { "time": 1665426000 },
+            "stop_id": "N02S"
+          },
+          {
+            "arrival": { "time": 1665426090 },
+            "departure": { "time": 1665426090 },
+            "stop_id": "N03S"
+          },
+          {
+            "arrival": { "time": 1665426210 },
+            "departure": { "time": 1665426210 },
+            "stop_id": "N04S"
+          },
+          {
+            "arrival": { "time": 1665426300 },
+            "departure": { "time": 1665426300 },
+            "stop_id": "N05S"
+          },
+          {
+            "arrival": { "time": 1665426390 },
+            "departure": { "time": 1665426390 },
+            "stop_id": "N06S"
+          },
+          {
+            "arrival": { "time": 1665426480 },
+            "departure": { "time": 1665426480 },
+            "stop_id": "N07S"
+          },
+          {
+            "arrival": { "time": 1665426600 },
+            "departure": { "time": 1665426600 },
+            "stop_id": "N08S"
+          },
+          {
+            "arrival": { "time": 1665426720 },
+            "departure": { "time": 1665426720 },
+            "stop_id": "N09S"
+          },
+          {
+            "arrival": { "time": 1665426900 },
+            "departure": { "time": 1665426900 },
+            "stop_id": "N10S"
+          },
+          {
+            "arrival": { "time": 1665427260 },
+            "departure": { "time": 1665427260 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000102N",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080550_N..S",
+          "start_time": "13:25:30",
+          "start_date": "20221010",
+          "route_id": "N"
+        },
+        "timestamp": 1665422730,
+        "stop_id": "R01S"
+      }
+    },
+    {
+      "id": "000001Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "059678_Q..N",
+          "start_time": "09:56:47",
+          "start_date": "20221010",
+          "route_id": "Q"
+        }
+      }
+    },
+    {
+      "id": "000002Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "059678_Q..N",
+          "start_time": "09:56:47",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 21,
+        "current_status": 1,
+        "timestamp": 1665414281,
+        "stop_id": "R20N"
+      }
+    },
+    {
+      "id": "000003Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "068600_Q..S",
+          "start_time": "11:26:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665419343 },
+            "departure": { "time": 1665419343 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665419583 },
+            "departure": { "time": 1665419583 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665419763 },
+            "departure": { "time": 1665419763 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665419883 },
+            "departure": { "time": 1665419883 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665419973 },
+            "departure": { "time": 1665419973 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000004Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "068600_Q..S",
+          "start_time": "11:26:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 23,
+        "current_status": 1,
+        "timestamp": 1665419228,
+        "stop_id": "D38S"
+      }
+    },
+    {
+      "id": "000005Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "067750_Q..N",
+          "start_time": "11:17:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000006Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "067750_Q..N",
+          "start_time": "11:17:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 27,
+        "current_status": 1,
+        "timestamp": 1665419096,
+        "stop_id": "Q04N"
+      }
+    },
+    {
+      "id": "000007Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "068850_Q..N",
+          "start_time": "11:28:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419498 },
+            "departure": { "time": 1665419498 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665419933 },
+            "departure": { "time": 1665419933 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665420038 },
+            "departure": { "time": 1665420038 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000008Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "068850_Q..N",
+          "start_time": "11:28:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 22,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R17N"
+      }
+    },
+    {
+      "id": "000009Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "069500_Q..N",
+          "start_time": "11:35:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419323 },
+            "departure": { "time": 1665419323 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419503 },
+            "departure": { "time": 1665419503 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419683 },
+            "departure": { "time": 1665419683 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665419803 },
+            "departure": { "time": 1665419803 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665419953 },
+            "departure": { "time": 1665419953 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665420073 },
+            "departure": { "time": 1665420073 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000010Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "069500_Q..N",
+          "start_time": "11:35:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 22,
+        "current_status": 1,
+        "timestamp": 1665419236,
+        "stop_id": "R17N"
+      }
+    },
+    {
+      "id": "000011Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "069535_Q..S",
+          "start_time": "11:35:21",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665419341 },
+            "departure": { "time": 1665419341 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665419491 },
+            "departure": { "time": 1665419491 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665419611 },
+            "departure": { "time": 1665419611 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665419671 },
+            "departure": { "time": 1665419671 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665419791 },
+            "departure": { "time": 1665419791 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665420031 },
+            "departure": { "time": 1665420031 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665420211 },
+            "departure": { "time": 1665420211 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665420331 },
+            "departure": { "time": 1665420331 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665420421 },
+            "departure": { "time": 1665420421 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000012Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "069535_Q..S",
+          "start_time": "11:35:21",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 19,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "D33S"
+      }
+    },
+    {
+      "id": "000013Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070148_Q..S",
+          "start_time": "11:41:29",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665419378 },
+            "departure": { "time": 1665419378 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665419498 },
+            "departure": { "time": 1665419498 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665419648 },
+            "departure": { "time": 1665419648 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665419768 },
+            "departure": { "time": 1665419768 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665419948 },
+            "departure": { "time": 1665419948 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665420188 },
+            "departure": { "time": 1665420188 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665420368 },
+            "departure": { "time": 1665420368 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665420488 },
+            "departure": { "time": 1665420488 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665420578 },
+            "departure": { "time": 1665420578 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000014Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070148_Q..S",
+          "start_time": "11:41:29",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 17,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "D31S"
+      }
+    },
+    {
+      "id": "000015Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070150_Q..N",
+          "start_time": "11:41:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665419388 },
+            "departure": { "time": 1665419388 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665419568 },
+            "departure": { "time": 1665419568 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665419658 },
+            "departure": { "time": 1665419658 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419838 },
+            "departure": { "time": 1665419838 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665420018 },
+            "departure": { "time": 1665420018 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665420138 },
+            "departure": { "time": 1665420138 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665420273 },
+            "departure": { "time": 1665420273 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665420378 },
+            "departure": { "time": 1665420378 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000016Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070150_Q..N",
+          "start_time": "11:41:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 20,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "Q01N"
+      }
+    },
+    {
+      "id": "000017Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071350_Q..N",
+          "start_time": "11:53:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665419655 },
+            "departure": { "time": 1665419655 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665419895 },
+            "departure": { "time": 1665419895 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420075 },
+            "departure": { "time": 1665420075 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420165 },
+            "departure": { "time": 1665420165 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665420345 },
+            "departure": { "time": 1665420345 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665420525 },
+            "departure": { "time": 1665420525 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665420645 },
+            "departure": { "time": 1665420645 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665420885 },
+            "departure": { "time": 1665420885 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000018Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071350_Q..N",
+          "start_time": "11:53:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 19,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R30N"
+      }
+    },
+    {
+      "id": "000019Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070903_Q..S",
+          "start_time": "11:49:02",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419248 },
+            "departure": { "time": 1665419248 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665419343 },
+            "departure": { "time": 1665419343 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665419403 },
+            "departure": { "time": 1665419403 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665419493 },
+            "departure": { "time": 1665419493 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665419583 },
+            "departure": { "time": 1665419583 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665419643 },
+            "departure": { "time": 1665419643 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665419763 },
+            "departure": { "time": 1665419763 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665419913 },
+            "departure": { "time": 1665419913 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665420033 },
+            "departure": { "time": 1665420033 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665420093 },
+            "departure": { "time": 1665420093 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665420213 },
+            "departure": { "time": 1665420213 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665420408 },
+            "departure": { "time": 1665420408 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665420543 },
+            "departure": { "time": 1665420543 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665420663 },
+            "departure": { "time": 1665420663 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665420753 },
+            "departure": { "time": 1665420753 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000020Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070903_Q..S",
+          "start_time": "11:49:02",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 14,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "D28S"
+      }
+    },
+    {
+      "id": "000021Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071800_Q..S",
+          "start_time": "11:58:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665419708 },
+            "departure": { "time": 1665419708 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665419888 },
+            "departure": { "time": 1665419888 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665419978 },
+            "departure": { "time": 1665419978 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665420038 },
+            "departure": { "time": 1665420038 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665420218 },
+            "departure": { "time": 1665420218 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665420278 },
+            "departure": { "time": 1665420278 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665420398 },
+            "departure": { "time": 1665420398 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665420548 },
+            "departure": { "time": 1665420548 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665420668 },
+            "departure": { "time": 1665420668 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665420728 },
+            "departure": { "time": 1665420728 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665420848 },
+            "departure": { "time": 1665420848 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665421043 },
+            "departure": { "time": 1665421043 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665421178 },
+            "departure": { "time": 1665421178 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665421298 },
+            "departure": { "time": 1665421298 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665421388 },
+            "departure": { "time": 1665421388 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000022Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071800_Q..S",
+          "start_time": "11:58:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 9,
+        "current_status": 1,
+        "timestamp": 1665419203,
+        "stop_id": "R30S"
+      }
+    },
+    {
+      "id": "000023Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072300_Q..N",
+          "start_time": "12:03:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665419948 },
+            "departure": { "time": 1665419948 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665420188 },
+            "departure": { "time": 1665420188 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420368 },
+            "departure": { "time": 1665420368 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420458 },
+            "departure": { "time": 1665420458 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665420638 },
+            "departure": { "time": 1665420638 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665420818 },
+            "departure": { "time": 1665420818 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665420938 },
+            "departure": { "time": 1665420938 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665421073 },
+            "departure": { "time": 1665421073 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665421178 },
+            "departure": { "time": 1665421178 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000024Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072300_Q..N",
+          "start_time": "12:03:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 17,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "D25N"
+      }
+    },
+    {
+      "id": "000025Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072551_Q..S",
+          "start_time": "12:05:31",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665419703 },
+            "departure": { "time": 1665419703 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665419823 },
+            "departure": { "time": 1665419823 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665419943 },
+            "departure": { "time": 1665419943 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665420213 },
+            "departure": { "time": 1665420213 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665420303 },
+            "departure": { "time": 1665420303 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665420393 },
+            "departure": { "time": 1665420393 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665420483 },
+            "departure": { "time": 1665420483 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665420543 },
+            "departure": { "time": 1665420543 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665420633 },
+            "departure": { "time": 1665420633 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665420723 },
+            "departure": { "time": 1665420723 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665420783 },
+            "departure": { "time": 1665420783 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665420903 },
+            "departure": { "time": 1665420903 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665421053 },
+            "departure": { "time": 1665421053 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665421173 },
+            "departure": { "time": 1665421173 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665421233 },
+            "departure": { "time": 1665421233 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665421353 },
+            "departure": { "time": 1665421353 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665421548 },
+            "departure": { "time": 1665421548 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665421683 },
+            "departure": { "time": 1665421683 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665421803 },
+            "departure": { "time": 1665421803 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665421893 },
+            "departure": { "time": 1665421893 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000026Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072551_Q..S",
+          "start_time": "12:05:31",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 8,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "Q01S"
+      }
+    },
+    {
+      "id": "000027Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073350_Q..S",
+          "start_time": "12:13:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665419558 },
+            "departure": { "time": 1665419558 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665420008 },
+            "departure": { "time": 1665420008 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665420248 },
+            "departure": { "time": 1665420248 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665420518 },
+            "departure": { "time": 1665420518 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665420608 },
+            "departure": { "time": 1665420608 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665420698 },
+            "departure": { "time": 1665420698 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665420788 },
+            "departure": { "time": 1665420788 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665420848 },
+            "departure": { "time": 1665420848 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665420938 },
+            "departure": { "time": 1665420938 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665421028 },
+            "departure": { "time": 1665421028 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665421088 },
+            "departure": { "time": 1665421088 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665421208 },
+            "departure": { "time": 1665421208 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665421358 },
+            "departure": { "time": 1665421358 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665421478 },
+            "departure": { "time": 1665421478 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665421538 },
+            "departure": { "time": 1665421538 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665421658 },
+            "departure": { "time": 1665421658 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665421853 },
+            "departure": { "time": 1665421853 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665421988 },
+            "departure": { "time": 1665421988 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665422108 },
+            "departure": { "time": 1665422108 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665422198 },
+            "departure": { "time": 1665422198 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000028Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073350_Q..S",
+          "start_time": "12:13:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 6,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R17S"
+      }
+    },
+    {
+      "id": "000029Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074600_Q..N",
+          "start_time": "12:26:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419250 },
+            "departure": { "time": 1665419250 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665419340 },
+            "departure": { "time": 1665419340 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665419460 },
+            "departure": { "time": 1665419460 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665419610 },
+            "departure": { "time": 1665419610 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665419730 },
+            "departure": { "time": 1665419730 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665420060 },
+            "departure": { "time": 1665420060 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665420180 },
+            "departure": { "time": 1665420180 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665420240 },
+            "departure": { "time": 1665420240 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665420450 },
+            "departure": { "time": 1665420450 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665420480 },
+            "departure": { "time": 1665420480 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665420600 },
+            "departure": { "time": 1665420600 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665420660 },
+            "departure": { "time": 1665420660 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665421290 },
+            "departure": { "time": 1665421290 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665421800 },
+            "departure": { "time": 1665421800 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665422040 },
+            "departure": { "time": 1665422040 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665422925 },
+            "departure": { "time": 1665422925 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000030Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074600_Q..N",
+          "start_time": "12:26:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 1,
+        "current_status": 1,
+        "timestamp": 1665419250,
+        "stop_id": "D42N"
+      }
+    },
+    {
+      "id": "000031Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073150_Q..N",
+          "start_time": "12:11:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665419378 },
+            "departure": { "time": 1665419378 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665419468 },
+            "departure": { "time": 1665419468 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665419618 },
+            "departure": { "time": 1665419618 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665419738 },
+            "departure": { "time": 1665419738 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665419918 },
+            "departure": { "time": 1665419918 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665420188 },
+            "departure": { "time": 1665420188 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665420308 },
+            "departure": { "time": 1665420308 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665420428 },
+            "departure": { "time": 1665420428 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665420938 },
+            "departure": { "time": 1665420938 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665421178 },
+            "departure": { "time": 1665421178 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665421358 },
+            "departure": { "time": 1665421358 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665421448 },
+            "departure": { "time": 1665421448 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665421628 },
+            "departure": { "time": 1665421628 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421808 },
+            "departure": { "time": 1665421808 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665421928 },
+            "departure": { "time": 1665421928 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665422063 },
+            "departure": { "time": 1665422063 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665422168 },
+            "departure": { "time": 1665422168 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000032Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073150_Q..N",
+          "start_time": "12:11:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 8,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "D34N"
+      }
+    },
+    {
+      "id": "000033Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074950_Q..S",
+          "start_time": "12:29:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419370 },
+            "departure": { "time": 1665419370 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665419490 },
+            "departure": { "time": 1665419490 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665419610 },
+            "departure": { "time": 1665419610 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665419730 },
+            "departure": { "time": 1665419730 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420090 },
+            "departure": { "time": 1665420090 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420360 },
+            "departure": { "time": 1665420360 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665421800 },
+            "departure": { "time": 1665421800 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665422040 },
+            "departure": { "time": 1665422040 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665422955 },
+            "departure": { "time": 1665422955 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000034Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074950_Q..S",
+          "start_time": "12:29:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665419370,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000035Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075350_Q..N",
+          "start_time": "12:33:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419610 },
+            "departure": { "time": 1665419610 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665419700 },
+            "departure": { "time": 1665419700 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665420060 },
+            "departure": { "time": 1665420060 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665420180 },
+            "departure": { "time": 1665420180 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665420240 },
+            "departure": { "time": 1665420240 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665420360 },
+            "departure": { "time": 1665420360 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665420900 },
+            "departure": { "time": 1665420900 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665423435 },
+            "departure": { "time": 1665423435 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000036Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075350_Q..N",
+          "start_time": "12:33:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665419610,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000037Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074100_Q..S",
+          "start_time": "12:21:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665419336 },
+            "departure": { "time": 1665419336 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665419516 },
+            "departure": { "time": 1665419516 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665419636 },
+            "departure": { "time": 1665419636 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665419786 },
+            "departure": { "time": 1665419786 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420026 },
+            "departure": { "time": 1665420026 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665420476 },
+            "departure": { "time": 1665420476 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665420596 },
+            "departure": { "time": 1665420596 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665420716 },
+            "departure": { "time": 1665420716 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665420986 },
+            "departure": { "time": 1665420986 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665421076 },
+            "departure": { "time": 1665421076 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665421166 },
+            "departure": { "time": 1665421166 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665421256 },
+            "departure": { "time": 1665421256 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665421316 },
+            "departure": { "time": 1665421316 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665421406 },
+            "departure": { "time": 1665421406 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665421496 },
+            "departure": { "time": 1665421496 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665421556 },
+            "departure": { "time": 1665421556 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665421676 },
+            "departure": { "time": 1665421676 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665421826 },
+            "departure": { "time": 1665421826 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665421946 },
+            "departure": { "time": 1665421946 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665422006 },
+            "departure": { "time": 1665422006 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665422126 },
+            "departure": { "time": 1665422126 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665422321 },
+            "departure": { "time": 1665422321 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665422456 },
+            "departure": { "time": 1665422456 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665422576 },
+            "departure": { "time": 1665422576 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665422666 },
+            "departure": { "time": 1665422666 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000038Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074100_Q..S",
+          "start_time": "12:21:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "current_stop_sequence": 3,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "B08S"
+      }
+    },
+    {
+      "id": "000039Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075750_Q..S",
+          "start_time": "12:37:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419850 },
+            "departure": { "time": 1665419850 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665419970 },
+            "departure": { "time": 1665419970 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665420090 },
+            "departure": { "time": 1665420090 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420630 },
+            "departure": { "time": 1665420630 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420750 },
+            "departure": { "time": 1665420750 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420900 },
+            "departure": { "time": 1665420900 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665422550 },
+            "departure": { "time": 1665422550 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665423555 },
+            "departure": { "time": 1665423555 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000040Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075750_Q..S",
+          "start_time": "12:37:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665419850,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000041Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076350_Q..N",
+          "start_time": "12:43:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665420300 },
+            "departure": { "time": 1665420300 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665420390 },
+            "departure": { "time": 1665420390 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665420660 },
+            "departure": { "time": 1665420660 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665420840 },
+            "departure": { "time": 1665420840 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665420960 },
+            "departure": { "time": 1665420960 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665421290 },
+            "departure": { "time": 1665421290 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665421380 },
+            "departure": { "time": 1665421380 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423270 },
+            "departure": { "time": 1665423270 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665423975 },
+            "departure": { "time": 1665423975 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000042Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076350_Q..N",
+          "start_time": "12:43:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665420210,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000043Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077150_Q..N",
+          "start_time": "12:51:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665420870 },
+            "departure": { "time": 1665420870 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665420990 },
+            "departure": { "time": 1665420990 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665421140 },
+            "departure": { "time": 1665421140 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665421440 },
+            "departure": { "time": 1665421440 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665423570 },
+            "departure": { "time": 1665423570 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665424020 },
+            "departure": { "time": 1665424020 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665424455 },
+            "departure": { "time": 1665424455 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000044Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077150_Q..N",
+          "start_time": "12:51:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665420690,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000045Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076550_Q..S",
+          "start_time": "12:45:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665420450 },
+            "departure": { "time": 1665420450 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665420570 },
+            "departure": { "time": 1665420570 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665420945 },
+            "departure": { "time": 1665420945 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665422280 },
+            "departure": { "time": 1665422280 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665422880 },
+            "departure": { "time": 1665422880 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665423120 },
+            "departure": { "time": 1665423120 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665424125 },
+            "departure": { "time": 1665424125 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665424470 },
+            "departure": { "time": 1665424470 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000046Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076550_Q..S",
+          "start_time": "12:45:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665420330,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000047Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077300_Q..S",
+          "start_time": "12:53:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420780 },
+            "departure": { "time": 1665420780 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665420900 },
+            "departure": { "time": 1665420900 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665421140 },
+            "departure": { "time": 1665421140 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665423150 },
+            "departure": { "time": 1665423150 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665423390 },
+            "departure": { "time": 1665423390 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665424305 },
+            "departure": { "time": 1665424305 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000048Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077300_Q..S",
+          "start_time": "12:53:00",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665420780,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000049Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077950_Q..N",
+          "start_time": "12:59:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421170 },
+            "departure": { "time": 1665421170 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665421800 },
+            "departure": { "time": 1665421800 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665421920 },
+            "departure": { "time": 1665421920 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665422070 },
+            "departure": { "time": 1665422070 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665424935 },
+            "departure": { "time": 1665424935 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000050Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077950_Q..N",
+          "start_time": "12:59:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665421170,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000051Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078150_Q..S",
+          "start_time": "13:01:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421290 },
+            "departure": { "time": 1665421290 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665421410 },
+            "departure": { "time": 1665421410 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422280 },
+            "departure": { "time": 1665422280 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665423570 },
+            "departure": { "time": 1665423570 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665424170 },
+            "departure": { "time": 1665424170 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665424815 },
+            "departure": { "time": 1665424815 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665425070 },
+            "departure": { "time": 1665425070 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665425160 },
+            "departure": { "time": 1665425160 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000052Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078150_Q..S",
+          "start_time": "13:01:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665421290,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000053Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078950_Q..N",
+          "start_time": "13:09:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665422070 },
+            "departure": { "time": 1665422070 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665423270 },
+            "departure": { "time": 1665423270 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665423390 },
+            "departure": { "time": 1665423390 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665424830 },
+            "departure": { "time": 1665424830 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665424920 },
+            "departure": { "time": 1665424920 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665425280 },
+            "departure": { "time": 1665425280 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665425400 },
+            "departure": { "time": 1665425400 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665425535 },
+            "departure": { "time": 1665425535 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665425640 },
+            "departure": { "time": 1665425640 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000054Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078950_Q..N",
+          "start_time": "13:09:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665421770,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000055Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078950_Q..S",
+          "start_time": "13:09:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665424020 },
+            "departure": { "time": 1665424020 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665424290 },
+            "departure": { "time": 1665424290 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665424530 },
+            "departure": { "time": 1665424530 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665424980 },
+            "departure": { "time": 1665424980 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665425160 },
+            "departure": { "time": 1665425160 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665425355 },
+            "departure": { "time": 1665425355 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665425490 },
+            "departure": { "time": 1665425490 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000056Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078950_Q..S",
+          "start_time": "13:09:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665421770,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000057Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079350_Q..N",
+          "start_time": "13:13:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665424020 },
+            "departure": { "time": 1665424020 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665424140 },
+            "departure": { "time": 1665424140 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665424890 },
+            "departure": { "time": 1665424890 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665425070 },
+            "departure": { "time": 1665425070 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665425160 },
+            "departure": { "time": 1665425160 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665425370 },
+            "departure": { "time": 1665425370 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665425580 },
+            "departure": { "time": 1665425580 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665425835 },
+            "departure": { "time": 1665425835 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665425940 },
+            "departure": { "time": 1665425940 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000058Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079350_Q..N",
+          "start_time": "13:13:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665422010,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000059Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079750_Q..S",
+          "start_time": "13:17:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665422370 },
+            "departure": { "time": 1665422370 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423150 },
+            "departure": { "time": 1665423150 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665424890 },
+            "departure": { "time": 1665424890 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665425130 },
+            "departure": { "time": 1665425130 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665425310 },
+            "departure": { "time": 1665425310 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665425460 },
+            "departure": { "time": 1665425460 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665425580 },
+            "departure": { "time": 1665425580 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665425640 },
+            "departure": { "time": 1665425640 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665425760 },
+            "departure": { "time": 1665425760 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665425955 },
+            "departure": { "time": 1665425955 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665426090 },
+            "departure": { "time": 1665426090 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665426210 },
+            "departure": { "time": 1665426210 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665426300 },
+            "departure": { "time": 1665426300 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000060Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079750_Q..S",
+          "start_time": "13:17:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665422250,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000061Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080350_Q..N",
+          "start_time": "13:23:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "D43N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "D42N"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "D41N"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "D40N"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "D39N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "D38N"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "D37N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "D35N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "D34N"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "D33N"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "D32N"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "D31N"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "D30N"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "D29N"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "D28N"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "D27N"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "D26N"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "D25N"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "D24N"
+          },
+          {
+            "arrival": { "time": 1665424740 },
+            "departure": { "time": 1665424740 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665425250 },
+            "departure": { "time": 1665425250 },
+            "stop_id": "Q01N"
+          },
+          {
+            "arrival": { "time": 1665425490 },
+            "departure": { "time": 1665425490 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665425670 },
+            "departure": { "time": 1665425670 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665425760 },
+            "departure": { "time": 1665425760 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665425940 },
+            "departure": { "time": 1665425940 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665426120 },
+            "departure": { "time": 1665426120 },
+            "stop_id": "B08N"
+          },
+          {
+            "arrival": { "time": 1665426240 },
+            "departure": { "time": 1665426240 },
+            "stop_id": "Q03N"
+          },
+          {
+            "arrival": { "time": 1665426375 },
+            "departure": { "time": 1665426375 },
+            "stop_id": "Q04N"
+          },
+          {
+            "arrival": { "time": 1665426480 },
+            "departure": { "time": 1665426480 },
+            "stop_id": "Q05N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000062Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080350_Q..N",
+          "start_time": "13:23:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665422610,
+        "stop_id": "D43N"
+      }
+    },
+    {
+      "id": "000063Q",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080550_Q..S",
+          "start_time": "13:25:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "Q05S"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "Q04S"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "Q03S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "B08S"
+          },
+          {
+            "arrival": { "time": 1665423345 },
+            "departure": { "time": 1665423345 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423870 },
+            "departure": { "time": 1665423870 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665424170 },
+            "departure": { "time": 1665424170 },
+            "stop_id": "Q01S"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "D24S"
+          },
+          {
+            "arrival": { "time": 1665424920 },
+            "departure": { "time": 1665424920 },
+            "stop_id": "D25S"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "D26S"
+          },
+          {
+            "arrival": { "time": 1665425280 },
+            "departure": { "time": 1665425280 },
+            "stop_id": "D27S"
+          },
+          {
+            "arrival": { "time": 1665425370 },
+            "departure": { "time": 1665425370 },
+            "stop_id": "D28S"
+          },
+          {
+            "arrival": { "time": 1665425460 },
+            "departure": { "time": 1665425460 },
+            "stop_id": "D29S"
+          },
+          {
+            "arrival": { "time": 1665425520 },
+            "departure": { "time": 1665425520 },
+            "stop_id": "D30S"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "D31S"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "D32S"
+          },
+          {
+            "arrival": { "time": 1665425760 },
+            "departure": { "time": 1665425760 },
+            "stop_id": "D33S"
+          },
+          {
+            "arrival": { "time": 1665425880 },
+            "departure": { "time": 1665425880 },
+            "stop_id": "D34S"
+          },
+          {
+            "arrival": { "time": 1665426030 },
+            "departure": { "time": 1665426030 },
+            "stop_id": "D35S"
+          },
+          {
+            "arrival": { "time": 1665426150 },
+            "departure": { "time": 1665426150 },
+            "stop_id": "D37S"
+          },
+          {
+            "arrival": { "time": 1665426210 },
+            "departure": { "time": 1665426210 },
+            "stop_id": "D38S"
+          },
+          {
+            "arrival": { "time": 1665426330 },
+            "departure": { "time": 1665426330 },
+            "stop_id": "D39S"
+          },
+          {
+            "arrival": { "time": 1665426525 },
+            "departure": { "time": 1665426525 },
+            "stop_id": "D40S"
+          },
+          {
+            "arrival": { "time": 1665426660 },
+            "departure": { "time": 1665426660 },
+            "stop_id": "D41S"
+          },
+          {
+            "arrival": { "time": 1665426780 },
+            "departure": { "time": 1665426780 },
+            "stop_id": "D42S"
+          },
+          {
+            "arrival": { "time": 1665426870 },
+            "departure": { "time": 1665426870 },
+            "stop_id": "D43S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000064Q",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080550_Q..S",
+          "start_time": "13:25:30",
+          "start_date": "20221010",
+          "route_id": "Q"
+        },
+        "timestamp": 1665422730,
+        "stop_id": "Q05S"
+      }
+    },
+    {
+      "id": "000001R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "065190_R..N",
+          "start_time": "10:51:54",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665419361 },
+            "departure": { "time": 1665419361 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665419451 },
+            "departure": { "time": 1665419451 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665419571 },
+            "departure": { "time": 1665419571 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665419691 },
+            "departure": { "time": 1665419691 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000002R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "065190_R..N",
+          "start_time": "10:51:54",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 42,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "G12N"
+      }
+    },
+    {
+      "id": "000003R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "066280_R..N",
+          "start_time": "11:02:48",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665419371 },
+            "departure": { "time": 1665419371 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665419461 },
+            "departure": { "time": 1665419461 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665419581 },
+            "departure": { "time": 1665419581 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665419671 },
+            "departure": { "time": 1665419671 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665419791 },
+            "departure": { "time": 1665419791 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665419911 },
+            "departure": { "time": 1665419911 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000004R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "066280_R..N",
+          "start_time": "11:02:48",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 40,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "G14N"
+      }
+    },
+    {
+      "id": "000005R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "067250_R..N",
+          "start_time": "11:12:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665419328 },
+            "departure": { "time": 1665419328 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665419448 },
+            "departure": { "time": 1665419448 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665419538 },
+            "departure": { "time": 1665419538 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665419628 },
+            "departure": { "time": 1665419628 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665419733 },
+            "departure": { "time": 1665419733 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665419868 },
+            "departure": { "time": 1665419868 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665419958 },
+            "departure": { "time": 1665419958 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665420078 },
+            "departure": { "time": 1665420078 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665420168 },
+            "departure": { "time": 1665420168 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665420288 },
+            "departure": { "time": 1665420288 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665420408 },
+            "departure": { "time": 1665420408 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000006R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "067250_R..N",
+          "start_time": "11:12:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 35,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "G20N"
+      }
+    },
+    {
+      "id": "000007R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "066650_R..S",
+          "start_time": "11:06:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665419371 },
+            "departure": { "time": 1665419371 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665419506 },
+            "departure": { "time": 1665419506 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000008R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "066650_R..S",
+          "start_time": "11:06:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 44,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R43S"
+      }
+    },
+    {
+      "id": "000009R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "067650_R..S",
+          "start_time": "11:16:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665419708 },
+            "departure": { "time": 1665419708 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665419918 },
+            "departure": { "time": 1665419918 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665420008 },
+            "departure": { "time": 1665420008 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665420158 },
+            "departure": { "time": 1665420158 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665420308 },
+            "departure": { "time": 1665420308 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000010R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "067650_R..S",
+          "start_time": "11:16:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 37,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R34S"
+      }
+    },
+    {
+      "id": "000011R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "068253_R..N",
+          "start_time": "11:22:32",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419340 },
+            "departure": { "time": 1665419340 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665419460 },
+            "departure": { "time": 1665419460 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665419580 },
+            "departure": { "time": 1665419580 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665419700 },
+            "departure": { "time": 1665419700 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665419880 },
+            "departure": { "time": 1665419880 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665419985 },
+            "departure": { "time": 1665419985 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665420120 },
+            "departure": { "time": 1665420120 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665420330 },
+            "departure": { "time": 1665420330 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665420540 },
+            "departure": { "time": 1665420540 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665420660 },
+            "departure": { "time": 1665420660 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000012R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "068253_R..N",
+          "start_time": "11:22:32",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 33,
+        "current_status": 1,
+        "timestamp": 1665419160,
+        "stop_id": "R60N"
+      }
+    },
+    {
+      "id": "000013R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "068650_R..S",
+          "start_time": "11:26:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665419343 },
+            "departure": { "time": 1665419343 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665419463 },
+            "departure": { "time": 1665419463 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665419583 },
+            "departure": { "time": 1665419583 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665419673 },
+            "departure": { "time": 1665419673 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665419763 },
+            "departure": { "time": 1665419763 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665419883 },
+            "departure": { "time": 1665419883 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665420033 },
+            "departure": { "time": 1665420033 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665420153 },
+            "departure": { "time": 1665420153 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665420243 },
+            "departure": { "time": 1665420243 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665420363 },
+            "departure": { "time": 1665420363 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665420453 },
+            "departure": { "time": 1665420453 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665420603 },
+            "departure": { "time": 1665420603 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665420753 },
+            "departure": { "time": 1665420753 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000014R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "068650_R..S",
+          "start_time": "11:26:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 33,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R30S"
+      }
+    },
+    {
+      "id": "000015R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "069181_R..N",
+          "start_time": "11:31:49",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665419883 },
+            "departure": { "time": 1665419883 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420008 },
+            "departure": { "time": 1665420008 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665420128 },
+            "departure": { "time": 1665420128 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665420248 },
+            "departure": { "time": 1665420248 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665420368 },
+            "departure": { "time": 1665420368 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665420458 },
+            "departure": { "time": 1665420458 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665420548 },
+            "departure": { "time": 1665420548 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665420653 },
+            "departure": { "time": 1665420653 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665420788 },
+            "departure": { "time": 1665420788 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665420878 },
+            "departure": { "time": 1665420878 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665420998 },
+            "departure": { "time": 1665420998 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665421088 },
+            "departure": { "time": 1665421088 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665421208 },
+            "departure": { "time": 1665421208 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665421328 },
+            "departure": { "time": 1665421328 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000016R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "069181_R..N",
+          "start_time": "11:31:49",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 28,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R16N"
+      }
+    },
+    {
+      "id": "000017R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "069600_R..S",
+          "start_time": "11:36:00",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419248 },
+            "departure": { "time": 1665419248 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665419428 },
+            "departure": { "time": 1665419428 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665419528 },
+            "departure": { "time": 1665419528 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665419648 },
+            "departure": { "time": 1665419648 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665419768 },
+            "departure": { "time": 1665419768 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665419948 },
+            "departure": { "time": 1665419948 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665420068 },
+            "departure": { "time": 1665420068 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665420188 },
+            "departure": { "time": 1665420188 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665420278 },
+            "departure": { "time": 1665420278 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665420368 },
+            "departure": { "time": 1665420368 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665420488 },
+            "departure": { "time": 1665420488 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665420638 },
+            "departure": { "time": 1665420638 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665420758 },
+            "departure": { "time": 1665420758 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665420848 },
+            "departure": { "time": 1665420848 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665420968 },
+            "departure": { "time": 1665420968 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665421058 },
+            "departure": { "time": 1665421058 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665421208 },
+            "departure": { "time": 1665421208 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665421358 },
+            "departure": { "time": 1665421358 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000018R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "069600_R..S",
+          "start_time": "11:36:00",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 28,
+        "current_status": 1,
+        "timestamp": 1665419248,
+        "stop_id": "R26S"
+      }
+    },
+    {
+      "id": "000019R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070251_R..N",
+          "start_time": "11:42:31",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419243 },
+            "departure": { "time": 1665419243 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665419438 },
+            "departure": { "time": 1665419438 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665419558 },
+            "departure": { "time": 1665419558 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665419828 },
+            "departure": { "time": 1665419828 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665419918 },
+            "departure": { "time": 1665419918 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665420063 },
+            "departure": { "time": 1665420063 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420323 },
+            "departure": { "time": 1665420323 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665420518 },
+            "departure": { "time": 1665420518 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665420638 },
+            "departure": { "time": 1665420638 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665420758 },
+            "departure": { "time": 1665420758 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665420848 },
+            "departure": { "time": 1665420848 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665420938 },
+            "departure": { "time": 1665420938 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665421043 },
+            "departure": { "time": 1665421043 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665421178 },
+            "departure": { "time": 1665421178 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665421268 },
+            "departure": { "time": 1665421268 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665421388 },
+            "departure": { "time": 1665421388 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665421478 },
+            "departure": { "time": 1665421478 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665421598 },
+            "departure": { "time": 1665421598 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665421718 },
+            "departure": { "time": 1665421718 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000020R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070251_R..N",
+          "start_time": "11:42:31",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 26,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R18N"
+      }
+    },
+    {
+      "id": "000021R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "070550_R..S",
+          "start_time": "11:45:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419248 },
+            "departure": { "time": 1665419248 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665419408 },
+            "departure": { "time": 1665419408 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665419558 },
+            "departure": { "time": 1665419558 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665419768 },
+            "departure": { "time": 1665419768 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665419888 },
+            "departure": { "time": 1665419888 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665420028 },
+            "departure": { "time": 1665420028 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665420098 },
+            "departure": { "time": 1665420098 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665420218 },
+            "departure": { "time": 1665420218 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665420338 },
+            "departure": { "time": 1665420338 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665420518 },
+            "departure": { "time": 1665420518 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665420638 },
+            "departure": { "time": 1665420638 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665420758 },
+            "departure": { "time": 1665420758 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665420848 },
+            "departure": { "time": 1665420848 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665420938 },
+            "departure": { "time": 1665420938 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665421058 },
+            "departure": { "time": 1665421058 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665421208 },
+            "departure": { "time": 1665421208 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665421328 },
+            "departure": { "time": 1665421328 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665421418 },
+            "departure": { "time": 1665421418 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665421538 },
+            "departure": { "time": 1665421538 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665421628 },
+            "departure": { "time": 1665421628 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665421763 },
+            "departure": { "time": 1665421763 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665421898 },
+            "departure": { "time": 1665421898 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000022R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "070550_R..S",
+          "start_time": "11:45:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 23,
+        "current_status": 1,
+        "timestamp": 1665419248,
+        "stop_id": "R21S"
+      }
+    },
+    {
+      "id": "000023R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071251_R..N",
+          "start_time": "11:52:31",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665419468 },
+            "departure": { "time": 1665419468 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665419558 },
+            "departure": { "time": 1665419558 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665419708 },
+            "departure": { "time": 1665419708 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665419798 },
+            "departure": { "time": 1665419798 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665419888 },
+            "departure": { "time": 1665419888 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665419978 },
+            "departure": { "time": 1665419978 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665420038 },
+            "departure": { "time": 1665420038 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420158 },
+            "departure": { "time": 1665420158 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665420278 },
+            "departure": { "time": 1665420278 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665420398 },
+            "departure": { "time": 1665420398 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665420548 },
+            "departure": { "time": 1665420548 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665420638 },
+            "departure": { "time": 1665420638 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665420843 },
+            "departure": { "time": 1665420843 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665420983 },
+            "departure": { "time": 1665420983 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665421118 },
+            "departure": { "time": 1665421118 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665421238 },
+            "departure": { "time": 1665421238 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665421358 },
+            "departure": { "time": 1665421358 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665421448 },
+            "departure": { "time": 1665421448 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665421538 },
+            "departure": { "time": 1665421538 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665421643 },
+            "departure": { "time": 1665421643 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665421778 },
+            "departure": { "time": 1665421778 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665421868 },
+            "departure": { "time": 1665421868 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665421988 },
+            "departure": { "time": 1665421988 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665422078 },
+            "departure": { "time": 1665422078 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665422198 },
+            "departure": { "time": 1665422198 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665422318 },
+            "departure": { "time": 1665422318 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000024R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071251_R..N",
+          "start_time": "11:52:31",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 19,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R25N"
+      }
+    },
+    {
+      "id": "000025R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "071665_R..S",
+          "start_time": "11:56:39",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419251 },
+            "departure": { "time": 1665419251 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665419408 },
+            "departure": { "time": 1665419408 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665419528 },
+            "departure": { "time": 1665419528 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665419588 },
+            "departure": { "time": 1665419588 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665419678 },
+            "departure": { "time": 1665419678 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665419768 },
+            "departure": { "time": 1665419768 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665419858 },
+            "departure": { "time": 1665419858 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665420008 },
+            "departure": { "time": 1665420008 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665420098 },
+            "departure": { "time": 1665420098 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665420248 },
+            "departure": { "time": 1665420248 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665420368 },
+            "departure": { "time": 1665420368 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665420458 },
+            "departure": { "time": 1665420458 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665420578 },
+            "departure": { "time": 1665420578 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665420691 },
+            "departure": { "time": 1665420691 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665420788 },
+            "departure": { "time": 1665420788 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665420908 },
+            "departure": { "time": 1665420908 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665421028 },
+            "departure": { "time": 1665421028 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665421208 },
+            "departure": { "time": 1665421208 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665421328 },
+            "departure": { "time": 1665421328 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665421448 },
+            "departure": { "time": 1665421448 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665421538 },
+            "departure": { "time": 1665421538 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665421628 },
+            "departure": { "time": 1665421628 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665421748 },
+            "departure": { "time": 1665421748 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665421898 },
+            "departure": { "time": 1665421898 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665422018 },
+            "departure": { "time": 1665422018 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665422108 },
+            "departure": { "time": 1665422108 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665422228 },
+            "departure": { "time": 1665422228 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665422318 },
+            "departure": { "time": 1665422318 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665422453 },
+            "departure": { "time": 1665422453 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665422588 },
+            "departure": { "time": 1665422588 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000026R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "071665_R..S",
+          "start_time": "11:56:39",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 16,
+        "current_status": 1,
+        "timestamp": 1665419251,
+        "stop_id": "R14S"
+      }
+    },
+    {
+      "id": "000027R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072250_R..N",
+          "start_time": "12:02:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419318 },
+            "departure": { "time": 1665419318 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665419408 },
+            "departure": { "time": 1665419408 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665419528 },
+            "departure": { "time": 1665419528 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665419766 },
+            "departure": { "time": 1665419766 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665419768 },
+            "departure": { "time": 1665419768 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665419888 },
+            "departure": { "time": 1665419888 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665419948 },
+            "departure": { "time": 1665419948 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665420068 },
+            "departure": { "time": 1665420068 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665420218 },
+            "departure": { "time": 1665420218 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665420308 },
+            "departure": { "time": 1665420308 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665420458 },
+            "departure": { "time": 1665420458 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665420548 },
+            "departure": { "time": 1665420548 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665420638 },
+            "departure": { "time": 1665420638 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665420728 },
+            "departure": { "time": 1665420728 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665420788 },
+            "departure": { "time": 1665420788 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665420908 },
+            "departure": { "time": 1665420908 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665421028 },
+            "departure": { "time": 1665421028 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665421148 },
+            "departure": { "time": 1665421148 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421298 },
+            "departure": { "time": 1665421298 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665421388 },
+            "departure": { "time": 1665421388 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665421626 },
+            "departure": { "time": 1665421626 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665421718 },
+            "departure": { "time": 1665421718 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665421838 },
+            "departure": { "time": 1665421838 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665421958 },
+            "departure": { "time": 1665421958 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665422078 },
+            "departure": { "time": 1665422078 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665422168 },
+            "departure": { "time": 1665422168 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665422258 },
+            "departure": { "time": 1665422258 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665422363 },
+            "departure": { "time": 1665422363 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665422498 },
+            "departure": { "time": 1665422498 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665422588 },
+            "departure": { "time": 1665422588 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665422708 },
+            "departure": { "time": 1665422708 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665422798 },
+            "departure": { "time": 1665422798 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665422918 },
+            "departure": { "time": 1665422918 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665423038 },
+            "departure": { "time": 1665423038 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000028R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072250_R..N",
+          "start_time": "12:02:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 12,
+        "current_status": 1,
+        "timestamp": 1665419226,
+        "stop_id": "R31N"
+      }
+    },
+    {
+      "id": "000029R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "072650_R..S",
+          "start_time": "12:06:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665419463 },
+            "departure": { "time": 1665419463 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665419583 },
+            "departure": { "time": 1665419583 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665419673 },
+            "departure": { "time": 1665419673 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665419823 },
+            "departure": { "time": 1665419823 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665419943 },
+            "departure": { "time": 1665419943 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420033 },
+            "departure": { "time": 1665420033 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420153 },
+            "departure": { "time": 1665420153 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420213 },
+            "departure": { "time": 1665420213 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665420303 },
+            "departure": { "time": 1665420303 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665420393 },
+            "departure": { "time": 1665420393 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420483 },
+            "departure": { "time": 1665420483 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665420633 },
+            "departure": { "time": 1665420633 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665420723 },
+            "departure": { "time": 1665420723 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665420873 },
+            "departure": { "time": 1665420873 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665420993 },
+            "departure": { "time": 1665420993 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665421083 },
+            "departure": { "time": 1665421083 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665421203 },
+            "departure": { "time": 1665421203 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665421293 },
+            "departure": { "time": 1665421293 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665421413 },
+            "departure": { "time": 1665421413 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665421533 },
+            "departure": { "time": 1665421533 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665421653 },
+            "departure": { "time": 1665421653 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665421833 },
+            "departure": { "time": 1665421833 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665421953 },
+            "departure": { "time": 1665421953 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665422073 },
+            "departure": { "time": 1665422073 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665422163 },
+            "departure": { "time": 1665422163 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665422253 },
+            "departure": { "time": 1665422253 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665422373 },
+            "departure": { "time": 1665422373 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665422523 },
+            "departure": { "time": 1665422523 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665422643 },
+            "departure": { "time": 1665422643 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665422733 },
+            "departure": { "time": 1665422733 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665422853 },
+            "departure": { "time": 1665422853 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665422943 },
+            "departure": { "time": 1665422943 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665423078 },
+            "departure": { "time": 1665423078 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665423213 },
+            "departure": { "time": 1665423213 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000030R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "072650_R..S",
+          "start_time": "12:06:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 12,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "G21S"
+      }
+    },
+    {
+      "id": "000031R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073251_R..N",
+          "start_time": "12:12:31",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665419356 },
+            "departure": { "time": 1665419356 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665419476 },
+            "departure": { "time": 1665419476 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665419596 },
+            "departure": { "time": 1665419596 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665419776 },
+            "departure": { "time": 1665419776 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665419866 },
+            "departure": { "time": 1665419866 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665419986 },
+            "departure": { "time": 1665419986 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665420153 },
+            "departure": { "time": 1665420153 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665420226 },
+            "departure": { "time": 1665420226 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665420346 },
+            "departure": { "time": 1665420346 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665420406 },
+            "departure": { "time": 1665420406 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665420526 },
+            "departure": { "time": 1665420526 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665420676 },
+            "departure": { "time": 1665420676 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665420766 },
+            "departure": { "time": 1665420766 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665420916 },
+            "departure": { "time": 1665420916 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665421006 },
+            "departure": { "time": 1665421006 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665421096 },
+            "departure": { "time": 1665421096 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665421186 },
+            "departure": { "time": 1665421186 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665421246 },
+            "departure": { "time": 1665421246 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665421366 },
+            "departure": { "time": 1665421366 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665421486 },
+            "departure": { "time": 1665421486 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665421606 },
+            "departure": { "time": 1665421606 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665421756 },
+            "departure": { "time": 1665421756 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665421846 },
+            "departure": { "time": 1665421846 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665422013 },
+            "departure": { "time": 1665422013 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665422251 },
+            "departure": { "time": 1665422251 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665422446 },
+            "departure": { "time": 1665422446 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665422566 },
+            "departure": { "time": 1665422566 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665422686 },
+            "departure": { "time": 1665422686 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665422776 },
+            "departure": { "time": 1665422776 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665422866 },
+            "departure": { "time": 1665422866 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665422971 },
+            "departure": { "time": 1665422971 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665423106 },
+            "departure": { "time": 1665423106 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665423196 },
+            "departure": { "time": 1665423196 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665423316 },
+            "departure": { "time": 1665423316 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665423406 },
+            "departure": { "time": 1665423406 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665423526 },
+            "departure": { "time": 1665423526 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665423646 },
+            "departure": { "time": 1665423646 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000032R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073251_R..N",
+          "start_time": "12:12:31",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 9,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R34N"
+      }
+    },
+    {
+      "id": "000033R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "073600_R..S",
+          "start_time": "12:16:00",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419248 },
+            "departure": { "time": 1665419248 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665419351 },
+            "departure": { "time": 1665419351 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665419471 },
+            "departure": { "time": 1665419471 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665419591 },
+            "departure": { "time": 1665419591 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665419823 },
+            "departure": { "time": 1665419823 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665419951 },
+            "departure": { "time": 1665419951 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665420041 },
+            "departure": { "time": 1665420041 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665420191 },
+            "departure": { "time": 1665420191 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665420311 },
+            "departure": { "time": 1665420311 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665420401 },
+            "departure": { "time": 1665420401 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665420521 },
+            "departure": { "time": 1665420521 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665420581 },
+            "departure": { "time": 1665420581 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665420671 },
+            "departure": { "time": 1665420671 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665420761 },
+            "departure": { "time": 1665420761 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665420851 },
+            "departure": { "time": 1665420851 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665421001 },
+            "departure": { "time": 1665421001 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665421091 },
+            "departure": { "time": 1665421091 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665421241 },
+            "departure": { "time": 1665421241 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665421361 },
+            "departure": { "time": 1665421361 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665421451 },
+            "departure": { "time": 1665421451 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665421571 },
+            "departure": { "time": 1665421571 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665421653 },
+            "departure": { "time": 1665421653 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665421781 },
+            "departure": { "time": 1665421781 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665421901 },
+            "departure": { "time": 1665421901 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665422021 },
+            "departure": { "time": 1665422021 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665422201 },
+            "departure": { "time": 1665422201 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665422321 },
+            "departure": { "time": 1665422321 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665422441 },
+            "departure": { "time": 1665422441 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665422531 },
+            "departure": { "time": 1665422531 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665422621 },
+            "departure": { "time": 1665422621 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665422741 },
+            "departure": { "time": 1665422741 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665422891 },
+            "departure": { "time": 1665422891 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665423011 },
+            "departure": { "time": 1665423011 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665423101 },
+            "departure": { "time": 1665423101 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665423221 },
+            "departure": { "time": 1665423221 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665423311 },
+            "departure": { "time": 1665423311 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665423446 },
+            "departure": { "time": 1665423446 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665423581 },
+            "departure": { "time": 1665423581 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000034R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "073600_R..S",
+          "start_time": "12:16:00",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 9,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "G18S"
+      }
+    },
+    {
+      "id": "000035R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074600_R..S",
+          "start_time": "12:26:00",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665419333 },
+            "departure": { "time": 1665419333 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665419453 },
+            "departure": { "time": 1665419453 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665419543 },
+            "departure": { "time": 1665419543 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665419663 },
+            "departure": { "time": 1665419663 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665419753 },
+            "departure": { "time": 1665419753 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665419843 },
+            "departure": { "time": 1665419843 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665419933 },
+            "departure": { "time": 1665419933 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665420053 },
+            "departure": { "time": 1665420053 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665420173 },
+            "departure": { "time": 1665420173 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665420293 },
+            "departure": { "time": 1665420293 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665420513 },
+            "departure": { "time": 1665420513 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665420653 },
+            "departure": { "time": 1665420653 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665420743 },
+            "departure": { "time": 1665420743 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665420893 },
+            "departure": { "time": 1665420893 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421013 },
+            "departure": { "time": 1665421013 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665421103 },
+            "departure": { "time": 1665421103 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421223 },
+            "departure": { "time": 1665421223 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665421283 },
+            "departure": { "time": 1665421283 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665421373 },
+            "departure": { "time": 1665421373 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665421463 },
+            "departure": { "time": 1665421463 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665421553 },
+            "departure": { "time": 1665421553 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665421703 },
+            "departure": { "time": 1665421703 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665421793 },
+            "departure": { "time": 1665421793 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665421943 },
+            "departure": { "time": 1665421943 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665422063 },
+            "departure": { "time": 1665422063 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665422153 },
+            "departure": { "time": 1665422153 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665422273 },
+            "departure": { "time": 1665422273 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665422343 },
+            "departure": { "time": 1665422343 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665422483 },
+            "departure": { "time": 1665422483 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665422603 },
+            "departure": { "time": 1665422603 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665422723 },
+            "departure": { "time": 1665422723 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665422903 },
+            "departure": { "time": 1665422903 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665423023 },
+            "departure": { "time": 1665423023 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665423143 },
+            "departure": { "time": 1665423143 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665423233 },
+            "departure": { "time": 1665423233 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665423323 },
+            "departure": { "time": 1665423323 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665423443 },
+            "departure": { "time": 1665423443 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665423593 },
+            "departure": { "time": 1665423593 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665423713 },
+            "departure": { "time": 1665423713 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665423803 },
+            "departure": { "time": 1665423803 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665423923 },
+            "departure": { "time": 1665423923 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665424013 },
+            "departure": { "time": 1665424013 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665424148 },
+            "departure": { "time": 1665424148 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665424283 },
+            "departure": { "time": 1665424283 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000036R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074600_R..S",
+          "start_time": "12:26:00",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 2,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "G10S"
+      }
+    },
+    {
+      "id": "000037R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075150_R..N",
+          "start_time": "12:31:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419490 },
+            "departure": { "time": 1665419490 },
+            "stop_id": "R45N"
+          },
+          {
+            "arrival": { "time": 1665419610 },
+            "departure": { "time": 1665419610 },
+            "stop_id": "R44N"
+          },
+          {
+            "arrival": { "time": 1665419760 },
+            "departure": { "time": 1665419760 },
+            "stop_id": "R43N"
+          },
+          {
+            "arrival": { "time": 1665419850 },
+            "departure": { "time": 1665419850 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665420000 },
+            "departure": { "time": 1665420000 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665420090 },
+            "departure": { "time": 1665420090 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665420360 },
+            "departure": { "time": 1665420360 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665420480 },
+            "departure": { "time": 1665420480 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665420570 },
+            "departure": { "time": 1665420570 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665421320 },
+            "departure": { "time": 1665421320 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665421560 },
+            "departure": { "time": 1665421560 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665421680 },
+            "departure": { "time": 1665421680 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665423870 },
+            "departure": { "time": 1665423870 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665424155 },
+            "departure": { "time": 1665424155 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665424290 },
+            "departure": { "time": 1665424290 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665424830 },
+            "departure": { "time": 1665424830 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000038R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075150_R..N",
+          "start_time": "12:31:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665419490,
+        "stop_id": "R45N"
+      }
+    },
+    {
+      "id": "000039R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "074265_R..N",
+          "start_time": "12:22:39",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419253 },
+            "departure": { "time": 1665419253 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665419331 },
+            "departure": { "time": 1665419331 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665419421 },
+            "departure": { "time": 1665419421 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665419541 },
+            "departure": { "time": 1665419541 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665419691 },
+            "departure": { "time": 1665419691 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665419811 },
+            "departure": { "time": 1665419811 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665419901 },
+            "departure": { "time": 1665419901 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665420021 },
+            "departure": { "time": 1665420021 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665420141 },
+            "departure": { "time": 1665420141 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665420261 },
+            "departure": { "time": 1665420261 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665420441 },
+            "departure": { "time": 1665420441 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665420531 },
+            "departure": { "time": 1665420531 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665420651 },
+            "departure": { "time": 1665420651 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665420873 },
+            "departure": { "time": 1665420873 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665420891 },
+            "departure": { "time": 1665420891 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665421011 },
+            "departure": { "time": 1665421011 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665421071 },
+            "departure": { "time": 1665421071 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665421191 },
+            "departure": { "time": 1665421191 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665421341 },
+            "departure": { "time": 1665421341 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665421431 },
+            "departure": { "time": 1665421431 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665421581 },
+            "departure": { "time": 1665421581 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665421671 },
+            "departure": { "time": 1665421671 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665421761 },
+            "departure": { "time": 1665421761 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665421851 },
+            "departure": { "time": 1665421851 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665421911 },
+            "departure": { "time": 1665421911 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665422031 },
+            "departure": { "time": 1665422031 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665422151 },
+            "departure": { "time": 1665422151 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665422271 },
+            "departure": { "time": 1665422271 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665422421 },
+            "departure": { "time": 1665422421 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665422511 },
+            "departure": { "time": 1665422511 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665422733 },
+            "departure": { "time": 1665422733 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665422841 },
+            "departure": { "time": 1665422841 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665422961 },
+            "departure": { "time": 1665422961 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665423081 },
+            "departure": { "time": 1665423081 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665423201 },
+            "departure": { "time": 1665423201 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665423291 },
+            "departure": { "time": 1665423291 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665423381 },
+            "departure": { "time": 1665423381 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665423486 },
+            "departure": { "time": 1665423486 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665423621 },
+            "departure": { "time": 1665423621 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665423711 },
+            "departure": { "time": 1665423711 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665423831 },
+            "departure": { "time": 1665423831 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665423921 },
+            "departure": { "time": 1665423921 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665424041 },
+            "departure": { "time": 1665424041 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665424161 },
+            "departure": { "time": 1665424161 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000040R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "074265_R..N",
+          "start_time": "12:22:39",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "current_stop_sequence": 3,
+        "current_status": 1,
+        "timestamp": 1665419253,
+        "stop_id": "R42N"
+      }
+    },
+    {
+      "id": "000041R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "075650_R..S",
+          "start_time": "12:36:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665419790 },
+            "departure": { "time": 1665419790 },
+            "stop_id": "G08S"
+          },
+          {
+            "arrival": { "time": 1665419910 },
+            "departure": { "time": 1665419910 },
+            "stop_id": "G09S"
+          },
+          {
+            "arrival": { "time": 1665420000 },
+            "departure": { "time": 1665420000 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665420090 },
+            "departure": { "time": 1665420090 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665420210 },
+            "departure": { "time": 1665420210 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665420300 },
+            "departure": { "time": 1665420300 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665420600 },
+            "departure": { "time": 1665420600 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665420930 },
+            "departure": { "time": 1665420930 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665421050 },
+            "departure": { "time": 1665421050 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665421410 },
+            "departure": { "time": 1665421410 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422040 },
+            "departure": { "time": 1665422040 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665422550 },
+            "departure": { "time": 1665422550 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665423030 },
+            "departure": { "time": 1665423030 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665424470 },
+            "departure": { "time": 1665424470 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665424770 },
+            "departure": { "time": 1665424770 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665424905 },
+            "departure": { "time": 1665424905 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000042R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "075650_R..S",
+          "start_time": "12:36:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665419790,
+        "stop_id": "G08S"
+      }
+    },
+    {
+      "id": "000043R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076250_R..N",
+          "start_time": "12:42:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420150 },
+            "departure": { "time": 1665420150 },
+            "stop_id": "R45N"
+          },
+          {
+            "arrival": { "time": 1665420270 },
+            "departure": { "time": 1665420270 },
+            "stop_id": "R44N"
+          },
+          {
+            "arrival": { "time": 1665420420 },
+            "departure": { "time": 1665420420 },
+            "stop_id": "R43N"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665420660 },
+            "departure": { "time": 1665420660 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665420750 },
+            "departure": { "time": 1665420750 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665420870 },
+            "departure": { "time": 1665420870 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665421140 },
+            "departure": { "time": 1665421140 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665421230 },
+            "departure": { "time": 1665421230 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665421770 },
+            "departure": { "time": 1665421770 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665421980 },
+            "departure": { "time": 1665421980 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665422520 },
+            "departure": { "time": 1665422520 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665423990 },
+            "departure": { "time": 1665423990 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665424245 },
+            "departure": { "time": 1665424245 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665424770 },
+            "departure": { "time": 1665424770 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665424965 },
+            "departure": { "time": 1665424965 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665425310 },
+            "departure": { "time": 1665425310 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665425400 },
+            "departure": { "time": 1665425400 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665425520 },
+            "departure": { "time": 1665425520 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665425640 },
+            "departure": { "time": 1665425640 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000044R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076250_R..N",
+          "start_time": "12:42:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665420150,
+        "stop_id": "R45N"
+      }
+    },
+    {
+      "id": "000045R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "076650_R..S",
+          "start_time": "12:46:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420390 },
+            "departure": { "time": 1665420390 },
+            "stop_id": "G08S"
+          },
+          {
+            "arrival": { "time": 1665420510 },
+            "departure": { "time": 1665420510 },
+            "stop_id": "G09S"
+          },
+          {
+            "arrival": { "time": 1665420600 },
+            "departure": { "time": 1665420600 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665420690 },
+            "departure": { "time": 1665420690 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665420810 },
+            "departure": { "time": 1665420810 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665420900 },
+            "departure": { "time": 1665420900 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665421290 },
+            "departure": { "time": 1665421290 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665421410 },
+            "departure": { "time": 1665421410 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665421530 },
+            "departure": { "time": 1665421530 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665421650 },
+            "departure": { "time": 1665421650 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422370 },
+            "departure": { "time": 1665422370 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665422640 },
+            "departure": { "time": 1665422640 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665423150 },
+            "departure": { "time": 1665423150 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665423630 },
+            "departure": { "time": 1665423630 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665425070 },
+            "departure": { "time": 1665425070 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665425160 },
+            "departure": { "time": 1665425160 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665425280 },
+            "departure": { "time": 1665425280 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665425370 },
+            "departure": { "time": 1665425370 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665425505 },
+            "departure": { "time": 1665425505 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665425640 },
+            "departure": { "time": 1665425640 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000046R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "076650_R..S",
+          "start_time": "12:46:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665420390,
+        "stop_id": "G08S"
+      }
+    },
+    {
+      "id": "000047R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077250_R..N",
+          "start_time": "12:52:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420750 },
+            "departure": { "time": 1665420750 },
+            "stop_id": "R45N"
+          },
+          {
+            "arrival": { "time": 1665420870 },
+            "departure": { "time": 1665420870 },
+            "stop_id": "R44N"
+          },
+          {
+            "arrival": { "time": 1665421020 },
+            "departure": { "time": 1665421020 },
+            "stop_id": "R43N"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665421260 },
+            "departure": { "time": 1665421260 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665421740 },
+            "departure": { "time": 1665421740 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665421830 },
+            "departure": { "time": 1665421830 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665422070 },
+            "departure": { "time": 1665422070 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665422370 },
+            "departure": { "time": 1665422370 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665422580 },
+            "departure": { "time": 1665422580 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665422940 },
+            "departure": { "time": 1665422940 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665423120 },
+            "departure": { "time": 1665423120 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665423270 },
+            "departure": { "time": 1665423270 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665424590 },
+            "departure": { "time": 1665424590 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665424770 },
+            "departure": { "time": 1665424770 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665424890 },
+            "departure": { "time": 1665424890 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665425010 },
+            "departure": { "time": 1665425010 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665425130 },
+            "departure": { "time": 1665425130 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665425220 },
+            "departure": { "time": 1665425220 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665425310 },
+            "departure": { "time": 1665425310 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665425415 },
+            "departure": { "time": 1665425415 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665425550 },
+            "departure": { "time": 1665425550 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665425640 },
+            "departure": { "time": 1665425640 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665425760 },
+            "departure": { "time": 1665425760 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665425850 },
+            "departure": { "time": 1665425850 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665425970 },
+            "departure": { "time": 1665425970 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665426090 },
+            "departure": { "time": 1665426090 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000048R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077250_R..N",
+          "start_time": "12:52:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665420750,
+        "stop_id": "R45N"
+      }
+    },
+    {
+      "id": "000049R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "077650_R..S",
+          "start_time": "12:56:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665420990 },
+            "departure": { "time": 1665420990 },
+            "stop_id": "G08S"
+          },
+          {
+            "arrival": { "time": 1665421110 },
+            "departure": { "time": 1665421110 },
+            "stop_id": "G09S"
+          },
+          {
+            "arrival": { "time": 1665421200 },
+            "departure": { "time": 1665421200 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665421290 },
+            "departure": { "time": 1665421290 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665421410 },
+            "departure": { "time": 1665421410 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665421500 },
+            "departure": { "time": 1665421500 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665421800 },
+            "departure": { "time": 1665421800 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665422130 },
+            "departure": { "time": 1665422130 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665422460 },
+            "departure": { "time": 1665422460 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423240 },
+            "departure": { "time": 1665423240 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665423750 },
+            "departure": { "time": 1665423750 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665424020 },
+            "departure": { "time": 1665424020 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665424230 },
+            "departure": { "time": 1665424230 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665424290 },
+            "departure": { "time": 1665424290 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665424980 },
+            "departure": { "time": 1665424980 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665425280 },
+            "departure": { "time": 1665425280 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665425400 },
+            "departure": { "time": 1665425400 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665425550 },
+            "departure": { "time": 1665425550 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665425670 },
+            "departure": { "time": 1665425670 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665425760 },
+            "departure": { "time": 1665425760 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665425880 },
+            "departure": { "time": 1665425880 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665425970 },
+            "departure": { "time": 1665425970 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665426105 },
+            "departure": { "time": 1665426105 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665426240 },
+            "departure": { "time": 1665426240 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000050R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "077650_R..S",
+          "start_time": "12:56:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665420990,
+        "stop_id": "G08S"
+      }
+    },
+    {
+      "id": "000051R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078250_R..N",
+          "start_time": "13:02:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421350 },
+            "departure": { "time": 1665421350 },
+            "stop_id": "R45N"
+          },
+          {
+            "arrival": { "time": 1665421470 },
+            "departure": { "time": 1665421470 },
+            "stop_id": "R44N"
+          },
+          {
+            "arrival": { "time": 1665421620 },
+            "departure": { "time": 1665421620 },
+            "stop_id": "R43N"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665421860 },
+            "departure": { "time": 1665421860 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665421950 },
+            "departure": { "time": 1665421950 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665422070 },
+            "departure": { "time": 1665422070 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665422340 },
+            "departure": { "time": 1665422340 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665422430 },
+            "departure": { "time": 1665422430 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665422550 },
+            "departure": { "time": 1665422550 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665422670 },
+            "departure": { "time": 1665422670 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665423180 },
+            "departure": { "time": 1665423180 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665423540 },
+            "departure": { "time": 1665423540 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665423870 },
+            "departure": { "time": 1665423870 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665424290 },
+            "departure": { "time": 1665424290 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665424800 },
+            "departure": { "time": 1665424800 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665425190 },
+            "departure": { "time": 1665425190 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665425370 },
+            "departure": { "time": 1665425370 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665425490 },
+            "departure": { "time": 1665425490 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665425610 },
+            "departure": { "time": 1665425610 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665425730 },
+            "departure": { "time": 1665425730 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665425820 },
+            "departure": { "time": 1665425820 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665425910 },
+            "departure": { "time": 1665425910 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665426015 },
+            "departure": { "time": 1665426015 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665426150 },
+            "departure": { "time": 1665426150 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665426240 },
+            "departure": { "time": 1665426240 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665426360 },
+            "departure": { "time": 1665426360 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665426450 },
+            "departure": { "time": 1665426450 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665426570 },
+            "departure": { "time": 1665426570 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665426690 },
+            "departure": { "time": 1665426690 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000052R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078250_R..N",
+          "start_time": "13:02:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665421350,
+        "stop_id": "R45N"
+      }
+    },
+    {
+      "id": "000053R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "078650_R..S",
+          "start_time": "13:06:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421590 },
+            "departure": { "time": 1665421590 },
+            "stop_id": "G08S"
+          },
+          {
+            "arrival": { "time": 1665421710 },
+            "departure": { "time": 1665421710 },
+            "stop_id": "G09S"
+          },
+          {
+            "arrival": { "time": 1665421800 },
+            "departure": { "time": 1665421800 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665422100 },
+            "departure": { "time": 1665422100 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665422220 },
+            "departure": { "time": 1665422220 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665422730 },
+            "departure": { "time": 1665422730 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665423060 },
+            "departure": { "time": 1665423060 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665423570 },
+            "departure": { "time": 1665423570 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665423780 },
+            "departure": { "time": 1665423780 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665423840 },
+            "departure": { "time": 1665423840 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665424020 },
+            "departure": { "time": 1665424020 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665424350 },
+            "departure": { "time": 1665424350 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665424830 },
+            "departure": { "time": 1665424830 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665424890 },
+            "departure": { "time": 1665424890 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665425160 },
+            "departure": { "time": 1665425160 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665425280 },
+            "departure": { "time": 1665425280 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665425460 },
+            "departure": { "time": 1665425460 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665425580 },
+            "departure": { "time": 1665425580 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665425790 },
+            "departure": { "time": 1665425790 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665425880 },
+            "departure": { "time": 1665425880 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665426000 },
+            "departure": { "time": 1665426000 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665426150 },
+            "departure": { "time": 1665426150 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665426270 },
+            "departure": { "time": 1665426270 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665426360 },
+            "departure": { "time": 1665426360 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665426480 },
+            "departure": { "time": 1665426480 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665426570 },
+            "departure": { "time": 1665426570 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665426705 },
+            "departure": { "time": 1665426705 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665426840 },
+            "departure": { "time": 1665426840 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000054R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "078650_R..S",
+          "start_time": "13:06:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665421590,
+        "stop_id": "G08S"
+      }
+    },
+    {
+      "id": "000055R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079650_R..S",
+          "start_time": "13:16:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422190 },
+            "departure": { "time": 1665422190 },
+            "stop_id": "G08S"
+          },
+          {
+            "arrival": { "time": 1665422310 },
+            "departure": { "time": 1665422310 },
+            "stop_id": "G09S"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665422700 },
+            "departure": { "time": 1665422700 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665422820 },
+            "departure": { "time": 1665422820 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665423450 },
+            "departure": { "time": 1665423450 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665423660 },
+            "departure": { "time": 1665423660 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665423900 },
+            "departure": { "time": 1665423900 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665424170 },
+            "departure": { "time": 1665424170 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665424380 },
+            "departure": { "time": 1665424380 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665424440 },
+            "departure": { "time": 1665424440 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665424530 },
+            "departure": { "time": 1665424530 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665424620 },
+            "departure": { "time": 1665424620 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665424710 },
+            "departure": { "time": 1665424710 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665424950 },
+            "departure": { "time": 1665424950 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665425220 },
+            "departure": { "time": 1665425220 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665425310 },
+            "departure": { "time": 1665425310 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665425430 },
+            "departure": { "time": 1665425430 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665425490 },
+            "departure": { "time": 1665425490 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665425640 },
+            "departure": { "time": 1665425640 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665425760 },
+            "departure": { "time": 1665425760 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665425880 },
+            "departure": { "time": 1665425880 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665426060 },
+            "departure": { "time": 1665426060 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665426180 },
+            "departure": { "time": 1665426180 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665426300 },
+            "departure": { "time": 1665426300 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665426390 },
+            "departure": { "time": 1665426390 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665426480 },
+            "departure": { "time": 1665426480 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665426600 },
+            "departure": { "time": 1665426600 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665426750 },
+            "departure": { "time": 1665426750 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665426870 },
+            "departure": { "time": 1665426870 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665426960 },
+            "departure": { "time": 1665426960 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665427080 },
+            "departure": { "time": 1665427080 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665427170 },
+            "departure": { "time": 1665427170 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665427305 },
+            "departure": { "time": 1665427305 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665427440 },
+            "departure": { "time": 1665427440 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000056R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079650_R..S",
+          "start_time": "13:16:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665422190,
+        "stop_id": "G08S"
+      }
+    },
+    {
+      "id": "000057R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "079150_R..N",
+          "start_time": "13:11:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665421890 },
+            "departure": { "time": 1665421890 },
+            "stop_id": "R45N"
+          },
+          {
+            "arrival": { "time": 1665422010 },
+            "departure": { "time": 1665422010 },
+            "stop_id": "R44N"
+          },
+          {
+            "arrival": { "time": 1665422160 },
+            "departure": { "time": 1665422160 },
+            "stop_id": "R43N"
+          },
+          {
+            "arrival": { "time": 1665422250 },
+            "departure": { "time": 1665422250 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665422400 },
+            "departure": { "time": 1665422400 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665422880 },
+            "departure": { "time": 1665422880 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665422970 },
+            "departure": { "time": 1665422970 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665423330 },
+            "departure": { "time": 1665423330 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665423720 },
+            "departure": { "time": 1665423720 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665423870 },
+            "departure": { "time": 1665423870 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665423960 },
+            "departure": { "time": 1665423960 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665424080 },
+            "departure": { "time": 1665424080 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665424140 },
+            "departure": { "time": 1665424140 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665424740 },
+            "departure": { "time": 1665424740 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665424830 },
+            "departure": { "time": 1665424830 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665424920 },
+            "departure": { "time": 1665424920 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665424980 },
+            "departure": { "time": 1665424980 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665425220 },
+            "departure": { "time": 1665425220 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665425340 },
+            "departure": { "time": 1665425340 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665425490 },
+            "departure": { "time": 1665425490 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665425580 },
+            "departure": { "time": 1665425580 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665425730 },
+            "departure": { "time": 1665425730 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665425910 },
+            "departure": { "time": 1665425910 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665426030 },
+            "departure": { "time": 1665426030 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665426150 },
+            "departure": { "time": 1665426150 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665426270 },
+            "departure": { "time": 1665426270 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665426360 },
+            "departure": { "time": 1665426360 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665426450 },
+            "departure": { "time": 1665426450 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665426555 },
+            "departure": { "time": 1665426555 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665426690 },
+            "departure": { "time": 1665426690 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665426780 },
+            "departure": { "time": 1665426780 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665426900 },
+            "departure": { "time": 1665426900 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665426990 },
+            "departure": { "time": 1665426990 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665427110 },
+            "departure": { "time": 1665427110 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665427230 },
+            "departure": { "time": 1665427230 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000058R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "079150_R..N",
+          "start_time": "13:11:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665421890,
+        "stop_id": "R45N"
+      }
+    },
+    {
+      "id": "000059R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080150_R..N",
+          "start_time": "13:21:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422490 },
+            "departure": { "time": 1665422490 },
+            "stop_id": "R45N"
+          },
+          {
+            "arrival": { "time": 1665422610 },
+            "departure": { "time": 1665422610 },
+            "stop_id": "R44N"
+          },
+          {
+            "arrival": { "time": 1665422760 },
+            "departure": { "time": 1665422760 },
+            "stop_id": "R43N"
+          },
+          {
+            "arrival": { "time": 1665422850 },
+            "departure": { "time": 1665422850 },
+            "stop_id": "R42N"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "R41N"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "R40N"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "R39N"
+          },
+          {
+            "arrival": { "time": 1665423360 },
+            "departure": { "time": 1665423360 },
+            "stop_id": "R36N"
+          },
+          {
+            "arrival": { "time": 1665423480 },
+            "departure": { "time": 1665423480 },
+            "stop_id": "R35N"
+          },
+          {
+            "arrival": { "time": 1665423570 },
+            "departure": { "time": 1665423570 },
+            "stop_id": "R34N"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "R33N"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "R32N"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "R31N"
+          },
+          {
+            "arrival": { "time": 1665424110 },
+            "departure": { "time": 1665424110 },
+            "stop_id": "R30N"
+          },
+          {
+            "arrival": { "time": 1665424200 },
+            "departure": { "time": 1665424200 },
+            "stop_id": "R29N"
+          },
+          {
+            "arrival": { "time": 1665424320 },
+            "departure": { "time": 1665424320 },
+            "stop_id": "R28N"
+          },
+          {
+            "arrival": { "time": 1665424470 },
+            "departure": { "time": 1665424470 },
+            "stop_id": "R65N"
+          },
+          {
+            "arrival": { "time": 1665424560 },
+            "departure": { "time": 1665424560 },
+            "stop_id": "R27N"
+          },
+          {
+            "arrival": { "time": 1665424680 },
+            "departure": { "time": 1665424680 },
+            "stop_id": "R26N"
+          },
+          {
+            "arrival": { "time": 1665424740 },
+            "departure": { "time": 1665424740 },
+            "stop_id": "R25N"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "R24N"
+          },
+          {
+            "arrival": { "time": 1665425010 },
+            "departure": { "time": 1665425010 },
+            "stop_id": "R23N"
+          },
+          {
+            "arrival": { "time": 1665425100 },
+            "departure": { "time": 1665425100 },
+            "stop_id": "R22N"
+          },
+          {
+            "arrival": { "time": 1665425250 },
+            "departure": { "time": 1665425250 },
+            "stop_id": "R21N"
+          },
+          {
+            "arrival": { "time": 1665425340 },
+            "departure": { "time": 1665425340 },
+            "stop_id": "R20N"
+          },
+          {
+            "arrival": { "time": 1665425430 },
+            "departure": { "time": 1665425430 },
+            "stop_id": "R19N"
+          },
+          {
+            "arrival": { "time": 1665425520 },
+            "departure": { "time": 1665425520 },
+            "stop_id": "R18N"
+          },
+          {
+            "arrival": { "time": 1665425580 },
+            "departure": { "time": 1665425580 },
+            "stop_id": "R17N"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "R16N"
+          },
+          {
+            "arrival": { "time": 1665425820 },
+            "departure": { "time": 1665425820 },
+            "stop_id": "R15N"
+          },
+          {
+            "arrival": { "time": 1665425940 },
+            "departure": { "time": 1665425940 },
+            "stop_id": "R14N"
+          },
+          {
+            "arrival": { "time": 1665426090 },
+            "departure": { "time": 1665426090 },
+            "stop_id": "R13N"
+          },
+          {
+            "arrival": { "time": 1665426180 },
+            "departure": { "time": 1665426180 },
+            "stop_id": "R11N"
+          },
+          {
+            "arrival": { "time": 1665426330 },
+            "departure": { "time": 1665426330 },
+            "stop_id": "R60N"
+          },
+          {
+            "arrival": { "time": 1665426540 },
+            "departure": { "time": 1665426540 },
+            "stop_id": "G21N"
+          },
+          {
+            "arrival": { "time": 1665426660 },
+            "departure": { "time": 1665426660 },
+            "stop_id": "G20N"
+          },
+          {
+            "arrival": { "time": 1665426780 },
+            "departure": { "time": 1665426780 },
+            "stop_id": "G19N"
+          },
+          {
+            "arrival": { "time": 1665426900 },
+            "departure": { "time": 1665426900 },
+            "stop_id": "G18N"
+          },
+          {
+            "arrival": { "time": 1665426990 },
+            "departure": { "time": 1665426990 },
+            "stop_id": "G16N"
+          },
+          {
+            "arrival": { "time": 1665427080 },
+            "departure": { "time": 1665427080 },
+            "stop_id": "G15N"
+          },
+          {
+            "arrival": { "time": 1665427185 },
+            "departure": { "time": 1665427185 },
+            "stop_id": "G14N"
+          },
+          {
+            "arrival": { "time": 1665427320 },
+            "departure": { "time": 1665427320 },
+            "stop_id": "G13N"
+          },
+          {
+            "arrival": { "time": 1665427410 },
+            "departure": { "time": 1665427410 },
+            "stop_id": "G12N"
+          },
+          {
+            "arrival": { "time": 1665427530 },
+            "departure": { "time": 1665427530 },
+            "stop_id": "G11N"
+          },
+          {
+            "arrival": { "time": 1665427620 },
+            "departure": { "time": 1665427620 },
+            "stop_id": "G10N"
+          },
+          {
+            "arrival": { "time": 1665427740 },
+            "departure": { "time": 1665427740 },
+            "stop_id": "G09N"
+          },
+          {
+            "arrival": { "time": 1665427860 },
+            "departure": { "time": 1665427860 },
+            "stop_id": "G08N"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000060R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080150_R..N",
+          "start_time": "13:21:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665422490,
+        "stop_id": "R45N"
+      }
+    },
+    {
+      "id": "000061R",
+      "trip_update": {
+        "trip": {
+          "trip_id": "080650_R..S",
+          "start_time": "13:26:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "stop_time_update": [
+          {
+            "arrival": { "time": 1665422790 },
+            "departure": { "time": 1665422790 },
+            "stop_id": "G08S"
+          },
+          {
+            "arrival": { "time": 1665422910 },
+            "departure": { "time": 1665422910 },
+            "stop_id": "G09S"
+          },
+          {
+            "arrival": { "time": 1665423000 },
+            "departure": { "time": 1665423000 },
+            "stop_id": "G10S"
+          },
+          {
+            "arrival": { "time": 1665423090 },
+            "departure": { "time": 1665423090 },
+            "stop_id": "G11S"
+          },
+          {
+            "arrival": { "time": 1665423210 },
+            "departure": { "time": 1665423210 },
+            "stop_id": "G12S"
+          },
+          {
+            "arrival": { "time": 1665423300 },
+            "departure": { "time": 1665423300 },
+            "stop_id": "G13S"
+          },
+          {
+            "arrival": { "time": 1665423420 },
+            "departure": { "time": 1665423420 },
+            "stop_id": "G14S"
+          },
+          {
+            "arrival": { "time": 1665423510 },
+            "departure": { "time": 1665423510 },
+            "stop_id": "G15S"
+          },
+          {
+            "arrival": { "time": 1665423600 },
+            "departure": { "time": 1665423600 },
+            "stop_id": "G16S"
+          },
+          {
+            "arrival": { "time": 1665423690 },
+            "departure": { "time": 1665423690 },
+            "stop_id": "G18S"
+          },
+          {
+            "arrival": { "time": 1665423810 },
+            "departure": { "time": 1665423810 },
+            "stop_id": "G19S"
+          },
+          {
+            "arrival": { "time": 1665423930 },
+            "departure": { "time": 1665423930 },
+            "stop_id": "G20S"
+          },
+          {
+            "arrival": { "time": 1665424050 },
+            "departure": { "time": 1665424050 },
+            "stop_id": "G21S"
+          },
+          {
+            "arrival": { "time": 1665424260 },
+            "departure": { "time": 1665424260 },
+            "stop_id": "R60S"
+          },
+          {
+            "arrival": { "time": 1665424410 },
+            "departure": { "time": 1665424410 },
+            "stop_id": "R11S"
+          },
+          {
+            "arrival": { "time": 1665424500 },
+            "departure": { "time": 1665424500 },
+            "stop_id": "R13S"
+          },
+          {
+            "arrival": { "time": 1665424650 },
+            "departure": { "time": 1665424650 },
+            "stop_id": "R14S"
+          },
+          {
+            "arrival": { "time": 1665424770 },
+            "departure": { "time": 1665424770 },
+            "stop_id": "R15S"
+          },
+          {
+            "arrival": { "time": 1665424860 },
+            "departure": { "time": 1665424860 },
+            "stop_id": "R16S"
+          },
+          {
+            "arrival": { "time": 1665424980 },
+            "departure": { "time": 1665424980 },
+            "stop_id": "R17S"
+          },
+          {
+            "arrival": { "time": 1665425040 },
+            "departure": { "time": 1665425040 },
+            "stop_id": "R18S"
+          },
+          {
+            "arrival": { "time": 1665425130 },
+            "departure": { "time": 1665425130 },
+            "stop_id": "R19S"
+          },
+          {
+            "arrival": { "time": 1665425220 },
+            "departure": { "time": 1665425220 },
+            "stop_id": "R20S"
+          },
+          {
+            "arrival": { "time": 1665425310 },
+            "departure": { "time": 1665425310 },
+            "stop_id": "R21S"
+          },
+          {
+            "arrival": { "time": 1665425460 },
+            "departure": { "time": 1665425460 },
+            "stop_id": "R22S"
+          },
+          {
+            "arrival": { "time": 1665425550 },
+            "departure": { "time": 1665425550 },
+            "stop_id": "R23S"
+          },
+          {
+            "arrival": { "time": 1665425700 },
+            "departure": { "time": 1665425700 },
+            "stop_id": "R24S"
+          },
+          {
+            "arrival": { "time": 1665425820 },
+            "departure": { "time": 1665425820 },
+            "stop_id": "R25S"
+          },
+          {
+            "arrival": { "time": 1665425910 },
+            "departure": { "time": 1665425910 },
+            "stop_id": "R26S"
+          },
+          {
+            "arrival": { "time": 1665426030 },
+            "departure": { "time": 1665426030 },
+            "stop_id": "R27S"
+          },
+          {
+            "arrival": { "time": 1665426090 },
+            "departure": { "time": 1665426090 },
+            "stop_id": "R65S"
+          },
+          {
+            "arrival": { "time": 1665426240 },
+            "departure": { "time": 1665426240 },
+            "stop_id": "R28S"
+          },
+          {
+            "arrival": { "time": 1665426360 },
+            "departure": { "time": 1665426360 },
+            "stop_id": "R29S"
+          },
+          {
+            "arrival": { "time": 1665426480 },
+            "departure": { "time": 1665426480 },
+            "stop_id": "R30S"
+          },
+          {
+            "arrival": { "time": 1665426660 },
+            "departure": { "time": 1665426660 },
+            "stop_id": "R31S"
+          },
+          {
+            "arrival": { "time": 1665426780 },
+            "departure": { "time": 1665426780 },
+            "stop_id": "R32S"
+          },
+          {
+            "arrival": { "time": 1665426900 },
+            "departure": { "time": 1665426900 },
+            "stop_id": "R33S"
+          },
+          {
+            "arrival": { "time": 1665426990 },
+            "departure": { "time": 1665426990 },
+            "stop_id": "R34S"
+          },
+          {
+            "arrival": { "time": 1665427080 },
+            "departure": { "time": 1665427080 },
+            "stop_id": "R35S"
+          },
+          {
+            "arrival": { "time": 1665427200 },
+            "departure": { "time": 1665427200 },
+            "stop_id": "R36S"
+          },
+          {
+            "arrival": { "time": 1665427350 },
+            "departure": { "time": 1665427350 },
+            "stop_id": "R39S"
+          },
+          {
+            "arrival": { "time": 1665427470 },
+            "departure": { "time": 1665427470 },
+            "stop_id": "R40S"
+          },
+          {
+            "arrival": { "time": 1665427560 },
+            "departure": { "time": 1665427560 },
+            "stop_id": "R41S"
+          },
+          {
+            "arrival": { "time": 1665427680 },
+            "departure": { "time": 1665427680 },
+            "stop_id": "R42S"
+          },
+          {
+            "arrival": { "time": 1665427770 },
+            "departure": { "time": 1665427770 },
+            "stop_id": "R43S"
+          },
+          {
+            "arrival": { "time": 1665427905 },
+            "departure": { "time": 1665427905 },
+            "stop_id": "R44S"
+          },
+          {
+            "arrival": { "time": 1665428040 },
+            "departure": { "time": 1665428040 },
+            "stop_id": "R45S"
+          }
+        ]
+      }
+    },
+    {
+      "id": "000062R",
+      "vehicle": {
+        "trip": {
+          "trip_id": "080650_R..S",
+          "start_time": "13:26:30",
+          "start_date": "20221010",
+          "route_id": "R"
+        },
+        "timestamp": 1665422790,
+        "stop_id": "G08S"
+      }
+    }
+  ]
+}

--- a/server/rankings/rankings.py
+++ b/server/rankings/rankings.py
@@ -1,0 +1,45 @@
+from ast import List
+from collections import defaultdict
+import datetime
+import os
+import pandas as pd
+
+from underground import metadata, SubwayFeed
+API_KEY = os.getenv('MTA_API_KEY')
+ROUTE = 'Q'
+
+if not API_KEY:
+    print("Set MTA_API_KEY before running")
+    exit()
+
+routes = ["A", "G", "Q", "1", "B", "J", "L"]
+
+avg_headsways_dict = {}
+
+def avg_headway(timestamps) -> datetime.timedelta:
+    mx = max(timestamps)
+    mn = min(timestamps)
+    if len(timestamps) > 1:
+        avg = (mx-mn)/(len(timestamps)-1)
+    else:
+        avg = (mx-mn)/(len(timestamps))
+    return avg
+
+# I am not a data scientist, there is probably a more statistically correct way to calculate this
+# This roughly works as a proof-of-concept
+for route in routes:
+    feed = SubwayFeed.get(route, api_key=API_KEY)
+
+    stops_dict = feed.extract_stop_dict()
+
+    for route_id in stops_dict:
+        avg_headsways_dict[route_id]= {}
+        for stop_id in stops_dict[route_id]:
+            avg_headsways_dict[route_id][stop_id] = avg_headway(stops_dict[route_id][stop_id])
+
+total_system_average = []
+
+for route_id in avg_headsways_dict:
+    total_system_average.append(pd.to_timedelta(pd.Series(avg_headsways_dict[route_id])).mean())
+    print(route_id, pd.to_timedelta(pd.Series(avg_headsways_dict[route_id])).mean())
+print("Total System: ", pd.to_timedelta(pd.Series(total_system_average)).mean())

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import App from './App';
 import OpenSource from './OpenSource';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { SlowZones } from './slowzones/SlowZones';
+import { Rankings } from './rankings/Rankings';
 
 ReactDOM.render(
   <BrowserRouter>
@@ -23,6 +24,9 @@ ReactDOM.render(
       </Route>
       <Route exact path="/slowzones">
         <SlowZones />
+      </Route>
+      <Route exact path="/rankings">
+        <Rankings />
       </Route>
     </Switch>
   </BrowserRouter>,

--- a/src/inputs/Select.tsx
+++ b/src/inputs/Select.tsx
@@ -5,11 +5,11 @@ import { Option, Options } from './types';
 interface SelectProps {
   options: Options;
   /** Non-standard value comparator because from/to gets copied by onpopstate */
-  optionComparator: (option: Option) => boolean;
+  optionComparator?: (option: Option) => boolean;
   onChange: (value: string | undefined) => void;
   defaultLabel: string;
   value: string;
-  className: string;
+  className?: string;
 }
 
 export const Select: React.FC<SelectProps> = ({

--- a/src/rankings/Rankings.tsx
+++ b/src/rankings/Rankings.tsx
@@ -1,0 +1,20 @@
+import React, { useMemo } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+function useQuery() {
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
+}
+
+export const Rankings: React.FC = () => {
+  document.title = 'Data Dashboard - Rankings';
+  const params = useQuery();
+  const history = useHistory();
+
+  return (
+    <>
+      <h1>Headways</h1>
+    </>
+  );
+};

--- a/src/slowzones/SlowZoneNav.tsx
+++ b/src/slowzones/SlowZoneNav.tsx
@@ -4,7 +4,7 @@ import { optionsForSelect } from './SlowZones';
 import { ChartView, Direction } from './types';
 import { getDateThreeMonthsAgo, trainDateRange } from '../constants';
 import moment, { Moment } from 'moment';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 interface SlowZoneNavProps {
   chartView: ChartView;
@@ -20,7 +20,7 @@ interface SlowZoneNavProps {
   params: URLSearchParams;
 }
 
-export const SlowZoneNav = ({
+export const SlowZoneNav: React.FC<SlowZoneNavProps> = ({
   chartView,
   setChartView,
   direction,
@@ -32,7 +32,7 @@ export const SlowZoneNav = ({
   setStartDate,
   setEndDate,
   params,
-}: SlowZoneNavProps) => {
+}) => {
   const getIsChecked = (value: string) => {
     return selectedLines.includes(value);
   };

--- a/src/slowzones/SlowZones.tsx
+++ b/src/slowzones/SlowZones.tsx
@@ -34,7 +34,7 @@ function useQuery() {
   return useMemo(() => new URLSearchParams(search), [search]);
 }
 
-export const SlowZones = () => {
+export const SlowZones: React.FC = () => {
   document.title = 'Data Dashboard - Slow zones';
   const params = useQuery();
   const history = useHistory();


### PR DESCRIPTION
Some python code that parses information from the MTA to allows us to see headways for each line and the system itself to compare against the mbta. Ideally we can get data like this for ~5 other systems to show where the MBTA ranks in several attributes (headways, ridership, etc.)