### PR TITLE
[v4] Make github actions for dashboard-v4 work hopefully

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dashboard-v4
 
 jobs:
   deploy:
@@ -14,9 +15,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       TM_FRONTEND_CERT_ARN: ${{ secrets.TM_FRONTEND_CERT_ARN }}
-      TM_FRONTEND_CERT_ARN_BETA: ${{ secrets.TM_FRONTEND_CERT_ARN_BETA }}
       TM_BACKEND_CERT_ARN: ${{ secrets.TM_BACKEND_CERT_ARN }}
-      TM_BACKEND_CERT_ARN_BETA: ${{ secrets.TM_BACKEND_CERT_ARN_BETA }}
+      TM_LABS_WILDCARD_CERT_ARN: ${{ secrets.TM_LABS_WILDCARD_CERT_ARN }}
       MBTA_V2_API_KEY: ${{ secrets.MBTA_V2_API_KEY }}
     steps:
       - name: Checkout repo


### PR DESCRIPTION
This should deploy to dashboard-v4-beta.labs.transitmatters.org on merge but no promises