### PR TITLE
V4/font size fix

### DIFF
--- a/components/Dropdowns/LineSelectorMobile.tsx
+++ b/components/Dropdowns/LineSelectorMobile.tsx
@@ -16,7 +16,7 @@ import {
 export const LineSelectorMobile = () => {
   const route = useDelimitatedRoute();
 
-  const buttonDiv = 'w-full sm:text-sm relative ml-2 h-8 w-8 bg-white';
+  const buttonDiv = 'w-full relative ml-2 h-8 w-8 bg-white';
 
   // Don't render until we have the line.
   if (!route.line) {
@@ -46,7 +46,7 @@ export const LineSelectorMobile = () => {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <Listbox.Options className="w-34 absolute left-1 -top-3 origin-top-right -translate-y-full transform divide-y divide-gray-100 rounded-md border border-design-lightGrey bg-white text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+            <Listbox.Options className="w-34 absolute left-1 -top-3 origin-top-right -translate-y-full transform divide-y divide-gray-100 rounded-md border border-design-lightGrey bg-white text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
               {Object.entries(LINE_OBJECTS).map(([, metadata], index) => {
                 const href = getLineSelectionItemHref(metadata, route);
                 return (

--- a/components/Dropdowns/LineSelectorNavBar.tsx
+++ b/components/Dropdowns/LineSelectorNavBar.tsx
@@ -16,7 +16,7 @@ interface LineSelectorNavBarProps {
 
 export const LineSelectorNavBar: React.FC<LineSelectorNavBarProps> = ({ value }) => {
   const route = useDelimitatedRoute();
-  const buttonDiv = 'w-full cursor-pointer sm:text-sm bg-tm-grey';
+  const buttonDiv = 'w-full cursor-pointer sm:text-xs bg-tm-grey';
 
   // Don't render fully until we have the line.
   if (!route.line) {
@@ -59,7 +59,7 @@ export const LineSelectorNavBar: React.FC<LineSelectorNavBarProps> = ({ value })
                         <div
                           className={classNames(
                             selected ? 'font-semibold' : 'font-normal',
-                            'flex flex-row gap-2 truncate border-black text-sm text-white'
+                            'flex flex-row gap-2 truncate border-black text-xs text-white'
                           )}
                         >
                           <div

--- a/components/widgets/BasicDataWidgetItem.tsx
+++ b/components/widgets/BasicDataWidgetItem.tsx
@@ -33,7 +33,7 @@ export const BasicDataWidgetItem: React.FC<BasicDataWidgetItemProps> = ({
           ) : (
             <ArrowDownNegative className="h-3 w-auto" alt="Negative Sentiment Indication" />
           )}
-          <p className={classNames('text-sm text-design-subtitleGrey')}>{analysis}</p>
+          <p className={classNames('text-xs text-design-subtitleGrey')}>{analysis}</p>
         </div>
       </div>
     </div>

--- a/components/widgets/internal/BasicWidgetDataLayout.tsx
+++ b/components/widgets/internal/BasicWidgetDataLayout.tsx
@@ -27,7 +27,7 @@ export const BasicWidgetDataLayout: React.FC<BasicWidgetDataLayoutProps> = ({
         </div>
         <div className="flex flex-row items-center gap-x-1">
           <div>{Icon}</div>
-          <p className={classNames('text-sm text-design-subtitleGrey')}>{analysis}</p>
+          <p className={classNames('text-xs text-design-subtitleGrey')}>{analysis}</p>
         </div>
       </div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,8 +23,8 @@ module.exports = {
     },
     fontSize: {
       // TODO: try using only defaults.
-      xs: '0.5rem',
-      sm: '0.75rem',
+      xs: '0.75rem',
+      sm: '0.875rem',
       base: '1rem',
       xl: '1.25rem',
       '2xl': '1.563rem',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,10 @@ module.exports = {
   theme: {
     screens: {
       sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
     },
     fontSize: {
       // TODO: try using only defaults.


### PR DESCRIPTION
Reset `xs` and `sm` tailwind font sizes to default. I had been experimenting with these when I made the first commit working on widgets.

Switched classNames on components to keep previous font size. Left `text-sm` on a few components where it looked good.