### PR TITLE
Change badge display source workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: pull_request
+on:  
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   frontend:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: lint
 
-on: pull_request
+on:  
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   frontend:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-## TransitMatters Data Dashboard
+# TransitMatters Data Dashboard
 
-![lint](https://github.com/transitmatters/t-performance-dash/workflows/lint/badge.svg)
-![build](https://github.com/transitmatters/t-performance-dash/workflows/build/badge.svg)
-![deploy](https://github.com/transitmatters/t-performance-dash/workflows/deploy/badge.svg)
+![lint](https://github.com/transitmatters/t-performance-dash/workflows/lint/badge.svg?branch=main)
+![build](https://github.com/transitmatters/t-performance-dash/workflows/build/badge.svg?branch=main)
+![deploy](https://github.com/transitmatters/t-performance-dash/workflows/deploy/badge.svg?branch=main)
 
 This is the repository for the TransitMatters Data Dashboard. Client code is written in JavaScript with React, and the backend is written in Python with Chalice.
 


### PR DESCRIPTION
Right now, the README badges display the status of the most recent workflow run, including those on PRs. This means that it sometimes appears that things are failing when they actually aren't. This PR adds a lint and build run to each push to `main` and updates the badges to only show workflows run against `main` so the badges reflect only the `main` branch.