### PR TITLE
Create DNS records as a part of deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -30,13 +30,14 @@ done
 
 $PRODUCTION && ENV_SUFFIX=""                                    || ENV_SUFFIX="-beta"
 $PRODUCTION && CHALICE_STAGE="production"                       || CHALICE_STAGE="beta"
-$PRODUCTION && DOMAIN_PREFIX=""                                 || DOMAIN_PREFIX="dashboard-beta."
 
 $PRODUCTION && FRONTEND_ZONE="dashboard.transitmatters.org"     || FRONTEND_ZONE="labs.transitmatters.org"
-$PRODUCTION && FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN"        || FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN_BETA"
+$PRODUCTION && FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN"        || FRONTEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
+$PRODUCTION && FRONTEND_DOMAIN_PREFIX=""                        || FRONTEND_DOMAIN_PREFIX="dashboard-beta."
 
 $PRODUCTION && BACKEND_ZONE="dashboard-api2.transitmatters.org" || BACKEND_ZONE="labs.transitmatters.org"
-$PRODUCTION && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN"          || BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN_BETA"
+$PRODUCTION && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN"          || BACKEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
+$PRODUCTION && BACKEND_DOMAIN_PREFIX=""                         || BACKEND_DOMAIN_PREFIX="dashboard-api-beta."
 
 
 # Fetch repository tags
@@ -60,12 +61,14 @@ else
 fi
 
 BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
-FRONTEND_HOSTNAME=$DOMAIN_PREFIX$FRONTEND_ZONE # Must match in .chalice/config.json!
+FRONTEND_HOSTNAME=$FRONTEND_DOMAIN_PREFIX$FRONTEND_ZONE # Must match in .chalice/config.json!
+BACKEND_HOSTNAME=$BACKEND_DOMAIN_PREFIX$BACKEND_ZONE # Must match in .chalice/config.json!
 CF_STACK_NAME=datadashboard$ENV_SUFFIX
 
 echo "Starting $CHALICE_STAGE deployment"
 echo "Backend bucket: $BACKEND_BUCKET"
-echo "Hostname: $FRONTEND_HOSTNAME"
+echo "Frontend hostname: $FRONTEND_HOSTNAME"
+echo "Backend hostname: $BACKEND_HOSTNAME"
 echo "CloudFormation stack name: $CF_STACK_NAME"
 
 # build frontend and patch in commit id
@@ -78,9 +81,10 @@ poetry run chalice package --stage $CHALICE_STAGE --merge-template frontend-cfn.
 aws cloudformation package --template-file cfn/sam.json --s3-bucket $BACKEND_BUCKET --output-template-file cfn/packaged.yaml
 aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STACK_NAME --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset --parameter-overrides \
     TMFrontendHostname=$FRONTEND_HOSTNAME \
+    TMFrontendZone=$FRONTEND_ZONE \
     TMFrontendCertArn=$FRONTEND_CERT_ARN \
     TMBackendCertArn=$BACKEND_CERT_ARN \
-    TMFrontendZone=$FRONTEND_ZONE \
+    TMBackendHostname=$BACKEND_HOSTNAME \
     TMBackendZone=$BACKEND_ZONE \
     MbtaV2ApiKey=$MBTA_V2_API_KEY
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,10 +28,16 @@ done
 # Setup environment stuff
 # By default deploy to beta, otherwise deploys to production
 
-$PRODUCTION && ENV_SUFFIX="" || ENV_SUFFIX="-beta"
-$PRODUCTION && CHALICE_STAGE="production" || CHALICE_STAGE="beta"
-$PRODUCTION && FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN" || FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN_BETA"
-$PRODUCTION && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN" || BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN_BETA"
+$PRODUCTION && ENV_SUFFIX=""                                    || ENV_SUFFIX="-beta"
+$PRODUCTION && CHALICE_STAGE="production"                       || CHALICE_STAGE="beta"
+$PRODUCTION && DOMAIN_PREFIX=""                                 || DOMAIN_PREFIX="dashboard-beta."
+
+$PRODUCTION && FRONTEND_ZONE="dashboard.transitmatters.org"     || FRONTEND_ZONE="labs.transitmatters.org"
+$PRODUCTION && FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN"        || FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN_BETA"
+
+$PRODUCTION && BACKEND_ZONE="dashboard-api2.transitmatters.org" || BACKEND_ZONE="labs.transitmatters.org"
+$PRODUCTION && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN"          || BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN_BETA"
+
 
 # Fetch repository tags
 # Run unshallow if deploying in CI
@@ -54,7 +60,7 @@ else
 fi
 
 BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
-FRONTEND_HOSTNAME=dashboard$ENV_SUFFIX.transitmatters.org # Must match in .chalice/config.json!
+FRONTEND_HOSTNAME=$DOMAIN_PREFIX$FRONTEND_ZONE # Must match in .chalice/config.json!
 CF_STACK_NAME=datadashboard$ENV_SUFFIX
 
 echo "Starting $CHALICE_STAGE deployment"
@@ -74,6 +80,8 @@ aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STA
     TMFrontendHostname=$FRONTEND_HOSTNAME \
     TMFrontendCertArn=$FRONTEND_CERT_ARN \
     TMBackendCertArn=$BACKEND_CERT_ARN \
+    TMFrontendZone=$FRONTEND_ZONE \
+    TMBackendZone=$BACKEND_ZONE \
     MbtaV2ApiKey=$MBTA_V2_API_KEY
 
 popd > /dev/null

--- a/server/.chalice/config.json
+++ b/server/.chalice/config.json
@@ -24,10 +24,10 @@
       "autogen_policy": false,
       "iam_policy_file": "policy.json",
       "environment_variables": {
-        "TM_FRONTEND_HOST": "dashboard-beta.transitmatters.org"
+        "TM_FRONTEND_HOST": "dashboard-beta.labs.transitmatters.org"
       },
       "api_gateway_custom_domain": {
-        "domain_name": "dashboard-api-beta.transitmatters.org",
+        "domain_name": "dashboard-api-beta.labs.transitmatters.org",
         "tls_version": "TLS_1_2",
         "certificate_arn": ""
       }

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -25,6 +25,45 @@
         "RegionalCertificateArn": { "Ref": "TMBackendCertArn" }
       }
     },
+    "FrontendDNSRecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "Name": { "Ref": "TMFrontendHostname" },
+        "HostedZoneName": "labs.transitmatters.org.",
+        "AliasTarget": {
+          "HostedZoneId": "Z2FDTNDATAQYW2",
+          "DNSName": {
+            "Fn::GetAtt": [
+              "FrontendCloudFront",
+              "DomainName"
+            ]
+          }
+        },
+        "Type": "A"
+      }
+    },
+    "BackendDNSRecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "Name": "dashboard-v4-beta-api.labs.transitmatters.org",
+        "HostedZoneName": "labs.transitmatters.org.",
+        "AliasTarget": {
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "ApiGatewayCustomDomain",
+              "RegionalHostedZoneId"
+            ]
+          },
+          "DNSName": {
+            "Fn::GetAtt": [
+              "ApiGatewayCustomDomain",
+              "RegionalDomainName"
+            ]
+          }
+        },
+        "Type": "A"
+      }
+    },
     "APIHandler": {
       "Properties": {
         "Environment": {

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -2,8 +2,8 @@
   "Parameters" : {
     "TMFrontendHostname": {
       "Type": "String",
-      "Default": "dashboard.transitmatters.org",
-      "AllowedValues": ["dashboard-beta.transitmatters.org", "dashboard.transitmatters.org"],
+      "Default": "dashboard-beta.labs.transitmatters.org",
+      "AllowedValues": ["dashboard-beta.labs.transitmatters.org", "dashboard.transitmatters.org"],
       "Description": "The frontend hostname for the data dashboard."
     },
     "TMFrontendZone": {
@@ -21,6 +21,12 @@
     "TMFrontendCertArn": {
       "Type": "String",
       "Description": "The ACM ARN of the frontend certificate."
+    },
+    "TMBackendHostname": {
+      "Type": "String",
+      "Default": "dashboard-api.labs.transitmatters.org",
+      "AllowedPattern": "^dashboard-api2\\.transitmatters\\.org$|^.*\\.labs\\.transitmatters\\.org$",
+      "Description": "The backend hostname for the data dashboard."
     },
     "TMBackendCertArn": {
       "Type": "String",
@@ -57,12 +63,7 @@
     "BackendDNSRecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
-        "Name": {
-          "Fn::GetAtt": [
-            "ApiGatewayCustomDomain",
-            "RegionalDomainName"
-          ]
-        },
+        "Name": { "Ref": "TMBackendHostname" },
         "HostedZoneName": { "Fn::Sub": "${TMBackendZone}." },
         "AliasTarget": {
           "HostedZoneId": {

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -6,6 +6,18 @@
       "AllowedValues": ["dashboard-beta.transitmatters.org", "dashboard.transitmatters.org"],
       "Description": "The frontend hostname for the data dashboard."
     },
+    "TMFrontendZone": {
+      "Type": "String",
+      "Default": "labs.transitmatters.org",
+      "AllowedPattern": "^dashboard\\.transitmatters\\.org$|^labs\\.transitmatters\\.org$",
+      "Description": "The frontend's DNS zone file name. Most likely dashboard.transitmatters.org or labs.transitmatters.org."
+    },
+    "TMBackendZone": {
+      "Type": "String",
+      "Default": "labs.transitmatters.org",
+      "AllowedPattern": "^dashboard-api2\\.transitmatters\\.org$|^labs\\.transitmatters\\.org$",
+      "Description": "The backend's DNS zone file name. Most likely dashboard.transitmatters.org or labs.transitmatters.org."
+    },
     "TMFrontendCertArn": {
       "Type": "String",
       "Description": "The ACM ARN of the frontend certificate."
@@ -29,7 +41,7 @@
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "Name": { "Ref": "TMFrontendHostname" },
-        "HostedZoneName": "labs.transitmatters.org.",
+        "HostedZoneName": { "Fn::Sub": "${TMFrontendZone}." },
         "AliasTarget": {
           "HostedZoneId": "Z2FDTNDATAQYW2",
           "DNSName": {
@@ -45,8 +57,13 @@
     "BackendDNSRecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
-        "Name": "dashboard-v4-beta-api.labs.transitmatters.org",
-        "HostedZoneName": "labs.transitmatters.org.",
+        "Name": {
+          "Fn::GetAtt": [
+            "ApiGatewayCustomDomain",
+            "RegionalDomainName"
+          ]
+        },
+        "HostedZoneName": { "Fn::Sub": "${TMBackendZone}." },
         "AliasTarget": {
           "HostedZoneId": {
             "Fn::GetAtt": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ import stations_json from './stations.json';
 export const PRODUCTION = 'dashboard.transitmatters.org';
 const FRONTEND_TO_BACKEND_MAP = new Map([
   [PRODUCTION, 'https://dashboard-api2.transitmatters.org'],
-  ['dashboard-beta.transitmatters.org', 'https://dashboard-api-beta.transitmatters.org'],
+  ['dashboard-beta.labs.transitmatters.org', 'https://dashboard-api-beta.labs.transitmatters.org'],
 ]);
 
 // Fetch the absolute location of the API to load from; fallback to "" which


### PR DESCRIPTION
We want DD, like RRE and NTT, to create its own DNS records as a part of deployment. I did some of this work in `dashboard-v4` but this brings it to `main`.

This is the first step in getting on-demand subdomains for different builds working and ready