### PR TITLE
Slowzone links fix

### DIFF
--- a/src/slowzones/formattingUtils.ts
+++ b/src/slowzones/formattingUtils.ts
@@ -65,7 +65,7 @@ const getDashUrl = (d: any) => {
   }
   now = now.toISOString().split('T')[0];
 
-  return `https://dashboard.transitmatters.org/rapidtransit?config=${d.custom.color},${d.custom.fr_id},${d.custom.to_id},${then},${now}`;
+  return new URL(`/rapidtransit?config=${d.custom.color},${d.custom.fr_id},${d.custom.to_id},${then},${now}`, window.location.origin);
 };
 
 const getDirection = (to: any, from: any) => {


### PR DESCRIPTION
Fix for Issue #237 

Changed the links on the slowzones page to link to the current URL rather than always linking to production.