### PR TITLE
Prevent update on selection of same date

### DIFF
--- a/src/inputs/date.tsx
+++ b/src/inputs/date.tsx
@@ -46,7 +46,9 @@ const FlatpickrDateSelect: React.FC<DateInputProps> = ({
       placeholder={placeholder}
       options={{ enableTime: false, ...options }}
       onChange={(dates, currentDateString) => {
-        onChange(currentDateString);
+        if(currentDateString !== value) {
+          onChange(currentDateString);
+        }
       }}
     />
   );


### PR DESCRIPTION
Issue #121: The Flatpickr object was firing onChange for date selection even when the currently selected date was chosen.

This is because Flatpickr always fires onChange on selection of a date ([doc]( https://flatpickr.js.org/events/)). Our `DatePicker` object has a separate element for use on mobile `RegularDateInput` which does not have this issue. So I added logic only on the Flatpickr. Not sure if it would be more clear to do just do it on both or leave a comment explaining this in the code. lmk.