### PR TITLE
fix obscure pandas bug

### DIFF
--- a/server/chalicelib/aggregation.py
+++ b/server/chalicelib/aggregation.py
@@ -11,6 +11,8 @@ SERVICE_HR_OFFSET = datetime.timedelta(hours=3, minutes=30)
 def train_peak_status(df):
     cal = USFederalHolidayCalendar()
     holidays = cal.holidays(start=df['dep_dt'].min(), end=df['dep_dt'].max())
+    # pandas has a bug where sometimes empty holidays returns an Index and we need DateTimeIndex
+    holidays = pd.to_datetime(holidays)
     df['holiday'] = df['service_date'].isin(holidays.date)
 
     # Peak Hours: non-holiday weekdays 6:30-9am; 3:30-6:30pm


### PR DESCRIPTION
Requesting historical data for August 2018, e.g. would not work because pandas decided to return an Index instead of a DateTimeIndex.
This should fix that by manually coercing it.
```
>>> cal = USFederalHolidayCalendar()
>>> cal.holidays(start=datetime.date(2021,8,1), end=datetime.date(2021,8,31))
DatetimeIndex([], dtype='datetime64[ns]', freq=None)
>>> cal.holidays(start=datetime.date(2020,8,1), end=datetime.date(2020,8,31))
DatetimeIndex([], dtype='datetime64[ns]', freq=None)
>>> cal.holidays(start=datetime.date(2019,8,1), end=datetime.date(2019,8,31))
DatetimeIndex([], dtype='datetime64[ns]', freq=None)
>>> cal.holidays(start=datetime.date(2018,8,1), end=datetime.date(2018,8,31))
Index([], dtype='object')
```