### PR TITLE
reduce history memory

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -236,14 +236,12 @@ class App extends React.Component {
     // Get updated URL
     const url = urlFromConfig(newConfiguration);
 
-    // Save to browser history only if we are leaving a complete configuration.
-    // So we check this.state because it has the values from before the current change.
-    const complete = formIsComplete(this.state.configuration);
-    const empty = formIsEmpty(this.state.configuration);
-    if(empty) {
+    // If the form is empty, we want to push an empty configuration to the history stack. This allows us to go back to the empty dashboard.
+    if(formIsEmpty(this.state.configuration)) {
       this.props.history.push(url, {configuration: {bus_mode: config_change.bus_mode || this.state.bus_mode }});
     } else {
-      if (complete) {
+      // Save to browser history only if we are leaving a complete configuration.
+      if (formIsComplete(this.state.configuration)) {
         this.props.history.push(url, update);
       } else {
         this.props.history.replace(url, update);

--- a/src/App.js
+++ b/src/App.js
@@ -59,13 +59,8 @@ const urlFromConfig = (config) => {
   const path = config.bus_mode ? BUS_PATH : RAPIDTRANSIT_PATH;
   const query = getQueryStrings(config);
 
-  // If the form is incomplete return the URL without a query.
-  if (!formIsComplete(config)) {
-    return path;
-  }
-
-  // Remove empty fields from array. Can only be end_date.
-  const queryString = query.filter((x) => x).join(',');
+  // Remove empty fields from array.
+  const queryString = query.join(',');
   return `${path}?config=${queryString}`;
 };
 
@@ -220,6 +215,15 @@ class App extends React.Component {
       configuration: newConfiguration,
     };
 
+    // If line is changed, reset data and from/to fields.
+    if ('line' in config_change && config_change.line !== this.state.configuration.line) {
+      newConfiguration.from = null;
+      newConfiguration.to = null;
+      update.headways = [];
+      update.traveltimes = [];
+      update.dwells = [];
+    }
+
     // Get updated URL
     const url = urlFromConfig(newConfiguration);
 
@@ -239,13 +243,6 @@ class App extends React.Component {
       refetch = false;
     }
 
-    if ('line' in config_change && config_change.line !== this.state.configuration.line) {
-      update.configuration.from = null;
-      update.configuration.to = null;
-      update.headways = [];
-      update.traveltimes = [];
-      update.dwells = [];
-    }
     this.setState(
       (state) => ({
         progressBarKey: state.progressBarKey + 1,

--- a/src/App.js
+++ b/src/App.js
@@ -129,8 +129,7 @@ class App extends React.Component {
 
     const url_config = new URLSearchParams(props.location.search).get('config');
     if (typeof url_config === 'string') {
-      const config = stateFromURL(props.location.pathname, url_config);
-      this.state.configuration = config
+      this.state.configuration = stateFromURL(props.location.pathname, url_config);
       this.state.error_message = this.checkForErrors(this.state.configuration);
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -139,7 +139,6 @@ class App extends React.Component {
 
     // Handle back/forward buttons
     window.onpopstate = (e) => {
-      console.log(e.state?.state)
       this.setState(e.state?.state, () => {
         this.download();
       });

--- a/src/StationConfiguration.js
+++ b/src/StationConfiguration.js
@@ -89,12 +89,12 @@ export class StationConfiguration extends React.Component {
     }
     if (type === "from") {
       const toStation = this.getVal("to");
-      return options_station_ui(this.props.current.line).filter(entry => entry.value !== toStation);
+      return options_station_ui(this.props.current.line).filter(entry => entry.value?.stop_name !== toStation?.stop_name);
     }
     if (type === "to") {
       const fromStation = this.getVal("from");
       return options_station_ui(this.props.current.line).filter(({ value }) => {
-        if (value === fromStation) {
+        if (value?.stop_name === fromStation?.stop_name) {
           return false;
         }
         if (fromStation && fromStation.branches && value.branches) {


### PR DESCRIPTION
Issue #126 

**Issue:**
React router history was storing all of the current app state in the browser. This included all data points in any visualization shown.

**Fix:**
Changed history to only save configuration and error message.

**Other Changes:**
- I was having a hard time understanding the code which was dealing with history and updating the URL query parameters. If people don't think the changes I made are improvements, I'm happy to remove them.
- One change was to remove the trailing comma at the end of the links when there is no `end_date`. Like this one: `/rapidtransit?config=Red,70061,70067,2022-11-09,` will now be: `/rapidtransit?config=Red,70061,70067,2022-11-09`
- Another change was to not add any parameters to the URL Query when the form is not complete. I figured there is no need to have a URL such as this one: `/rapidtransit?config=Red,,,,` which just links to an empty dashboard with the red line selected.
- Removed `update.error` field, as it was not being used anywhere.

I think it might be good to transition away from using an array of values as a single query parameter. If we need to add another optional field like `end_date` it will be easier to do so without adjusting the ordering of all the fields. I can make a ticket for this if there is agreement.
