### PR TITLE
Ignore TS Errors on build temporarily

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,12 +9,19 @@ if (process.env.NODE_ENV === 'development') {
   });
 }
 
+// This is to prevent typescript errors from failing the build while we set up v4.
+const tsSettings = { ignoreBuildErrors: false };
+if (process.env.V4_TEMP) {
+  tsSettings.ignoreBuildErrors = true;
+}
+
 const nextConfig = {
   async rewrites() {
     return rewrites;
   },
   reactStrictMode: true,
   swcMinify: true,
+  typescript: tsSettings,
   experimental: {
     appDir: true,
   },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "start-python": "cd server && poetry run chalice local --port=5000",
     "start-react": "next dev",
     "build": "next build && rm -rf build/static/slowzones",
+    "build-v4": "V4_TEMP=true next build && rm -rf build/static/slowzones",
     "get-sz-data": "npm run get-sz-totals && npm run get-szs",
     "get-sz-totals": "wget -N -x -nH -P public https://dashboard.transitmatters.org/static/slowzones/delay_totals.json",
     "get-szs": "wget -N -x -nH -P public https://dashboard.transitmatters.org/static/slowzones/all_slow.json",

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -36,4 +36,9 @@ const FRONTEND_TO_BACKEND_MAP = {
   PRODUCTION: 'https://dashboard-api2.transitmatters.org',
   BETA: 'https://dashboard-api-beta.transitmatters.org',
 };
-export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP[window.location.hostname] || '';
+let index = '';
+// This is to prevent a next js render error https://nextjs.org/docs/messages/prerender-error
+if (typeof window !== 'undefined') {
+  index = window.location.hostname;
+}
+export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP[index];


### PR DESCRIPTION
Temporary work-around to get the build to work while sorting out typescript issues. As per: https://transitmatters.slack.com/archives/GSJ6F35DW/p1673839728818259 @mathcolo 

I set it up to use a separate command to prevent us from accidentally deploying a build to prod with this workaround.


