### PR TITLE
Temporarily disable v4 auto-deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dashboard-v4
 
 jobs:
   deploy:


### PR DESCRIPTION
Issues with fetching were fixed manually. Don't want them to get overridden. Will add this back after that's fixed.