### PR TITLE
Add all tailwind default breakpoints to custom config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,10 @@ module.exports = {
   theme: {
     screens: {
       sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
     },
     fontSize: {
       // TODO: try using only defaults.


### PR DESCRIPTION
I added tailwind screen breakpoints to our config to make accessing them easier. Only added `sm` at first. This adds the remaining default breakpoints