### PR TITLE
Add healthcheck to GitHub Actions

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,33 +1,13 @@
 name: healthcheck
 
-on:  
-  pull_request:
-  push:
-    branches:
-      - main
+on:
+  schedule:
+    - cron: '15 23 * * *' # 7:15PM EST every day
 
 jobs:
   backend:
-    runs-on: ubuntu-latest
-    env:
-      MBTA_V2_API_KEY: ${{ secrets.MBTA_V2_API_KEY }}
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.9
-      - name: Set up Node 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Setup local server deployment and run healthcheck
+      - name: Run backend healthcheck
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          npm install
-          echo Server deploying - sleeping for 1 min before testing...
-          npm start &
-          sleep 60
-          curl -w "\n" http://localhost:3000/healthcheck
-          curl -f http://localhost:3000/healthcheck
+          curl --fail-with-body https://dashboard-api2.transitmatters.org/healthcheck

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  frontend:
+  healthcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -24,5 +24,6 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
           npm install
-          npm start
+          npm start &
+          sleep 60
           curl -f http://localhost:3000/healthcheck

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,28 @@
+name: healthcheck
+
+on:  
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Set up Node 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Setup local server deployment and run healthcheck
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          npm install
+          npm start
+          curl -f http://localhost:3000/healthcheck

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -24,7 +24,8 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
           npm install
+          echo Server deploying - sleeping for 1 min before testing...
           npm start &
-          echo "Server deployed - sleeping for 1 min before testing..."
           sleep 60
-          curl --fail-with-body http://localhost:3000/healthcheck
+          curl http://localhost:3000/healthcheck
+          curl -f http://localhost:3000/healthcheck

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
+    env:
+      MBTA_V2_API_KEY: ${{ secrets.MBTA_V2_API_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  healthcheck:
+  backend:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -25,5 +25,6 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           npm install
           npm start &
+          echo "Server deployed - sleeping for 1 min before testing..."
           sleep 60
-          curl -f http://localhost:3000/healthcheck
+          curl --fail-with-body http://localhost:3000/healthcheck

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -29,5 +29,5 @@ jobs:
           echo Server deploying - sleeping for 1 min before testing...
           npm start &
           sleep 60
-          curl http://localhost:3000/healthcheck
+          curl -w "\n" http://localhost:3000/healthcheck
           curl -f http://localhost:3000/healthcheck

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![lint](https://github.com/transitmatters/t-performance-dash/workflows/lint/badge.svg?branch=main)
 ![build](https://github.com/transitmatters/t-performance-dash/workflows/build/badge.svg?branch=main)
+![healthcheck](https://github.com/transitmatters/t-performance-dash/workflows/healthcheck/badge.svg?branch=main)
 ![deploy](https://github.com/transitmatters/t-performance-dash/workflows/deploy/badge.svg?branch=main)
 
 This is the repository for the TransitMatters Data Dashboard. Client code is written in JavaScript with React, and the backend is written in Python with Chalice.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![lint](https://github.com/transitmatters/t-performance-dash/workflows/lint/badge.svg?branch=main)
 ![build](https://github.com/transitmatters/t-performance-dash/workflows/build/badge.svg?branch=main)
-![healthcheck](https://github.com/transitmatters/t-performance-dash/workflows/healthcheck/badge.svg?branch=main)
 ![deploy](https://github.com/transitmatters/t-performance-dash/workflows/deploy/badge.svg?branch=main)
+![healthcheck](https://github.com/transitmatters/t-performance-dash/workflows/healthcheck/badge.svg)
 
 This is the repository for the TransitMatters Data Dashboard. Client code is written in JavaScript with React, and the backend is written in Python with Chalice.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "t-dash",
-  "version": "0.1.0",
+  "name": "t-performance-dash",
+  "version": "3.3.0",
   "private": true,
   "dependencies": {
     "@tippyjs/react": "^4.0.2",

--- a/server/app.py
+++ b/server/app.py
@@ -2,11 +2,12 @@ import json
 import os
 import subprocess
 from chalice import Chalice, CORSConfig, ConflictError, Response
-from datetime import date
+from datetime import date, timedelta
 from chalicelib import (
     aggregation,
     data_funcs,
-    secrets,
+    MbtaPerformanceAPI,
+    secrets
 )
 
 app = Chalice(app_name="data-dashboard")
@@ -37,7 +38,8 @@ def healthcheck():
     # These functions must return True or False :-)
     checks = {
         "API Key Present": (lambda: len(secrets.MBTA_V2_API_KEY) > 0),
-        "S3 Headway Fetching": (lambda: "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"])))
+        "S3 Headway Fetching": (lambda: "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"]))),
+        "Performance API Check": (lambda: MbtaPerformanceAPI.get_api_data("headways", {"stop": [70067]}, date.today() - timedelta(days=1), date.today()))
     }
 
     failed_checks = {}

--- a/server/app.py
+++ b/server/app.py
@@ -40,13 +40,14 @@ def healthcheck():
         "S3 Alert Fetching": (lambda: "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"])))
     }
 
-    failed_checks = []
+    failed_checks = {}
     for check in checks:
         try:
-            if not checks[check]():
-                failed_checks += [check]
-        except Exception:
-            failed_checks += [check]
+            check_bool = checks[check]()
+            if not check_bool:
+                failed_checks[check] = "Check ran successfully but failed :("
+        except Exception as e:
+            failed_checks[check] = f"Check failed to run: {e}"
 
     if len(failed_checks) == 0:
         return Response(body={

--- a/server/app.py
+++ b/server/app.py
@@ -47,9 +47,9 @@ def healthcheck():
         try:
             check_bool = checks[check]()
             if not check_bool:
-                failed_checks[check] = "Check ran successfully but failed :("
+                failed_checks[check] = "Check failed :("
         except Exception as e:
-            failed_checks[check] = f"Check failed to run: {e}"
+            failed_checks[check] = f"Check threw an exception: {e}"
 
     if len(failed_checks) == 0:
         return Response(body={

--- a/server/app.py
+++ b/server/app.py
@@ -44,7 +44,7 @@ def healthcheck():
     for check in checks:
         try:
             if not checks[check]():
-                failed_checks += check
+                failed_checks += [check]
         except Exception:
             failed_checks += [check]
 

--- a/server/app.py
+++ b/server/app.py
@@ -37,7 +37,7 @@ def healthcheck():
     # These functions must return True or False :-)
     checks = {
         "API Key Present": (lambda: len(secrets.MBTA_V2_API_KEY) > 0),
-        "S3 Alert Fetching": (lambda: "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"])))
+        "S3 Headway Fetching": (lambda: "2020-11-07 10:33:40" in json.dumps(data_funcs.headways(date(year=2020, month=11, day=7), ["70061"])))
     }
 
     failed_checks = {}

--- a/server/app.py
+++ b/server/app.py
@@ -50,8 +50,8 @@ def healthcheck():
 
     if len(failed_checks) == 0:
         return Response(body={
-        "status": "pass"
-    }, status_code=200)
+            "status": "pass"
+        }, status_code=200)
 
     return Response(body={
         "status": "fail",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "t-performance-dash"
-version = "1.0.0"
-description = ""
+version = "3.3.0"
+description = "TransitMatters performance visualizer for the MBTA"
 authors = ["TransitMatters Labs Team"]
 license = "MIT"
 


### PR DESCRIPTION
This is a quick and dirty CI implementation using the `/healthcheck` endpoint introduced in #88 

Very open to suggestions here - for example right now the job is running on PRs and merges to `main`, but we could also have it be an independent job that fires on a [schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) instead.