### PR TITLE
V4 single day fetch

### DIFF
--- a/api/datadashboard.ts
+++ b/api/datadashboard.ts
@@ -1,14 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
 import { SingleDayDataPoint } from '../src/charts/types';
-import { SingleDayAPIOptions } from '../types/api';
+import { QueryNameOptions, SingleDayAPIOptions } from '../types/api';
 import { APP_DATA_BASE_PATH } from '../utils/constants';
 
 // Date isn't really optional. If date is not set this query will be disabled.
 // Just setting it as optional because dashboard loads this before user input.
-export const fetchSingleDayData = (name: string, options: SingleDayAPIOptions, date?: string,): Promise<SingleDayDataPoint[]> => {
-    const url = new URL(`${APP_DATA_BASE_PATH}/${name}/${date}`, window.location.origin);
+export const fetchSingleDayData = (
+  name: string,
+  options: SingleDayAPIOptions,
+  date?: string | null
+): Promise<SingleDayDataPoint[]> => {
+  const url = new URL(`${APP_DATA_BASE_PATH}/${name}/${date}`, window.location.origin);
 
-    Object.entries(options).forEach(([key, value]) => {
-        value?.forEach((subvalue) => url.searchParams.append(key, subvalue))
-    });
-    return fetch(url).then((resp) => resp.json());
+  Object.entries(options).forEach(([key, value]) => {
+    value?.forEach((subvalue) => url.searchParams.append(key, subvalue));
+  });
+  return fetch(url).then((resp) => resp.json());
+};
+
+export const useQuerySingleDayData = (
+  params: SingleDayAPIOptions,
+  name: QueryNameOptions,
+  queryReady: boolean,
+  date?: string
+) => {
+  const queryKeys = [name, date];
+  Object.entries(params).forEach(([key, value]) => queryKeys.push(key, value?.toString()));
+  return useQuery({
+    enabled: queryReady,
+    queryKey: queryKeys,
+    queryFn: () => fetchSingleDayData(name, params, date),
+  });
 };

--- a/api/datadashboard.ts
+++ b/api/datadashboard.ts
@@ -1,0 +1,14 @@
+import { SingleDayDataPoint } from '../src/charts/types';
+import { SingleDayAPIOptions } from '../types/api';
+import { APP_DATA_BASE_PATH } from '../utils/constants';
+
+// Date isn't really optional. If date is not set this query will be disabled.
+// Just setting it as optional because dashboard loads this before user input.
+export const fetchSingleDayData = (name: string, options: SingleDayAPIOptions, date?: string,): Promise<SingleDayDataPoint[]> => {
+    const url = new URL(`${APP_DATA_BASE_PATH}/${name}/${date}`, window.location.origin);
+
+    Object.entries(options).forEach(([key, value]) => {
+        value?.forEach((subvalue) => url.searchParams.append(key, subvalue))
+    });
+    return fetch(url).then((resp) => resp.json());
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,19 @@
 'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import { Layout } from '../components/Layout';
 import '../styles/dashboard.css';
 import '../styles/globals.css';
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 0,
+      staleTime: 10000, // 10 seconds
+    },
+  },
+});
 
 export default function RootLayout({
   // Layouts must accept a children prop.
@@ -14,13 +23,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="h-full bg-gray-100 font-sans">
+    <html lang="en" className="font-sans h-full bg-gray-100">
       <head>
         <title>Dashboard</title>
       </head>
       <body className="h-full ">
         <QueryClientProvider client={queryClient}>
           <Layout>{children}</Layout>
+          <ReactQueryDevtools />
         </QueryClientProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState } from 'react';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { AlertBar } from '../components/alerts/AlertBar';
 import { DateInput } from '../components/inputs/DateInput';
 import { Select } from '../components/inputs/Select';
@@ -89,14 +88,19 @@ export default function Home() {
       </div>
       <AlertBar alerts={alerts} today={'2022-10-11'} isLoading={false} />
       <div className="px-4">
-        {dateSelection?.endDate ?
+        {dateSelection?.endDate ? (
           <AggregatePage dateSelection={dateSelection} />
-          :
-          <SingleDayPage configuration={{ fromStation: fromStation?.value, toStation: toStation?.value, dateSelection: dateSelection }} />
-        }
+        ) : (
+          <SingleDayPage
+            configuration={{
+              fromStation: fromStation?.value,
+              toStation: toStation?.value,
+              dateSelection: dateSelection,
+            }}
+          />
+        )}
       </div>
       {/* Only loads in development */}
-      <ReactQueryDevtools />
     </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { AlertBar } from '../components/alerts/AlertBar';
-import { AggregateLineChart } from '../components/dashboard/charts/AggregateLineChart';
-import { SingleDayLineChart } from '../components/dashboard/charts/SingleDayLineChart';
 import { DateInput } from '../components/inputs/DateInput';
 import { Select } from '../components/inputs/Select';
 import alerts from '../data/alerts.json';
 import { DateOption, SelectOption } from '../types/inputs';
 import { optionsForField, swapStations } from '../utils/stations';
-import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../src/charts/types';
-import { COLORS } from '../constants/colors';
 import { AggregatePage } from '../components/dashboard/charts/AggregatePage';
 import { SingleDayPage } from '../components/dashboard/charts/SingleDayPage';
 
@@ -95,9 +92,11 @@ export default function Home() {
         {dateSelection?.endDate ?
           <AggregatePage dateSelection={dateSelection} />
           :
-          <SingleDayPage />
+          <SingleDayPage configuration={{ fromStation: fromStation?.value, toStation: toStation?.value, dateSelection: dateSelection }} />
         }
       </div>
+      {/* Only loads in development */}
+      <ReactQueryDevtools />
     </>
   );
 }

--- a/components/dashboard/charts/AggregateLineChart.tsx
+++ b/components/dashboard/charts/AggregateLineChart.tsx
@@ -35,13 +35,13 @@ ChartJS.register(
 
 const xAxisLabel = (startDate: string, endDate: string, hourly: boolean) => {
   if (hourly) {
-    return `${prettyDate(startDate, false)} – ${prettyDate(endDate, false)}`;
+    return `${prettyDate(startDate, false)} – ${prettyDate(endDate, false)}`
   } else {
-    const y1 = startDate.split('-')[0];
-    const y2 = endDate.split('-')[0];
-    return y1 === y2 ? y1 : `${y1} – ${y2}`;
+    const y1 = startDate.split("-")[0];
+    const y2 = endDate.split("-")[0];
+    return (y1 === y2) ? y1 : `${y1} – ${y2}`;
   }
-};
+}
 
 export const AggregateLineChart: React.FC<AggregateLineProps> = ({
   chartId,

--- a/components/dashboard/charts/AggregateLineChart.tsx
+++ b/components/dashboard/charts/AggregateLineChart.tsx
@@ -35,13 +35,13 @@ ChartJS.register(
 
 const xAxisLabel = (startDate: string, endDate: string, hourly: boolean) => {
   if (hourly) {
-    return `${prettyDate(startDate, false)} – ${prettyDate(endDate, false)}`
+    return `${prettyDate(startDate, false)} – ${prettyDate(endDate, false)}`;
   } else {
-    const y1 = startDate.split("-")[0];
-    const y2 = endDate.split("-")[0];
-    return (y1 === y2) ? y1 : `${y1} – ${y2}`;
+    const y1 = startDate.split('-')[0];
+    const y2 = endDate.split('-')[0];
+    return y1 === y2 ? y1 : `${y1} – ${y2}`;
   }
-}
+};
 
 export const AggregateLineChart: React.FC<AggregateLineProps> = ({
   chartId,

--- a/components/dashboard/charts/SingleDayLineChart.tsx
+++ b/components/dashboard/charts/SingleDayLineChart.tsx
@@ -159,7 +159,7 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                   type: 'time',
                   time: {
                     unit: 'hour',
-                    tooltipFormat: 'LTS', // locale time with seconds
+                    tooltipFormat: 'h:mm:ss a', // locale time with seconds
                   },
                   adapters: {
                     date: {
@@ -190,6 +190,20 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
               {
                 id: 'customTitle',
                 afterDraw: (chart) => {
+                  if (date.length === 0 && !isLoading) {
+                    // No data is present
+                    const ctx = chart.ctx;
+                    const width = chart.width;
+                    const height = chart.height;
+                    chart.clear();
+
+                    ctx.save();
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.font = "16px normal 'Helvetica Nueue'";
+                    ctx.fillText('No data to display', width / 2, height / 2);
+                    ctx.restore();
+                  }
                   drawTitle(
                     title,
                     { to: 'Park Street', from: 'Porter', direction: 'southbound', line: 'Red' },

--- a/components/dashboard/charts/SingleDayLineChart.tsx
+++ b/components/dashboard/charts/SingleDayLineChart.tsx
@@ -173,35 +173,33 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                   },
 
                   afterDataLimits: (axis) => {
-                        const today = new Date(`${date}T00:00:00`);
-                        const low = new Date(today);
-                        low.setHours(6);
-                        axis.min = Math.min(axis.min, low.valueOf());
-                        const high = new Date(today);
-                        high.setDate(high.getDate() + 1);
-                        high.setHours(1);
-                        axis.max = Math.max(axis.max, high.valueOf());
-                      }
-                    },
-                  },
-                 animation:false, 
-                }
-              }
-            plugins={
-                [
-                {
-                  id: 'customTitle',
-                  afterDraw: (chart) => {
-                    drawTitle(
-                      title,
-                      { to: 'Park Street', from: 'Porter', direction: 'southbound', line: 'Red' },
-                      bothStops,
-                      chart
-                    );
+                    const today = new Date(`${date}T00:00:00`);
+                    const low = new Date(today);
+                    low.setHours(6);
+                    axis.min = Math.min(axis.min, low.valueOf());
+                    const high = new Date(today);
+                    high.setDate(high.getDate() + 1);
+                    high.setHours(1);
+                    axis.max = Math.max(axis.max, high.valueOf());
                   },
                 },
+              },
+              animation: false,
+            }}
+            plugins={[
+              {
+                id: 'customTitle',
+                afterDraw: (chart) => {
+                  drawTitle(
+                    title,
+                    { to: 'Park Street', from: 'Porter', direction: 'southbound', line: 'Red' },
+                    bothStops,
+                    chart
+                  );
+                },
+              },
             ]}
-              />
+          />
         </div>
         <div className="chart-extras">{benchmarkField && <LegendView />}</div>
       </div>

--- a/components/dashboard/charts/SingleDayLineChart.tsx
+++ b/components/dashboard/charts/SingleDayLineChart.tsx
@@ -72,9 +72,12 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
   chartId,
   title,
   data,
+  date,
   metricField,
-  benchmarkField,
   pointField,
+  benchmarkField,
+  // TODO: loading animation?
+  isLoading,
   bothStops = false,
 }) => {
   const labels = data.map((item) => item[pointField]);
@@ -166,25 +169,39 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                   display: true,
                   title: {
                     display: true,
-                    text: prettyDate('2022-10-17', true),
+                    text: prettyDate(date, true),
+                  },
+
+                  afterDataLimits: (axis) => {
+                        const today = new Date(`${date}T00:00:00`);
+                        const low = new Date(today);
+                        low.setHours(6);
+                        axis.min = Math.min(axis.min, low.valueOf());
+                        const high = new Date(today);
+                        high.setDate(high.getDate() + 1);
+                        high.setHours(1);
+                        axis.max = Math.max(axis.max, high.valueOf());
+                      }
+                    },
+                  },
+                 animation:false, 
+                }
+              }
+            plugins={
+                [
+                {
+                  id: 'customTitle',
+                  afterDraw: (chart) => {
+                    drawTitle(
+                      title,
+                      { to: 'Park Street', from: 'Porter', direction: 'southbound', line: 'Red' },
+                      bothStops,
+                      chart
+                    );
                   },
                 },
-              },
-            }}
-            plugins={[
-              {
-                id: 'customTitle',
-                afterDraw: (chart) => {
-                  drawTitle(
-                    title,
-                    { to: 'Park Street', from: 'Porter', direction: 'southbound', line: 'Red' },
-                    bothStops,
-                    chart
-                  );
-                },
-              },
             ]}
-          />
+              />
         </div>
         <div className="chart-extras">{benchmarkField && <LegendView />}</div>
       </div>

--- a/components/dashboard/charts/SingleDayPage.tsx
+++ b/components/dashboard/charts/SingleDayPage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
 
 import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../../../src/charts/types';
 import { stopIdsForStations } from '../../../utils/stations';
-import { fetchSingleDayData } from '../../../api/datadashboard';
+import { useQuerySingleDayData } from '../../../api/datadashboard';
 import { Station } from '../../../types/stations';
+import { QueryNameKeys, SingleDayAPIKeys } from '../../../types/api';
 import { DateOption } from '../../../types/inputs';
 import { SingleDayLineChart } from './SingleDayLineChart';
 
@@ -20,30 +20,35 @@ export const SingleDayPage: React.FC<SingleDayPageProps> = ({ configuration }) =
   const { fromStation, toStation, dateSelection } = configuration;
   const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
   const date = dateSelection?.startDate;
-  const queryReady = !!(fromStopIds && date);
+  const queryIsReady = !!(fromStopIds && date);
 
-  //TODO: deal with errors
-  const headwaysRequest = useQuery({
-    refetchOnWindowFocus: false,
-    enabled: queryReady,
-    queryKey: ['headways', fromStopIds, date],
-    queryFn: () => fetchSingleDayData('headways', { stop: fromStopIds }, date),
-  });
-  const traveltimesRequest = useQuery({
-    refetchOnWindowFocus: false,
-    enabled: queryReady,
-    queryKey: ['traveltimes', fromStopIds, toStopIds, date],
-    queryFn: () =>
-      fetchSingleDayData('traveltimes', { from_stop: fromStopIds, to_stop: toStopIds }, date),
-  });
-  const dwellsRequest = useQuery({
-    refetchOnWindowFocus: false,
-    enabled: queryReady,
-    queryKey: ['dwells', fromStopIds, date],
-    queryFn: () => fetchSingleDayData('dwells', { stop: fromStopIds }, date),
-  });
+  const traveltimesRequest = useQuerySingleDayData(
+    {
+      [SingleDayAPIKeys.fromStop]: fromStopIds,
+      [SingleDayAPIKeys.toStop]: toStopIds,
+    },
+    QueryNameKeys.traveltimes,
+    queryIsReady,
+    date
+  );
+  const headwaysRequest = useQuerySingleDayData(
+    {
+      [SingleDayAPIKeys.stop]: fromStopIds,
+    },
+    QueryNameKeys.headways,
+    queryIsReady,
+    date
+  );
+  const dwellsRequest = useQuerySingleDayData(
+    {
+      [SingleDayAPIKeys.stop]: fromStopIds,
+    },
+    QueryNameKeys.dwells,
+    queryIsReady,
+    date
+  );
 
-  if (!queryReady) {
+  if (!queryIsReady) {
     //TODO: Add something nice here when no charts are loaded.
     return <p> select values to load charts.</p>;
   }

--- a/components/dashboard/charts/SingleDayPage.tsx
+++ b/components/dashboard/charts/SingleDayPage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 
-import { SingleDayLineChart } from './SingleDayLineChart';
 import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../../../src/charts/types';
 import { stopIdsForStations } from '../../../utils/stations';
 import { fetchSingleDayData } from '../../../api/datadashboard';
-import { useQuery } from '@tanstack/react-query';
 import { Station } from '../../../types/stations';
 import { DateOption } from '../../../types/inputs';
+import { SingleDayLineChart } from './SingleDayLineChart';
 
 interface SingleDayPageProps {
   configuration: {

--- a/components/inputs/DateInput.tsx
+++ b/components/inputs/DateInput.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { DateOption } from '../../types/inputs';
 import { formatDate } from '../utils/Date';
 
-function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ');
-}
-
 interface DateInputProps {
   dateSelection: DateOption | null;
   setDateSelection: (dateSelection: DateOption | null) => void;

--- a/components/inputs/DateInput.tsx
+++ b/components/inputs/DateInput.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { DateOption } from '../../types/inputs';
 import { formatDate } from '../utils/Date';
 
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}
+
 interface DateInputProps {
   dateSelection: DateOption | null;
   setDateSelection: (dateSelection: DateOption | null) => void;
@@ -16,44 +20,77 @@ export const DateInput: React.FC<DateInputProps> = ({ dateSelection, setDateSele
       <input
         type="date"
         className=""
-        onChange={(event) =>
-          setDateSelection({
-            ...dateSelection,
-            startDate: event.target.value,
-          })
-        }
+        onChange={(event) => setDateSelection({ ...dateSelection, startDate: event.target.value })}
         max={formatDate(new Date())}
       />
       {/* TODO: Dynamically set the color based on the selected line */}
-      {dateSelection?.range ? (
-        <span className="flex flex-row">
-          <label className="block text-sm font-medium text-gray-700">{'To'}</label>
-          <span>
-            <input
-              type="date"
-              className=""
-              onChange={(event) => {
-                setDateSelection({ ...dateSelection, endDate: event.target.value });
-              }}
-              max={formatDate(new Date())}
-            />
-            <button
-              onClick={() =>
-                setDateSelection({ ...dateSelection, endDate: undefined, range: false })
-              }
-            >
-              🅧
-            </button>
+      {
+        dateSelection?.range ? (
+          <span className="flex flex-row">
+            <label className="block text-sm font-medium text-gray-700">{'To'}</label>
+            <span>
+              <input
+                type="date"
+                className=""
+                onChange={(event) => {
+                  setDateSelection({ ...dateSelection, endDate: event.target.value });
+                }}
+                max={formatDate(new Date())}
+              />
+              <button
+                onClick={() =>
+                  setDateSelection({ ...dateSelection, endDate: undefined, range: false })
+                }
+              >
+                🅧
+              </button>
+            </span>
           </span>
-        </span>
-      ) : (
-        <button
-          className="rounded border border-mbta-red bg-transparent py-2 px-4 font-medium text-gray-700 hover:border-transparent hover:bg-mbta-red hover:text-white"
-          onClick={() => setDateSelection({ ...dateSelection, range: true })}
-        >
-          Range...
-        </button>
-      )}
+        ) : (
+          <button
+            className="rounded border border-mbta-red bg-transparent py-2 px-4 font-medium text-gray-700 hover:border-transparent hover:bg-mbta-red hover:text-white"
+            onClick={() => setDateSelection({ ...dateSelection, range: true })}
+          >
+            Range...
+          </button>
+        )
+        //x button
+      }
     </div>
+
+    // <div className="option option-date">
+    //     <span className="date-label">Date</span>
+    //     <DatePicker
+    //         value={this.getVal('date_start') || ''}
+    //         onChange={this.handleSelectOption('date_start')}
+    //         options={availableDates}
+    //         placeholder="Select date..."
+    //     />
+    //     <button
+    //         className="more-options-button"
+    //         style={this.state.show_date_end_picker ? { display: 'none' } : {}}
+    //         onClick={() => this.setState({ show_date_end_picker: true })}
+    //     >
+    //         Range...
+    //     </button>
+    //     {!!this.state.show_date_end_picker && (
+    //         <>
+    //             <span className="date-label end-date-label">to</span>
+    //             <DatePicker
+    //                 value={this.getVal('date_end') || ''}
+    //                 onChange={this.handleSelectOption('date_end')}
+    //                 options={availableDates}
+    //                 placeholder="Select date..."
+    //             />
+    //             <button
+    //                 className="clear-button"
+    //                 style={{ visibility: this.state.show_date_end_picker ? 'visible' : 'hidden' }}
+    //                 onClick={this.clearMoreOptions}
+    //             >
+    //                 🅧
+    //             </button>
+    //         </>
+    //     )}
+    // </div>
   );
 };

--- a/components/utils/Date.tsx
+++ b/components/utils/Date.tsx
@@ -3,6 +3,7 @@ export const formatDate = (date: Date) => {
     date.getDate() < 10 ? '0' : ''
   }${date.getDate()}`;
 };
+
 export const prettyDate = (dateString: string, withDow: boolean) => {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,20 @@
 /** @type {import('next').NextConfig} */
+
+let rewrites = []
+// If running locally rewrite requests to server port (proxy).
+if(process.env.NODE_ENV === 'development') {
+  rewrites.push(
+    {
+      source: '/:path*',
+      destination: 'http://localhost:5000/:path*'
+    }
+  );
+}
+
 const nextConfig = {
+ async rewrites() {
+    return rewrites
+  },
   reactStrictMode: true,
   swcMinify: true,
   experimental: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^2.0.12",
         "@tanstack/react-query": "^4.13.0",
+        "@tanstack/react-query-devtools": "^4.16.1",
         "@tippyjs/react": "^4.2.6",
         "chart.js": "^3.9.1",
         "chartjs-adapter-date-fns": "^2.0.0",
@@ -448,21 +449,36 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
     "node_modules/@tanstack/query-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.13.0.tgz",
-      "integrity": "sha512-PzmLQcEgC4rl2OzkiPHYPC9O79DFcMGaKsOzDEP+U4PJ+tbkcEP+Z+FQDlfvX8mCwYC7UNH7hXrQ5EdkGlJjVg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.15.1.tgz",
+      "integrity": "sha512-+UfqJsNbPIVo0a9ANW0ZxtjiMfGLaaoIaL9vZeVycvmBuWywJGtSi7fgPVMCPdZQFOzMsaXaOsDtSKQD5xLRVQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.13.0.tgz",
-      "integrity": "sha512-dI/5hJ/pGQ74P5hxBLC9h6K0/Cap2T3k0ZjjjFLBCNnohDYgl7LNmMopzrRzBHk2mMjf2hgXHIzcKNG8GOZ5hg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.16.1.tgz",
+      "integrity": "sha512-PDE9u49wSDykPazlCoLFevUpceLjQ0Mm8i6038HgtTEKb/aoVnUZdlUP7C392ds3Cd75+EGlHU7qpEX06R7d9Q==",
       "dependencies": {
-        "@tanstack/query-core": "4.13.0",
+        "@tanstack/query-core": "4.15.1",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -481,6 +497,25 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.16.1.tgz",
+      "integrity": "sha512-VrDYLmG+OOcvGSZL5avG4R8jhqeMFP7pzW2sh2BWEV9UfI+aocG+CW8y8ygacxuKy48m8Tyo/xfe8H1z9BGb+g==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "8.1.1",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.16.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@tippyjs/react": {
@@ -1263,6 +1298,20 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.2.tgz",
+      "integrity": "sha512-CzATjGXzUQ0EvuvgOCI6A4BGOo2bcVx8B+eC2nF862iv9fopnPQwlrbACakNCHRIJbCSBj+J/9JeDf60k64MkA==",
+      "dependencies": {
+        "is-what": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/core-js-pure": {
@@ -2649,6 +2698,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.7.tgz",
+      "integrity": "sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3531,6 +3591,11 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3815,6 +3880,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.11.0.tgz",
+      "integrity": "sha512-6PfAg1FKhqkwWvPb2uXhH4MkMttdc17eJ91+Aoz4s1XUEDZFmLfFx/xVA3wgkPxAGy5dpozgGdK6V/n20Wj9yg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -4444,17 +4520,35 @@
         "mini-svg-data-uri": "^1.2.3"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
     "@tanstack/query-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.13.0.tgz",
-      "integrity": "sha512-PzmLQcEgC4rl2OzkiPHYPC9O79DFcMGaKsOzDEP+U4PJ+tbkcEP+Z+FQDlfvX8mCwYC7UNH7hXrQ5EdkGlJjVg=="
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.15.1.tgz",
+      "integrity": "sha512-+UfqJsNbPIVo0a9ANW0ZxtjiMfGLaaoIaL9vZeVycvmBuWywJGtSi7fgPVMCPdZQFOzMsaXaOsDtSKQD5xLRVQ=="
     },
     "@tanstack/react-query": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.13.0.tgz",
-      "integrity": "sha512-dI/5hJ/pGQ74P5hxBLC9h6K0/Cap2T3k0ZjjjFLBCNnohDYgl7LNmMopzrRzBHk2mMjf2hgXHIzcKNG8GOZ5hg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.16.1.tgz",
+      "integrity": "sha512-PDE9u49wSDykPazlCoLFevUpceLjQ0Mm8i6038HgtTEKb/aoVnUZdlUP7C392ds3Cd75+EGlHU7qpEX06R7d9Q==",
       "requires": {
-        "@tanstack/query-core": "4.13.0",
+        "@tanstack/query-core": "4.15.1",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.16.1.tgz",
+      "integrity": "sha512-VrDYLmG+OOcvGSZL5avG4R8jhqeMFP7pzW2sh2BWEV9UfI+aocG+CW8y8ygacxuKy48m8Tyo/xfe8H1z9BGb+g==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "8.1.1",
+        "superjson": "^1.10.0",
         "use-sync-external-store": "^1.2.0"
       }
     },
@@ -4986,6 +5080,14 @@
         "supports-color": "^8.1.0",
         "tree-kill": "^1.2.2",
         "yargs": "^17.3.1"
+      }
+    },
+    "copy-anything": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.2.tgz",
+      "integrity": "sha512-CzATjGXzUQ0EvuvgOCI6A4BGOo2bcVx8B+eC2nF862iv9fopnPQwlrbACakNCHRIJbCSBj+J/9JeDf60k64MkA==",
+      "requires": {
+        "is-what": "^4.1.6"
       }
     },
     "core-js-pure": {
@@ -5994,6 +6096,11 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-what": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.7.tgz",
+      "integrity": "sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6588,6 +6695,11 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6779,6 +6891,14 @@
       "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
       "requires": {
         "client-only": "0.0.1"
+      }
+    },
+    "superjson": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.11.0.tgz",
+      "integrity": "sha512-6PfAg1FKhqkwWvPb2uXhH4MkMttdc17eJ91+Aoz4s1XUEDZFmLfFx/xVA3wgkPxAGy5dpozgGdK6V/n20Wj9yg==",
+      "requires": {
+        "copy-anything": "^3.0.2"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@headlessui/react": "^1.7.3",
     "@heroicons/react": "^2.0.12",
     "@tanstack/react-query": "^4.13.0",
+    "@tanstack/react-query-devtools": "^4.16.1",
     "@tippyjs/react": "^4.2.6",
     "chart.js": "^3.9.1",
     "chartjs-adapter-date-fns": "^2.0.0",

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -1,59 +1,58 @@
 export interface SingleDayDataPoint {
-    route_id: string;
-    direction: number;
-    dep_dt?: string;
-    arr_dt?: string;
-    current_dep_dt?: string;
-    travel_time_sec?: number;
-    headway_time_sec?: number;
-    dwell_time_sec?: number;
-    benchmark_travel_time_sec?: number;
-    benchmark_headway_time_sec?: number;
-    threshold_flag_1?: string;
-  }
-  
-  export interface AggregateDataPoint {
-    '25%': number;
-    '50%': number;
-    '75%': number;
-    count: number;
-    max: number;
-    mean: number;
-    min: number;
-    std: number;
-    service_date?: string;
-    dep_time_from_epoch?: string;
-    is_peak_day?: boolean;
-  }
-  
-  export interface Location {
-    to: string;
-    from: string;
-    direction: Direction;
-    line: string;
-  }
-  
-  type Direction = 'northbound' | 'southbound' | 'eastbound' | 'westbound' | 'inbound' | 'outbound';
-  
-  export enum PointFieldKeys {
-    depDt = 'dep_dt',
-    currentDepDt = 'current_dep_dt',
-    arrDt = 'arr_dt',
-    serviceDate = 'service_date',
-    depTimeFromEpoch = 'dep_time_from_epoch',
-  }
-  
-  export enum MetricFieldKeys {
-    travelTimeSec = 'travel_time_sec',
-    headWayTimeSec = 'headway_time_sec',
-    dwellTimeSec = 'dwell_time_sec',
-  }
-  export enum BenchmarkFieldKeys {
-    benchmarkTravelTimeSec = 'benchmark_travel_time_sec',
-    benchmarkHeadwayTimeSec = 'benchmark_headway_time_sec',
-  }
+  route_id: string;
+  direction: number;
+  dep_dt?: string;
+  arr_dt?: string;
+  current_dep_dt?: string;
+  travel_time_sec?: number;
+  headway_time_sec?: number;
+  dwell_time_sec?: number;
+  benchmark_travel_time_sec?: number;
+  benchmark_headway_time_sec?: number;
+  threshold_flag_1?: string;
+}
 
-  export type PointField = PointFieldKeys;
-  export type MetricField = MetricFieldKeys;
-  export type BenchmarkField = BenchmarkFieldKeys;
-  
+export interface AggregateDataPoint {
+  '25%': number;
+  '50%': number;
+  '75%': number;
+  count: number;
+  max: number;
+  mean: number;
+  min: number;
+  std: number;
+  service_date?: string;
+  dep_time_from_epoch?: string;
+  is_peak_day?: boolean;
+}
+
+export interface Location {
+  to: string;
+  from: string;
+  direction: Direction;
+  line: string;
+}
+
+type Direction = 'northbound' | 'southbound' | 'eastbound' | 'westbound' | 'inbound' | 'outbound';
+
+export enum PointFieldKeys {
+  depDt = 'dep_dt',
+  currentDepDt = 'current_dep_dt',
+  arrDt = 'arr_dt',
+  serviceDate = 'service_date',
+  depTimeFromEpoch = 'dep_time_from_epoch',
+}
+
+export enum MetricFieldKeys {
+  travelTimeSec = 'travel_time_sec',
+  headWayTimeSec = 'headway_time_sec',
+  dwellTimeSec = 'dwell_time_sec',
+}
+export enum BenchmarkFieldKeys {
+  benchmarkTravelTimeSec = 'benchmark_travel_time_sec',
+  benchmarkHeadwayTimeSec = 'benchmark_headway_time_sec',
+}
+
+export type PointField = PointFieldKeys;
+export type MetricField = MetricFieldKeys;
+export type BenchmarkField = BenchmarkFieldKeys;

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,7 @@
+export enum SingleDayAPIKeys {
+  stop = 'stop',
+  fromStop = 'from_stop',
+  toStop = 'to_stop',
+}
+
+export type SingleDayAPIOptions = { [key in SingleDayAPIKeys]?: string[] | null }

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,7 +1,13 @@
+export enum QueryNameKeys {
+  traveltimes = 'traveltimes',
+  dwells = 'dwells',
+  headways = 'headways',
+}
+export type QueryNameOptions = QueryNameKeys;
+
 export enum SingleDayAPIKeys {
   stop = 'stop',
   fromStop = 'from_stop',
   toStop = 'to_stop',
 }
-
-export type SingleDayAPIOptions = { [key in SingleDayAPIKeys]?: string[] | null }
+export type SingleDayAPIOptions = { [key in SingleDayAPIKeys]?: string[] | null };

--- a/types/lines.ts
+++ b/types/lines.ts
@@ -1,32 +1,39 @@
-import { TimeUnit } from "chart.js"
-import React from "react"
-import { AggregateDataPoint, BenchmarkField, MetricField, PointField, SingleDayDataPoint } from "../src/charts/types"
+import { TimeUnit } from 'chart.js';
+import React from 'react';
+import {
+  AggregateDataPoint,
+  BenchmarkField,
+  MetricField,
+  PointField,
+  SingleDayDataPoint,
+} from '../src/charts/types';
 
 export interface LineProps {
-    title: string,
-    chartId: string,
-    location: any,
-    isLoading: any,
-    pointField: PointField; // X value
-    bothStops?: boolean,
-    fname: any,
+  title: string;
+  chartId: string;
+  location: any;
+  isLoading: any;
+  pointField: PointField; // X value
+  bothStops?: boolean;
+  fname: any;
 }
 
 export interface AggregateLineProps extends LineProps {
-    timeUnit: TimeUnit,
-    data: AggregateDataPoint[]
-    timeFormat: string,
-    seriesName: string,
-    startDate: any,
-    endDate: any,
-    fillColor: any,
-    suggestedYMin?: number,
-    suggestedYMax?: number,
-    children?: React.ReactNode,
+  timeUnit: TimeUnit;
+  data: AggregateDataPoint[];
+  timeFormat: string;
+  seriesName: string;
+  startDate: string;
+  endDate: string;
+  fillColor: any;
+  suggestedYMin?: number;
+  suggestedYMax?: number;
+  children?: React.ReactNode;
 }
 
 export interface SingleDayLineProps extends LineProps {
-    data: SingleDayDataPoint[],
-    metricField: MetricField, // Y value
-    benchmarkField?: BenchmarkField,
+  data: SingleDayDataPoint[];
+  metricField: MetricField; // Y value
+  date: string;
+  benchmarkField?: BenchmarkField;
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -5,13 +5,13 @@ export const stations: { [key: string]: LineMap } = stations_json;
 
 // Colors for charts
 export const CHART_COLORS = {
-    GREY: '#1c1c1c',
-    GREEN: '#64b96a',
-    YELLOW: '#f5ed00',
-    RED: '#c33149',
-    PURPLE: '#bb5cc1',
-    FILL: '#bfc8d680',
-    FILL_HOURLY: '#88aee680',
+  GREY: '#1c1c1c',
+  GREEN: '#64b96a',
+  YELLOW: '#f5ed00',
+  RED: '#c33149',
+  PURPLE: '#bb5cc1',
+  FILL: '#bfc8d680',
+  FILL_HOURLY: '#88aee680',
 };
 
 export const LINE_COLORS = {
@@ -28,4 +28,12 @@ export const colorsForLine: Record<string, string> = {
   blue: LINE_COLORS.BLUE,
   green: LINE_COLORS.GREEN,
   bus: LINE_COLORS.BUS,
-}
+};
+
+export const PRODUCTION = 'dashboard.transitmatters.org';
+export const BETA = 'dashboard-beta.transitmatters.org';
+const FRONTEND_TO_BACKEND_MAP = {
+  PRODUCTION: 'https://dashboard-api2.transitmatters.org',
+  BETA: 'https://dashboard-api-beta.transitmatters.org',
+};
+export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP[window.location.hostname] || '';

--- a/utils/stations.ts
+++ b/utils/stations.ts
@@ -66,3 +66,15 @@ export const lookup_station_by_id = (line: string, id: string) => {
     [...(x.stops['0'] || []), ...(x.stops['1'] || [])].includes(id)
   );
 };
+
+// TODO: Add types
+export const stopIdsForStations = (from: Station, to: Station): {fromStopIds: string[], toStopIds: string[]} | {fromStopIds: null, toStopIds: null} => {
+  if (!from || !to) {
+    return { fromStopIds: null, toStopIds: null };
+  }
+  const isDirection1 = from.order < to.order;
+  return {
+    fromStopIds: isDirection1 ? from.stops['1'] : from.stops['0'],
+    toStopIds: isDirection1 ? to.stops['1'] : to.stops['0'],
+  };
+};


### PR DESCRIPTION
Added queries to get data for single day charts. Haven't used these technologies before, so feedback is more than welcome.

TanStack has default behavior to refetch all queries on page focus. This meant if you switched tabs, clicked on dev tools, etc. then the data will be fetched when you return to the site. I disabled this on the queries I added. Not sure if people agree with that. Might be worth discussing.

I also added React Queries Dev tools. Shows up as a little flower icon on the page when in development. It didn't end up helping me much with the bug I was working on but it seems useful. I'm fine with keeping or removing it.

One really cool thing with react queries I didn't know about was the queryKeys. Lets you define what causes the query to refetch. So I set it up that headways and dwells don't rely on toStopIds changing, since the values won't change, as they only rely on fromStopIds.

I added a rewrite in next.config.js, which takes the place of the `proxy` we had before switching to next.js. It's included based on process.env.DEV_NODE === 'development'. Which is when the command `next dev` is used. Pretty sure that's what we want but if someone knows better lmk.
