### PR TITLE
[v4] Fleshing out full details of all pages

### DIFF
--- a/common/utils/stations.ts
+++ b/common/utils/stations.ts
@@ -1,6 +1,8 @@
 import type { SelectOption } from '../../common/types/inputs';
 import type { LineShort } from '../../common/types/lines';
 import type { Station } from '../../common/types/stations';
+import type { Location } from '../types/charts';
+import type { Direction } from '../types/dataPoints';
 import { rtStations } from './../constants/stations';
 
 export const optionsForField = (
@@ -85,5 +87,31 @@ export const stopIdsForStations = (
   return {
     fromStopIds: isDirection1 ? from.stops['1'] : from.stops['0'],
     toStopIds: isDirection1 ? to.stops['1'] : to.stops['0'],
+  };
+};
+
+export const travelDirection = (from: Station, to: Station): Direction => {
+  return from.order < to.order ? 'southbound' : 'northbound';
+};
+
+export const locationDetails = (
+  from: Station | undefined,
+  to: Station | undefined,
+  lineShort: LineShort
+): Location => {
+  if (to === undefined || from === undefined) {
+    return {
+      to: to?.stop_name || 'Loading...',
+      from: from?.stop_name || 'Loading...',
+      direction: 'southbound',
+      line: lineShort,
+    };
+  }
+
+  return {
+    to: to.stop_name,
+    from: from.stop_name,
+    direction: travelDirection(from, to),
+    line: lineShort,
   };
 };

--- a/modules/dwells/DwellsDetails.tsx
+++ b/modules/dwells/DwellsDetails.tsx
@@ -1,8 +1,115 @@
-import { useRouter } from 'next/router';
+'use client';
+
 import React from 'react';
+import { useCustomQueries } from '../../common/api/datadashboard';
+import { SingleDayLineChart } from '../../common/components/charts/SingleDayLineChart';
+import { MetricFieldKeys, PointFieldKeys } from '../../src/charts/types';
+import ArrowDownNegative from '../../public/Icons/ArrowDownNegative.svg';
+import { SingleDayAPIParams } from '../../common/types/api';
+import { locationDetails, optionsStation, stopIdsForStations } from '../../common/utils/stations';
+import { getCurrentDate } from '../../common/utils/date';
+import { useDelimitatedRoute } from '../../common/utils/router';
+import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
+import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWidgetItem';
+import { averageDwells, longestDwells } from '../../common/utils/dwells';
 
 export default function DwellsDetails() {
-  const router = useRouter();
-  const line = router.query.line;
-  return <div>{`${line} > dwells`}</div>;
+  const startDate = getCurrentDate();
+  const { linePath, lineShort } = useDelimitatedRoute();
+
+  const stations = optionsStation(lineShort);
+  const toStation = stations?.[stations.length - 3];
+  const fromStation = stations?.[3];
+
+  const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
+  const { fromStopIds: fromStopIdsNorth, toStopIds: toStopIdsNorth } = stopIdsForStations(
+    toStation,
+    fromStation
+  );
+
+  const { dwells } = useCustomQueries(
+    {
+      [SingleDayAPIParams.fromStop]: fromStopIds || '',
+      [SingleDayAPIParams.toStop]: toStopIds || '',
+      [SingleDayAPIParams.stop]: fromStopIds || '',
+      [SingleDayAPIParams.date]: startDate,
+    },
+    false,
+    fromStopIds !== null && toStopIds !== null
+  );
+
+  const { dwells: dwellsReversed } = useCustomQueries(
+    {
+      [SingleDayAPIParams.fromStop]: fromStopIdsNorth || '',
+      [SingleDayAPIParams.toStop]: toStopIdsNorth || '',
+      [SingleDayAPIParams.stop]: fromStopIdsNorth || '',
+      [SingleDayAPIParams.date]: startDate,
+    },
+    false,
+    fromStopIdsNorth !== null && toStopIdsNorth !== null
+  );
+
+  const isLoading = dwells.isLoading || toStation === undefined || fromStation === undefined;
+
+  if (dwells.isError) {
+    return <>Uh oh... error</>;
+  }
+
+  return (
+    <>
+      <BasicDataWidgetPair>
+        <BasicDataWidgetItem
+          title="Average Dwell"
+          value={dwells.data ? averageDwells(dwells.data).toFixed(2).toString() : 'Loading...'}
+          units="sec"
+          analysis="+1.0 since last week"
+          icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}
+        />
+        <BasicDataWidgetItem
+          title="Longest Dwell"
+          value={
+            dwells.data && dwellsReversed.data
+              ? Math.max(longestDwells(dwells.data), longestDwells(dwellsReversed.data))
+                  .toFixed(2)
+                  .toString()
+              : 'Loading...'
+          }
+          units="sec"
+          analysis="+1.0 since last week"
+          icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}
+        />
+      </BasicDataWidgetPair>
+      <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
+        <SingleDayLineChart
+          chartId={`dwells-widget-${linePath}`}
+          title={'Time spent at station (dwells)'}
+          data={dwells.data ?? []}
+          date={startDate}
+          metricField={MetricFieldKeys.dwellTimeSec}
+          pointField={PointFieldKeys.arrDt}
+          isLoading={isLoading}
+          location={locationDetails(fromStation, toStation, lineShort)}
+          fname={'dwells'}
+          showLegend={false}
+        />
+      </div>
+      <div className="flex w-full flex-row items-center justify-between text-lg">
+        <h3>Return Trip</h3>
+      </div>
+      <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
+        <SingleDayLineChart
+          chartId={`dwells-widget-${linePath}-return`}
+          title={'Time spent at station (dwells)'}
+          data={dwellsReversed.data ?? []}
+          date={startDate}
+          metricField={MetricFieldKeys.dwellTimeSec}
+          pointField={PointFieldKeys.arrDt}
+          isLoading={isLoading}
+          location={locationDetails(toStation, fromStation, lineShort)}
+          fname={'dwells'}
+          showLegend={false}
+        />
+      </div>
+    </>
+  );
 }

--- a/modules/dwells/DwellsWidget.tsx
+++ b/modules/dwells/DwellsWidget.tsx
@@ -1,15 +1,14 @@
 'use client';
-import React, { useMemo } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { secondsToMinutes } from 'date-fns';
 import ArrowDownNegative from '../../public/Icons/ArrowDownNegative.svg';
 import { SingleDayLineChart } from '../../common/components/charts/SingleDayLineChart';
 import { MetricFieldKeys, PointFieldKeys } from '../../src/charts/types';
-import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
+import { locationDetails, optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { useCustomQueries } from '../../common/api/datadashboard';
 import { getCurrentDate } from '../../common/utils/date';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import type { Location } from '../../common/types/charts';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
 import { SingleDayAPIParams } from '../../common/types/api';
@@ -17,7 +16,7 @@ import { averageDwells, longestDwells } from '../../common/utils/dwells';
 
 export const DwellsWidget: React.FC = () => {
   const startDate = getCurrentDate();
-  const { linePath, lineShort } = useDelimitatedRoute();
+  const { line, linePath, lineShort } = useDelimitatedRoute();
 
   const stations = optionsStation(lineShort);
   const toStation = stations?.[stations.length - 3];
@@ -36,28 +35,15 @@ export const DwellsWidget: React.FC = () => {
     fromStopIds !== null && toStopIds !== null
   );
 
-  const location: Location = useMemo(() => {
-    if (toStation === undefined || fromStation === undefined) {
-      return {
-        to: toStation?.stop_name || 'Loading...',
-        from: fromStation?.stop_name || 'Loading...',
-        direction: 'southbound',
-        line: lineShort,
-      };
-    }
-
-    return {
-      to: toStation.stop_name,
-      from: fromStation.stop_name,
-      direction: 'southbound',
-      line: lineShort,
-    };
-  }, [fromStation, lineShort, toStation]);
-
   const isLoading = dwells.isLoading || toStation === undefined || fromStation === undefined;
 
   if (dwells.isError) {
     return <>Uh oh... error</>;
+  }
+
+  // Buses don't record dwells
+  if (line === 'BUS') {
+    return null;
   }
 
   return (
@@ -72,7 +58,7 @@ export const DwellsWidget: React.FC = () => {
           metricField={MetricFieldKeys.dwellTimeSec}
           pointField={PointFieldKeys.arrDt}
           isLoading={isLoading}
-          location={location}
+          location={locationDetails(fromStation, toStation, lineShort)}
           fname={'dwells'}
           showLegend={false}
         />

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -1,8 +1,118 @@
-import { useRouter } from 'next/router';
+'use client';
+
 import React from 'react';
+import { secondsToMinutes } from 'date-fns';
+import { useCustomQueries } from '../../common/api/datadashboard';
+import { SingleDayLineChart } from '../../common/components/charts/SingleDayLineChart';
+import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../../src/charts/types';
+import ArrowDownNegative from '../../public/Icons/ArrowDownNegative.svg';
+import { SingleDayAPIParams } from '../../common/types/api';
+import { locationDetails, optionsStation, stopIdsForStations } from '../../common/utils/stations';
+import { getCurrentDate } from '../../common/utils/date';
+import { useDelimitatedRoute } from '../../common/utils/router';
+import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
+import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWidgetItem';
+import { averageHeadway, longestHeadway } from '../../common/utils/headways';
 
 export default function HeadwaysDetails() {
-  const router = useRouter();
-  const line = router.query.line;
-  return <div>{`${line} > headways`}</div>;
+  const startDate = getCurrentDate();
+  const { linePath, lineShort } = useDelimitatedRoute();
+
+  const stations = optionsStation(lineShort);
+  const toStation = stations?.[stations.length - 3];
+  const fromStation = stations?.[3];
+
+  const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
+  const { fromStopIds: fromStopIdsNorth, toStopIds: toStopIdsNorth } = stopIdsForStations(
+    toStation,
+    fromStation
+  );
+
+  const { headways } = useCustomQueries(
+    {
+      [SingleDayAPIParams.fromStop]: fromStopIds || '',
+      [SingleDayAPIParams.toStop]: toStopIds || '',
+      [SingleDayAPIParams.stop]: fromStopIds || '',
+      [SingleDayAPIParams.date]: startDate,
+    },
+    false,
+    fromStopIds !== null && toStopIds !== null
+  );
+
+  const { headways: headwaysReversed } = useCustomQueries(
+    {
+      [SingleDayAPIParams.fromStop]: fromStopIdsNorth || '',
+      [SingleDayAPIParams.toStop]: toStopIdsNorth || '',
+      [SingleDayAPIParams.stop]: fromStopIdsNorth || '',
+      [SingleDayAPIParams.date]: startDate,
+    },
+    false,
+    fromStopIdsNorth !== null && toStopIdsNorth !== null
+  );
+
+  const isLoading = headways.isLoading || toStation === undefined || fromStation === undefined;
+
+  if (headways.isError) {
+    return <>Uh oh... error</>;
+  }
+
+  return (
+    <>
+      <BasicDataWidgetPair>
+        <BasicDataWidgetItem
+          title="Average Headway"
+          value={
+            headways.data
+              ? secondsToMinutes(averageHeadway(headways.data)).toString()
+              : 'Loading...'
+          }
+          units="min"
+          analysis="+1.0 since last week"
+          icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}
+        />
+        <BasicDataWidgetItem
+          title="Longest Headway"
+          value={
+            headways.data
+              ? secondsToMinutes(longestHeadway(headways.data)).toString()
+              : 'Loading...'
+          }
+          units="min"
+          analysis="+1.0 since last week"
+          icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}
+        />
+      </BasicDataWidgetPair>
+      <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
+        <SingleDayLineChart
+          chartId={`headways-widget-${linePath}`}
+          title={'Time between trains (headways)'}
+          data={headways.data ?? []}
+          date={startDate}
+          metricField={MetricFieldKeys.headWayTimeSec}
+          pointField={PointFieldKeys.currentDepDt}
+          benchmarkField={BenchmarkFieldKeys.benchmarkHeadwayTimeSec}
+          isLoading={isLoading}
+          location={locationDetails(fromStation, toStation, lineShort)}
+          fname={'headways'}
+        />
+      </div>
+      <div className="flex w-full flex-row items-center justify-between text-lg">
+        <h3>Return Trip</h3>
+      </div>
+      <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
+        <SingleDayLineChart
+          chartId={`headways-widget-${linePath}-return`}
+          title={'Time between trains (headways)'}
+          data={headwaysReversed.data ?? []}
+          date={startDate}
+          metricField={MetricFieldKeys.headWayTimeSec}
+          pointField={PointFieldKeys.currentDepDt}
+          benchmarkField={BenchmarkFieldKeys.benchmarkHeadwayTimeSec}
+          isLoading={isLoading}
+          location={locationDetails(toStation, fromStation, lineShort)}
+          fname={'headways'}
+        />
+      </div>
+    </>
+  );
 }

--- a/modules/headways/HeadwaysWidget.tsx
+++ b/modules/headways/HeadwaysWidget.tsx
@@ -1,17 +1,16 @@
 'use client';
-import React, { useMemo } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { secondsToMinutes } from 'date-fns';
 import ArrowDownNegative from '../../public/Icons/ArrowDownNegative.svg';
 import { SingleDayLineChart } from '../../common/components/charts/SingleDayLineChart';
 import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../../src/charts/types';
 import { SingleDayAPIParams } from '../../common/types/api';
-import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
+import { locationDetails, optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { useCustomQueries } from '../../common/api/datadashboard';
 import { getCurrentDate } from '../../common/utils/date';
 import { averageHeadway, longestHeadway } from '../../common/utils/headways';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import type { Location } from '../../common/types/charts';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { useBreakpoint } from '../../common/hooks/useBreakpoint';
@@ -38,24 +37,6 @@ export const HeadwaysWidget: React.FC = () => {
     fromStopIds !== null && toStopIds !== null
   );
 
-  const location: Location = useMemo(() => {
-    if (toStation === undefined || fromStation === undefined) {
-      return {
-        to: toStation?.stop_name || 'Loading...',
-        from: fromStation?.stop_name || 'Loading...',
-        direction: 'southbound',
-        line: lineShort,
-      };
-    }
-
-    return {
-      to: toStation.stop_name,
-      from: fromStation.stop_name,
-      direction: 'southbound',
-      line: lineShort,
-    };
-  }, [fromStation, lineShort, toStation]);
-
   const isLoading = headways.isLoading || toStation === undefined || fromStation === undefined;
 
   if (headways.isError) {
@@ -75,7 +56,7 @@ export const HeadwaysWidget: React.FC = () => {
           pointField={PointFieldKeys.currentDepDt}
           benchmarkField={BenchmarkFieldKeys.benchmarkHeadwayTimeSec}
           isLoading={isLoading}
-          location={location}
+          location={locationDetails(fromStation, toStation, lineShort)}
           fname={'headways'}
           showLegend={!isMobile}
         />

--- a/modules/navigation/desktop/SideNavBar.tsx
+++ b/modules/navigation/desktop/SideNavBar.tsx
@@ -83,7 +83,7 @@ export const SideNavBar = () => {
               <div className="flex flex-shrink-0 px-2">
                 <TmLogoSvg alt="TransitMatters Logo" />
               </div>
-              <div className="mt-5 flex flex-grow flex-col px-2">
+              <div className="mt-5 flex flex-col px-2">
                 <SideNavigation items={NAV_ITEMS} />
               </div>
             </div>

--- a/modules/slowzones/SlowZonesDetails.tsx
+++ b/modules/slowzones/SlowZonesDetails.tsx
@@ -12,7 +12,7 @@ import { fetchAllSlow, fetchDelayTotals } from './api/slowzones';
 export default function SlowZonesDetails() {
   const delayTotals = useQuery(['delayTotals'], fetchDelayTotals);
   const allSlow = useQuery(['allSlow'], fetchAllSlow);
-  const route = useDelimitatedRoute();
+  const { lineShort } = useDelimitatedRoute();
 
   const formattedTotals = useMemo(
     () =>
@@ -35,7 +35,7 @@ export default function SlowZonesDetails() {
           title="Total Delay"
           value={
             formattedTotals &&
-            (formattedTotals[formattedTotals.length - 1][route.lineShort] / 60).toFixed(2)
+            (formattedTotals[formattedTotals.length - 1][lineShort] / 60).toFixed(2)
           }
           units="min"
           analysis="+1.0 since last week"
@@ -50,11 +50,7 @@ export default function SlowZonesDetails() {
         />
       </BasicDataWidgetPair>
       {}
-      <SlowZonesContainer
-        allSlow={allSlow.data}
-        delayTotals={formattedTotals}
-        line={route.lineShort}
-      />
+      <SlowZonesContainer allSlow={allSlow.data} delayTotals={formattedTotals} line={lineShort} />
     </>
   );
 }

--- a/modules/slowzones/SlowZonesWidget.tsx
+++ b/modules/slowzones/SlowZonesWidget.tsx
@@ -29,6 +29,10 @@ export default function SlowZonesWidget() {
     return <>Uh oh... error</>;
   }
 
+  if (line === 'BUS' || line === 'GL') {
+    return null;
+  }
+
   return (
     <>
       <HomescreenWidgetTitle title="Slow Zones" href={`/${linePath}/slowzones`} />

--- a/modules/traveltimes/TravelTimesDetails.tsx
+++ b/modules/traveltimes/TravelTimesDetails.tsx
@@ -1,24 +1,32 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React from 'react';
+import { secondsToMinutes } from 'date-fns';
 import { useCustomQueries } from '../../common/api/datadashboard';
 import { SingleDayLineChart } from '../../common/components/charts/SingleDayLineChart';
 import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../../src/charts/types';
+import ArrowDownNegative from '../../public/Icons/ArrowDownNegative.svg';
 import { SingleDayAPIParams } from '../../common/types/api';
-import type { Location } from '../../common/types/charts';
-import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
+import { locationDetails, optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { getCurrentDate } from '../../common/utils/date';
 import { useDelimitatedRoute } from '../../common/utils/router';
+import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
+import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWidgetItem';
+import { averageTravelTime } from '../../common/utils/traveltimes';
 
 export default function TravelTimesDetails() {
   const startDate = getCurrentDate();
-  const route = useDelimitatedRoute();
+  const { linePath, lineShort } = useDelimitatedRoute();
 
-  const stations = optionsStation(route.lineShort);
+  const stations = optionsStation(lineShort);
   const toStation = stations?.[stations.length - 3];
   const fromStation = stations?.[3];
 
   const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
+  const { fromStopIds: fromStopIdsNorth, toStopIds: toStopIdsNorth } = stopIdsForStations(
+    toStation,
+    fromStation
+  );
 
   const { traveltimes } = useCustomQueries(
     {
@@ -31,35 +39,54 @@ export default function TravelTimesDetails() {
     fromStopIds !== null && toStopIds !== null
   );
 
-  const location: Location = useMemo(() => {
-    if (toStation === undefined || fromStation === undefined) {
-      return {
-        to: toStation?.stop_name || 'Loading...',
-        from: fromStation?.stop_name || 'Loading...',
-        direction: 'southbound',
-        line: route.lineShort,
-      };
-    }
-
-    return {
-      to: toStation.stop_name,
-      from: fromStation.stop_name,
-      direction: 'southbound',
-      line: route.lineShort,
-    };
-  }, [fromStation, route, toStation]);
+  const { traveltimes: traveltimesReversed } = useCustomQueries(
+    {
+      [SingleDayAPIParams.fromStop]: fromStopIdsNorth || '',
+      [SingleDayAPIParams.toStop]: toStopIdsNorth || '',
+      [SingleDayAPIParams.stop]: fromStopIdsNorth || '',
+      [SingleDayAPIParams.date]: startDate,
+    },
+    false,
+    fromStopIdsNorth !== null && toStopIdsNorth !== null
+  );
 
   const isLoading = traveltimes.isLoading || toStation === undefined || fromStation === undefined;
 
-  if (traveltimes.isError || !route.line) {
+  if (traveltimes.isError || !linePath) {
     return <>Uh oh... error</>;
   }
 
   return (
     <>
+      <BasicDataWidgetPair>
+        <BasicDataWidgetItem
+          title="Average Travel Time"
+          value={
+            traveltimes.data
+              ? secondsToMinutes(averageTravelTime(traveltimes.data)).toString()
+              : 'Loading...'
+          }
+          units="min"
+          analysis="+1.0 since last week"
+          icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}
+        />
+        <BasicDataWidgetItem
+          title="Round Trip"
+          value={
+            traveltimes.data && traveltimesReversed.data
+              ? secondsToMinutes(
+                  averageTravelTime(traveltimes.data) + averageTravelTime(traveltimesReversed.data)
+                ).toString()
+              : 'Loading...'
+          }
+          units="min"
+          analysis="+2 since last week"
+          icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}
+        />
+      </BasicDataWidgetPair>
       <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
         <SingleDayLineChart
-          chartId={'traveltimes'}
+          chartId={`traveltimes-widget-${linePath}`}
           title={'Travel Times'}
           data={traveltimes.data || []}
           date={startDate}
@@ -68,7 +95,25 @@ export default function TravelTimesDetails() {
           benchmarkField={BenchmarkFieldKeys.benchmarkTravelTimeSec}
           isLoading={isLoading}
           bothStops={true}
-          location={location}
+          location={locationDetails(fromStation, toStation, lineShort)}
+          fname={'traveltimes'}
+        />
+      </div>
+      <div className="flex w-full flex-row items-center justify-between text-lg">
+        <h3>Return Trip</h3>
+      </div>
+      <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
+        <SingleDayLineChart
+          chartId={`traveltimes-widget-${linePath}-return`}
+          title={'Travel Times'}
+          data={traveltimesReversed.data || []}
+          date={startDate}
+          metricField={MetricFieldKeys.travelTimeSec}
+          pointField={PointFieldKeys.depDt}
+          benchmarkField={BenchmarkFieldKeys.benchmarkTravelTimeSec}
+          isLoading={isLoading}
+          bothStops={true}
+          location={locationDetails(toStation, fromStation, lineShort)}
           fname={'traveltimes'}
         />
       </div>

--- a/modules/traveltimes/TravelTimesWidget.tsx
+++ b/modules/traveltimes/TravelTimesWidget.tsx
@@ -1,16 +1,15 @@
 'use client';
-import React, { useMemo } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { secondsToMinutes } from 'date-fns';
 import ArrowDownNegative from '../../public/Icons/ArrowDownNegative.svg';
 import { SingleDayLineChart } from '../../common/components/charts/SingleDayLineChart';
 import { BenchmarkFieldKeys, MetricFieldKeys, PointFieldKeys } from '../../src/charts/types';
 import { SingleDayAPIParams } from '../../common/types/api';
-import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
+import { locationDetails, optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { useCustomQueries } from '../../common/api/datadashboard';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { getCurrentDate } from '../../common/utils/date';
-import type { Location } from '../../common/types/charts';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { averageTravelTime } from '../../common/utils/traveltimes';
@@ -38,24 +37,6 @@ export const TravelTimesWidget: React.FC = () => {
     fromStopIds !== null && toStopIds !== null
   );
 
-  const location: Location = useMemo(() => {
-    if (toStation === undefined || fromStation === undefined) {
-      return {
-        to: toStation?.stop_name || 'Loading...',
-        from: fromStation?.stop_name || 'Loading...',
-        direction: 'southbound',
-        line: lineShort,
-      };
-    }
-
-    return {
-      to: toStation.stop_name,
-      from: fromStation.stop_name,
-      direction: 'southbound',
-      line: lineShort,
-    };
-  }, [fromStation, lineShort, toStation]);
-
   const isLoading = traveltimes.isLoading || toStation === undefined || fromStation === undefined;
 
   if (traveltimes.isError || !linePath) {
@@ -76,7 +57,7 @@ export const TravelTimesWidget: React.FC = () => {
           benchmarkField={BenchmarkFieldKeys.benchmarkTravelTimeSec}
           isLoading={isLoading}
           bothStops={true}
-          location={location}
+          location={locationDetails(fromStation, toStation, lineShort)}
           fname={'traveltimes'}
           showLegend={!isMobile}
         />
@@ -98,7 +79,7 @@ export const TravelTimesWidget: React.FC = () => {
               traveltimes.data
                 ? secondsToMinutes(averageTravelTime(traveltimes.data) * 2).toString()
                 : 'Loading...'
-            } //TODO: Show real time for a round trip
+            }
             units="min"
             analysis="+2 since last week"
             Icon={<ArrowDownNegative className="h-3 w-auto" alt="Your Company" />}


### PR DESCRIPTION
- Adds details to Headways and Dwells pages
- Adds more details to traveltimes
- Adds utils to clean up existing views code
- Cleans up existing widgets code
- Hides widgets for views that don't apply to them (buses, green line slow zone)

<img width="1512" alt="Screenshot 2023-02-06 at 9 57 15 PM" src="https://user-images.githubusercontent.com/9310513/217136779-28f81e43-241f-4296-b3e7-83f5af4ef76d.png">
<img width="1512" alt="Screenshot 2023-02-06 at 9 57 26 PM" src="https://user-images.githubusercontent.com/9310513/217136781-356e92a5-5e60-4218-adf5-88fe39d51342.png">
