### PR TITLE
V4/fix links

### DIFF
--- a/common/constants/lines.ts
+++ b/common/constants/lines.ts
@@ -38,11 +38,3 @@ export const LINE_OBJECTS: LineObject = {
     color: COLORS.mbta.bus,
   },
 };
-
-export const lineTabs = [
-  { name: 'Red Line', current: false, id: 'red' },
-  { name: 'Blue Line', current: false, id: 'blue' },
-  { name: 'Orange Line', current: false, id: 'orange' },
-  { name: 'Green Line', current: false, id: 'green' },
-  { name: 'Bus', current: false, id: 'bus' },
-];

--- a/common/types/lines.ts
+++ b/common/types/lines.ts
@@ -1,14 +1,3 @@
-import type { TimeUnit } from 'chart.js';
-import type React from 'react';
-import type {
-  AggregateDataPoint,
-  BenchmarkField,
-  MetricField,
-  PointField,
-  SingleDayDataPoint,
-  Location,
-} from './charts';
-
 export type Line = 'RL' | 'OL' | 'GL' | 'BL' | 'BUS';
 export type LineShort = 'Red' | 'Orange' | 'Green' | 'Blue' | 'Bus';
 export type LinePath = 'red' | 'orange' | 'green' | 'blue' | 'bus';
@@ -20,37 +9,16 @@ export type LineMetadata = {
   key: Line;
 };
 export type LineObject = { [key in Line]: LineMetadata };
+export const ALL_LINE_PATHS = ['red', 'orange', 'green', 'blue'].map((line) => {
+  return {
+    params: {
+      line: line,
+    },
+  };
+});
 
-type DataName = 'traveltimes' | 'headways' | 'dwells' | 'traveltimesByHour';
-
-export interface LineProps {
-  title: string;
-  chartId: string;
-  location: Location;
-  isLoading: any;
-  pointField: PointField; // X value
-  bothStops?: boolean;
-  fname: DataName;
-  homescreen?: boolean;
-  showLegend?: boolean;
-}
-
-export interface AggregateLineProps extends LineProps {
-  timeUnit: TimeUnit;
-  data: AggregateDataPoint[];
-  timeFormat: string;
-  seriesName: string;
-  fillColor: string;
-  startDate: string;
-  endDate: string;
-  suggestedYMin?: number;
-  suggestedYMax?: number;
-  children?: React.ReactNode;
-}
-
-export interface SingleDayLineProps extends LineProps {
-  data: SingleDayDataPoint[];
-  metricField: MetricField; // Y value
-  date: string | undefined;
-  benchmarkField?: BenchmarkField;
-}
+export const BUS_PATH = {
+  params: {
+    line: 'bus',
+  },
+};

--- a/common/types/lines.ts
+++ b/common/types/lines.ts
@@ -1,3 +1,14 @@
+import type { TimeUnit } from 'chart.js';
+import type React from 'react';
+import type {
+  AggregateDataPoint,
+  BenchmarkField,
+  MetricField,
+  PointField,
+  SingleDayDataPoint,
+  Location,
+} from './charts';
+
 export type Line = 'RL' | 'OL' | 'GL' | 'BL' | 'BUS';
 export type LineShort = 'Red' | 'Orange' | 'Green' | 'Blue' | 'Bus';
 export type LinePath = 'red' | 'orange' | 'green' | 'blue' | 'bus';
@@ -9,6 +20,41 @@ export type LineMetadata = {
   key: Line;
 };
 export type LineObject = { [key in Line]: LineMetadata };
+
+type DataName = 'traveltimes' | 'headways' | 'dwells' | 'traveltimesByHour';
+
+export interface LineProps {
+  title: string;
+  chartId: string;
+  location: Location;
+  isLoading: any;
+  pointField: PointField; // X value
+  bothStops?: boolean;
+  fname: DataName;
+  homescreen?: boolean;
+  showLegend?: boolean;
+}
+
+export interface AggregateLineProps extends LineProps {
+  timeUnit: TimeUnit;
+  data: AggregateDataPoint[];
+  timeFormat: string;
+  seriesName: string;
+  fillColor: string;
+  startDate: string;
+  endDate: string;
+  suggestedYMin?: number;
+  suggestedYMax?: number;
+  children?: React.ReactNode;
+}
+
+export interface SingleDayLineProps extends LineProps {
+  data: SingleDayDataPoint[];
+  metricField: MetricField; // Y value
+  date: string | undefined;
+  benchmarkField?: BenchmarkField;
+}
+
 export const ALL_LINE_PATHS = ['red', 'orange', 'green', 'blue'].map((line) => {
   return {
     params: {

--- a/next.config.js
+++ b/next.config.js
@@ -9,12 +9,6 @@ if (process.env.NODE_ENV === 'development') {
   });
 }
 
-// This is to prevent typescript errors from failing the build while we set up v4.
-const tsSettings = { ignoreBuildErrors: false };
-if (process.env.V4_TEMP) {
-  tsSettings.ignoreBuildErrors = true;
-}
-
 const nextConfig = {
   webpack(config) {
     config.module.rules.push({
@@ -30,7 +24,6 @@ const nextConfig = {
   trailingSlash: true,
   reactStrictMode: true,
   swcMinify: true,
-  typescript: tsSettings,
   // No nextJS image optimization for a static site.
   images: {
     unoptimized: true,

--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,7 @@ const nextConfig = {
   async rewrites() {
     return rewrites;
   },
+  trailingSlash: true,
   reactStrictMode: true,
   swcMinify: true,
   typescript: tsSettings,

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "start-python": "cd server && poetry run chalice local --port=5000",
     "start-react": "next dev",
     "build": "next build && rm -rf build/static/slowzones",
-    "build-v4": "V4_TEMP=true next build && next export && rm -rf build/static/slowzones",
+    "build-v4": "next build && next export && rm -rf build/static/slowzones",
     "get-sz-data": "npm run get-sz-totals && npm run get-szs",
     "get-sz-totals": "wget -N -x -nH -P public https://dashboard.transitmatters.org/static/slowzones/delay_totals.json",
     "get-szs": "wget -N -x -nH -P public https://dashboard.transitmatters.org/static/slowzones/all_slow.json",

--- a/pages/[line]/dwells.tsx
+++ b/pages/[line]/dwells.tsx
@@ -1,3 +1,15 @@
+import { ALL_LINE_PATHS } from '../../common/types/lines';
 import DwellsDetails from '../../modules/dwells/DwellsDetails';
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: ALL_LINE_PATHS,
+    fallback: false,
+  };
+}
 
 export default DwellsDetails;

--- a/pages/[line]/headways.tsx
+++ b/pages/[line]/headways.tsx
@@ -1,3 +1,15 @@
+import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
 import HeadwaysDetails from '../../modules/headways/HeadwaysDetails';
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [...ALL_LINE_PATHS, BUS_PATH],
+    fallback: false,
+  };
+}
 
 export default HeadwaysDetails;

--- a/pages/[line]/index.tsx
+++ b/pages/[line]/index.tsx
@@ -1,3 +1,15 @@
+import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
 import Overview from '../../modules/dashboard/Overview';
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [...ALL_LINE_PATHS, BUS_PATH],
+    fallback: false,
+  };
+}
 
 export default Overview;

--- a/pages/[line]/more.tsx
+++ b/pages/[line]/more.tsx
@@ -1,8 +1,0 @@
-import { useRouter } from 'next/router';
-import React from 'react';
-
-export default function More() {
-  const router = useRouter();
-  const line = router.query.line;
-  return <div>{`${line} > more`}</div>;
-}

--- a/pages/[line]/ridership.tsx
+++ b/pages/[line]/ridership.tsx
@@ -1,3 +1,15 @@
+import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
 import RidershipDetails from '../../modules/ridership/RidershipDetails';
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [...ALL_LINE_PATHS, BUS_PATH],
+    fallback: false,
+  };
+}
 
 export default RidershipDetails;

--- a/pages/[line]/slowzones.tsx
+++ b/pages/[line]/slowzones.tsx
@@ -1,3 +1,15 @@
+import { ALL_LINE_PATHS } from '../../common/types/lines';
 import SlowZonesDetails from '../../modules/slowzones/SlowZonesDetails';
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: ALL_LINE_PATHS,
+    fallback: false,
+  };
+}
 
 export default SlowZonesDetails;

--- a/pages/[line]/traveltimes.tsx
+++ b/pages/[line]/traveltimes.tsx
@@ -1,3 +1,15 @@
+import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
 import TravelTimesDetails from '../../modules/traveltimes/TravelTimesDetails';
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [...ALL_LINE_PATHS, BUS_PATH],
+    fallback: false,
+  };
+}
 
 export default TravelTimesDetails;

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -136,7 +136,7 @@
                 "HTTPSPort": "443",
                 "OriginProtocolPolicy": "http-only"
               },
-              "DomainName": { "Fn::GetAtt": ["FrontendBucket", "DomainName"] },
+              "DomainName": { "Fn::Join": ["", [{ "Ref": "TMFrontendHostname" }, ".s3-website-us-east-1.amazonaws.com"]] },
               "Id": "only-origin"
             }
           ],


### PR DESCRIPTION
Our links were not working in v4. This was caused by the static export not generating files for our dynamic routes like `/[line]/`

There was also an issue caused by the cloudfront distribution. We needed the "website" URL `.s3-website-us-east-1.amazonaws.com` for our S3 bucket rather than just `s3`.

Last change was adding `trailingSlash:true` to the next config. My understanding is that allows the server to know a url ending in `/green` should become '/green/' which is a folder containing an `index.html' file.

Would've liked to apply `getStaticPaths` and `getStaticProps` universally to all pages inside the `[line]` folder, but don't think it's possible. I also didn't include bus routes for dwells and slow zones.

@mathcolo Pretty sure there was no good way of getting `.s3-website-us-east-1.amazonaws.com` from cloudformation other than directly appending it. Closest thing is `WebsiteURL` but that includes `https`. I also don't know if we want/need a more general setup for other regions. 

Tested by running `deploy.sh` locally. Successfully created the correct Cloudfront distribution.