### PR TITLE
Donate button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
 
 <body>
   <section class="hero is-dark is-bold">
+    <a class="like-button donate-button" target="_blank" href="https://transitmatters.org/donate">Donate</a>
     <div class="hero-body">
       <div class="container">
         <a href="/"><img style="width: 250px; margin-right: 30px;"
@@ -30,8 +31,7 @@
         <h1 class="title">
           Data Dashboard
           <span class="beta-tag"></span>
-        </h1>
-      </div>
+        </h1>      </div>
     </div>
   </section>
 

--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,12 @@
   --download-icon: url("data:image/svg+xml,<svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M9 17L15 17' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round'/><path d='M12 6V13M12 13L15.5 9.5M12 13L8.5 9.5' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 }
 
+.hero .donate-button {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+}
+
 .App {
   font-size: 14px;
 }
@@ -174,6 +180,7 @@
 
 select,
 .option-date input,
+a.like-button,
 button {
   border-radius: 4px;
   appearance: none;
@@ -181,6 +188,12 @@ button {
   font-size: 1em;
   height: 30px;
   border: 1px solid currentColor;
+}
+
+a.like-button {
+  display: flex;
+  align-items: center;
+  padding: 3px 6px;
 }
 
 select option:disabled {


### PR DESCRIPTION
As the Slow Zones tracker (and the Data Dashboard generally) receive an enormous influx of traffic, we should at least try to convert some of those visits into donations for TM. I've added a very quick link to our org-wide `/donate` page affixed to the top-right of all DD pages that looks like this:

![image](https://user-images.githubusercontent.com/2208769/195449897-6e4eb0d1-de59-4e4e-b7d1-920c54fb78e2.png)

It works well on desktop and on modern mobile viewports (>350px).

_Test plan:_
Visit any page and verify that the new button takes you to the `/donate` page, in a new tab.