### PR TITLE
Add line health date range (not functional)

### DIFF
--- a/common/components/general/ButtonGroup.tsx
+++ b/common/components/general/ButtonGroup.tsx
@@ -1,0 +1,47 @@
+import { Tab } from '@headlessui/react';
+import classNames from 'classnames';
+import type { SetStateAction } from 'react';
+import React, { Fragment } from 'react';
+import { lineColorBackground, lineColorRing } from '../../styles/general';
+import { useDelimitatedRoute } from '../../utils/router';
+
+interface ButtonGroupProps<T> {
+  options: [string, T][];
+  pressFunction: React.Dispatch<SetStateAction<string>>;
+}
+
+export const ButtonGroup: <T extends string>(
+  props: ButtonGroupProps<T>
+) => React.ReactElement<ButtonGroupProps<T>> = ({ options, pressFunction }) => {
+  const { line } = useDelimitatedRoute();
+  return (
+    <Tab.Group onChange={(value) => pressFunction(options[value][0])}>
+      <Tab.List className="isolate inline-flex rounded-md shadow-sm">
+        {options.map((option, index) => {
+          return (
+            <Tab as={Fragment} key={option[0]}>
+              {({ selected }) => (
+                <button
+                  type="button"
+                  className={classNames(
+                    index === 0 ? 'rounded-l-md' : '-ml-px',
+                    index === options.length - 1 && 'rounded-r-md',
+                    'relative inline-flex items-center  px-3 py-2 text-sm ring-1 ring-inset focus:z-10',
+                    lineColorRing[line ?? 'DEFAULT'],
+                    selected
+                      ? `${lineColorBackground[line ?? 'DEFAULT']} text-white hover:bg-opacity-90`
+                      : `hover:${
+                          lineColorBackground[line ?? 'DEFAULT']
+                        } bg-white text-stone-900 hover:bg-opacity-70 hover:text-white`
+                  )}
+                >
+                  {option[1]}
+                </button>
+              )}
+            </Tab>
+          );
+        })}
+      </Tab.List>
+    </Tab.Group>
+  );
+};

--- a/common/styles/general.ts
+++ b/common/styles/general.ts
@@ -32,3 +32,12 @@ export const lineColorText = {
   BUS: `text-mbta-bus`,
   DEFAULT: `text-stone-800`,
 };
+
+export const lineColorRing = {
+  RL: `ring-mbta-red`,
+  OL: `ring-mbta-orange`,
+  GL: `ring-mbta-green`,
+  BL: `ring-mbta-blue`,
+  BUS: `ring-mbta-bus`,
+  DEFAULT: `ring-stone-800`,
+};

--- a/common/types/inputs.ts
+++ b/common/types/inputs.ts
@@ -1,5 +1,14 @@
 export interface SelectOption<T = any> {
   label: string;
   value: T;
-  id: string | number;
+  id: string;
+}
+
+export type TimeRange = 'week' | 'month' | 'year' | 'all';
+
+export enum TimeRangeNames {
+  'week' = 'Past Week',
+  'month' = 'Past Month',
+  'year' = 'Past Year',
+  'all' = 'All Time',
 }

--- a/modules/commute/alerts/Alerts.tsx
+++ b/modules/commute/alerts/Alerts.tsx
@@ -14,7 +14,7 @@ export const Alerts: React.FC = () => {
   );
 
   const divStyle = classNames(
-    'flex flex-col items-center rounded-md p-4 text-white shadow-dataBox w-full xl:w-1/2 gap-y-2 md:h-[240px] lg:h-[360px] md:overflow-y-auto',
+    'flex flex-col rounded-md p-4 text-white shadow-dataBox w-full xl:w-1/3 gap-y-2 md:max-h-[309px] md:overflow-y-auto',
     lineColorBackground[line ?? 'DEFAULT']
   );
 
@@ -27,7 +27,7 @@ export const Alerts: React.FC = () => {
 
   return (
     <div className={divStyle}>
-      <h3 className="w-full text-2xl font-bold md:w-auto">Alerts</h3>
+      <h3 className="w-full text-2xl font-semibold md:w-auto">Alerts</h3>
       <div className="flex w-full flex-row gap-x-4 overflow-x-scroll pb-2 md:flex-col md:gap-x-0 md:overflow-x-auto">
         <div className="md:w-full">
           <Divider title="Today" line={line} />

--- a/modules/dashboard/LineHealth.tsx
+++ b/modules/dashboard/LineHealth.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { ButtonGroup } from '../../common/components/general/ButtonGroup';
+import type { TimeRange } from '../../common/types/inputs';
+import { TimeRangeNames } from '../../common/types/inputs';
+import { useDelimitatedRoute } from '../../common/utils/router';
+import { DwellsWidget } from '../dwells/DwellsWidget';
+import { HeadwaysWidget } from '../headways/HeadwaysWidget';
+import { RidershipWidget } from '../ridership/RidershipWidget';
+import SlowZonesWidget from '../slowzones/SlowZonesWidget';
+import { TravelTimesWidget } from '../traveltimes/TravelTimesWidget';
+
+export const LineHealth = () => {
+  const [timeRange, setTimeRange] = useState<TimeRange>('week');
+  const { tab } = useDelimitatedRoute();
+
+  return (
+    <div>
+      <div className="flex w-full flex-col justify-between sm:flex-row">
+        <h1 className="text-xl">Line Health</h1>
+        <ButtonGroup pressFunction={setTimeRange} options={Object.entries(TimeRangeNames)} />
+      </div>
+      <hr className="my-2 h-[2px] border-0 border-b border-white bg-gray-400" />
+      <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
+        {tab === 'Subway' && <SlowZonesWidget />}
+        <TravelTimesWidget />
+        <HeadwaysWidget />
+        {tab === 'Subway' && <DwellsWidget />}
+        <RidershipWidget />
+      </div>
+    </div>
+  );
+};

--- a/modules/dashboard/Overview.tsx
+++ b/modules/dashboard/Overview.tsx
@@ -1,33 +1,12 @@
 import React from 'react';
-import { useDelimitatedRoute } from '../../common/utils/router';
-import { DwellsWidget } from '../../modules/dwells/DwellsWidget';
-import { HeadwaysWidget } from '../../modules/headways/HeadwaysWidget';
-import SlowZonesWidget from '../../modules/slowzones/SlowZonesWidget';
-import { TravelTimesWidget } from '../../modules/traveltimes/TravelTimesWidget';
-import { Alerts } from '../commute/alerts/Alerts';
-import { RidershipWidget } from '../ridership/RidershipWidget';
+import { LineHealth } from './LineHealth';
+import { TodaysCommute } from './TodaysCommute';
 
 export default function Overview() {
-  const { tab } = useDelimitatedRoute();
   return (
     <div className="flex flex-col gap-y-8 pt-2">
-      <div>
-        <h1 className="text-xl">Today's Commute</h1>
-        <hr className="my-2 h-[2px] border-0 border-b border-white bg-gray-400" />
-        <Alerts />
-      </div>
-      <div>
-        <h1 className="text-xl">Line Health</h1>
-        <hr className="my-2 h-[2px] border-0 border-b border-white bg-gray-400" />
-
-        <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
-          <TravelTimesWidget />
-          {tab === 'Subway' && <SlowZonesWidget />}
-          <HeadwaysWidget />
-          {tab === 'Subway' && <DwellsWidget />}
-          <RidershipWidget />
-        </div>
-      </div>
+      <TodaysCommute />
+      <LineHealth />
     </div>
   );
 }

--- a/modules/dashboard/TodaysCommute.tsx
+++ b/modules/dashboard/TodaysCommute.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Alerts } from '../commute/alerts/Alerts';
+export const TodaysCommute = () => {
+  return (
+    <div>
+      <h1 className="text-xl">Today's Commute</h1>
+      <hr className="my-2 h-[2px] border-0 border-b border-white bg-gray-400" />
+      <div className="flex flex-col gap-y-2 gap-x-4 xl:flex-row">
+        <Alerts />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
- Add date range selector to line health section of overview page. It is not functional yet, that's next.
- Minor alerts style changes in preparation for `speed` metric
- Refactor overview component into `LineHealth` and`TodaysCommute` components

![Screen Shot 2023-03-30 at 2 40 24 PM](https://user-images.githubusercontent.com/46229349/228933222-917b1ac1-eb04-447c-97ce-4c5b67497b57.png)
