### PR TITLE
Default date selector to today

### DIFF
--- a/common/components/inputs/DateSelector.tsx
+++ b/common/components/inputs/DateSelector.tsx
@@ -15,24 +15,26 @@ export const DateSelector: React.FC<DateSelectorProps> = ({ range }) => {
   const updateQueryParams = useUpdateQuery({ range });
   const maxDate = getCurrentDate();
 
-  const dates = useMemo(
-    () => ({
-      startDate: startDate ?? null,
-      endDate: endDate ?? startDate ?? null,
-    }),
-    [startDate, endDate]
-  );
+  const dates = useMemo(() => {
+    return startDate
+      ? {
+          startDate: startDate,
+          endDate: endDate ?? startDate,
+        }
+      : null;
+  }, [startDate, endDate]);
 
   return (
     <Datepicker
       primaryColor={linePath !== 'bus' ? linePath : 'yellow'}
       value={dates}
+      placeholder="Date"
       onChange={(evt) => updateQueryParams(evt)}
       maxDate={maxDate}
       asSingle={!range}
       useRange={range}
       showShortcuts={true}
-      displayFormat={'YYYY-MM-DD'}
+      displayFormat={'M/D/YY'}
       containerClassName={'w-auto'}
       inputClassName={'h-8'}
       i18n={'en-us'}

--- a/common/components/inputs/DateSelector.tsx
+++ b/common/components/inputs/DateSelector.tsx
@@ -34,7 +34,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({ range }) => {
       asSingle={!range}
       useRange={range}
       showShortcuts={true}
-      displayFormat={'M/D/YY'}
+      displayFormat={'MMM D, YYYY'}
       containerClassName={'w-auto'}
       inputClassName={'h-8'}
       i18n={'en-us'}

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { capitalize, isEqual, pickBy } from 'lodash';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
@@ -20,17 +21,20 @@ export const useDelimitatedRoute = (): Route => {
   const path = router.asPath.split('?');
   const pathItems = path[0].split('/');
   const { startDate, endDate, busLine } = router.query;
-
   return {
     line: linePathToKeyMap[pathItems[1]],
     linePath: pathItems[1] as LinePath, //TODO: Remove as
     lineShort: capitalize(pathItems[1]) as LineShort, //TODO: Remove as
     datapage: (pathItems[2] as DataPage) || 'overview', //TODO: Remove as
-    query: {
-      startDate: Array.isArray(startDate) ? startDate[0] : startDate,
-      endDate: Array.isArray(endDate) ? endDate[0] : endDate,
-      busLine: Array.isArray(busLine) ? busLine[0] : busLine ?? '22', // TODO: Remove default bus
-    },
+    query: router.isReady
+      ? {
+          startDate: Array.isArray(startDate)
+            ? startDate[0]
+            : startDate ?? dayjs().format('YYYY-MM-DD'),
+          endDate: Array.isArray(endDate) ? endDate[0] : endDate,
+          busLine: Array.isArray(busLine) ? busLine[0] : busLine ?? '22', // TODO: Remove default bus
+        }
+      : { startDate: undefined, endDate: undefined, busLine: undefined },
   };
 };
 
@@ -75,9 +79,11 @@ export const useUpdateQuery = ({ range }: { range: boolean }) => {
 // If a datapage is selected, stay on that datapage. If the current line is selected, go to overview.
 export const getLineSelectionItemHref = (metadata: LineMetadata, route: Route): string => {
   const { datapage, line, query } = route;
-  const queryParams = new URLSearchParams(
-    Object.entries(query).filter(([, value]) => value !== undefined)
-  ).toString();
+  const queryParams = query
+    ? new URLSearchParams(
+        Object.entries(query).filter(([, value]) => value !== undefined)
+      ).toString()
+    : '';
   let href = `/${metadata.path}`;
   if (metadata.key !== line && datapage) {
     if (datapage !== 'overview') {


### PR DESCRIPTION
Set default date to be current date.

Three notes:
1) I didn't put the date in the URL. So if someone shares the link it will always be today. Makes sense to me but idk. Maybe if the user is on a data page then we should add the date? Just not on overview?

2) I think the whole router situation needs some work. Lots of type weirdness. I started getting into it then undid my changes because it was getting gross.

3) Small UI change: date format YYYY-MM-DD, changed to M/D/YY. Still need to update on mobile.

![Screen Shot 2023-03-06 at 6 05 56 PM](https://user-images.githubusercontent.com/46229349/223276846-e8a430ea-54ee-413a-a7c6-2dd2ac16b990.png)
