### PR TITLE
Add simple titles and fix agg chart titles

### DIFF
--- a/common/components/charts/AggregateLineChart.tsx
+++ b/common/components/charts/AggregateLineChart.tsx
@@ -157,6 +157,11 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
               legend: {
                 display: false,
               },
+              title: {
+                // empty title to set font and leave room for drawTitle fn
+                display: true,
+                text: '',
+              },
               tooltip: {
                 mode: 'index',
                 position: 'nearest',

--- a/common/components/charts/Title.tsx
+++ b/common/components/charts/Title.tsx
@@ -101,3 +101,32 @@ export const drawTitle = (title: string, location: Location, bothStops: boolean,
   }
   ctx.restore();
 };
+
+export const drawSimpleTitle = (title: string, chart: Chart) => {
+  const ctx = chart.ctx;
+  ctx.save();
+
+  const leftMargin = chart.scales.x.left;
+  const rightMargin = chart.width - chart.scales.x.right;
+  const minGap = 10;
+  const vpos_row1 = 25;
+  const vpos_row2 = 50;
+
+  const fontSize = 16;
+  ctx.font = font(fontSize);
+  const titleWidth = ctx.measureText(title).width;
+
+  if (leftMargin + titleWidth + minGap + rightMargin > chart.width) {
+    // small screen: centered title stacks vertically
+    ctx.textAlign = 'center';
+    ctx.fillStyle = titleColor;
+    ctx.fillText(title, chart.width / 2, vpos_row1);
+  } else {
+    // larger screen
+    // Primary chart title goes left
+    ctx.textAlign = 'left';
+    ctx.fillStyle = titleColor;
+    ctx.fillText(title, leftMargin, vpos_row2);
+  }
+  ctx.restore();
+};

--- a/modules/commute/alerts/Time.tsx
+++ b/modules/commute/alerts/Time.tsx
@@ -14,7 +14,7 @@ export const CurrentTime: React.FC<TimeProps> = ({ times }) => {
   const now = dayjs();
   const timeStrings = times.map((time) => {
     if (time.end == null) {
-      return 'Indefinitely';
+      return 'Ongoing';
     }
     const startTime = dayjs(time.start);
     const endTime = dayjs(time.end);

--- a/modules/slowzones/charts/TotalSlowTime.tsx
+++ b/modules/slowzones/charts/TotalSlowTime.tsx
@@ -6,6 +6,7 @@ import { Line } from 'react-chartjs-2';
 import { COLORS, LINE_COLORS } from '../../../common/constants/colors';
 import type { DayDelayTotals } from '../../../common/types/dataPoints';
 import { useDelimitatedRoute } from '../../../common/utils/router';
+import { drawSimpleTitle } from '../../../common/components/charts/Title';
 
 interface TotalSlowTimeProps {
   data?: DayDelayTotals[];
@@ -86,11 +87,24 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({ data }) => {
           },
         },
         plugins: {
+          title: {
+            // empty title to set font and leave room for drawTitle fn
+            display: true,
+            text: '',
+          },
           legend: {
             display: false,
           },
         },
       }}
+      plugins={[
+        {
+          id: 'customTitle',
+          afterDraw: (chart) => {
+            drawSimpleTitle('Total Slow Time', chart);
+          },
+        },
+      ]}
     />
   );
 };


### PR DESCRIPTION
1) Add simple title for charts without stops.

2) Fix bug where title is overlaid on agg charts

**1**
![Screen Shot 2023-03-30 at 2 36 02 PM](https://user-images.githubusercontent.com/46229349/228932281-e408664d-af7b-4c9f-8e06-b54d655b70c9.png)
**2**
![Screen Shot 2023-03-30 at 2 36 39 PM](https://user-images.githubusercontent.com/46229349/228932589-67eb017d-d703-4db5-92f2-2e4ea67c4793.png)
