### PR TITLE
Add customizable layouts

### DIFF
--- a/common/components/Layouts.tsx
+++ b/common/components/Layouts.tsx
@@ -1,0 +1,10 @@
+import { DashboardLayout } from '../layouts/DashboardLayout';
+import { MetricsLayout } from '../layouts/MetricsLayout';
+import { TripExplorerLayout } from '../layouts/TripExplorerLayout';
+import type { LayoutNames } from '../layouts/layoutTypes';
+export const Layouts: { [key in LayoutNames]: ({ children }) => JSX.Element } = {
+  Dashboards: DashboardLayout,
+  Metrics: MetricsLayout,
+  Trips: TripExplorerLayout,
+};
+export type LayoutKeys = keyof typeof Layouts;

--- a/common/components/Layouts.tsx
+++ b/common/components/Layouts.tsx
@@ -1,4 +1,5 @@
 import { DashboardLayout } from '../layouts/DashboardLayout';
+import { EmptyLayout } from '../layouts/EmptyLayout';
 import { MetricsLayout } from '../layouts/MetricsLayout';
 import { TripExplorerLayout } from '../layouts/TripExplorerLayout';
 import type { LayoutNames } from '../layouts/layoutTypes';
@@ -6,5 +7,6 @@ export const Layouts: { [key in LayoutNames]: ({ children }) => JSX.Element } = 
   Dashboards: DashboardLayout,
   Metrics: MetricsLayout,
   Trips: TripExplorerLayout,
+  Empty: EmptyLayout,
 };
 export type LayoutKeys = keyof typeof Layouts;

--- a/common/components/inputs/DateSelection/DateSelection.tsx
+++ b/common/components/inputs/DateSelection/DateSelection.tsx
@@ -7,8 +7,8 @@ import { faCalendarDay, faCalendarWeek } from '@fortawesome/free-solid-svg-icons
 import { lineColorBackground, lineColorDarkBorder } from '../../../styles/general';
 import { useDelimitatedRoute, useUpdateQuery } from '../../../utils/router';
 import { buttonHighlightConfig } from '../styles/inputStyle';
-import { DatePickers } from './DatePickers';
 import { DATE_PICKER_PRESETS, TODAY_STRING } from '../../../constants/dates';
+import { DatePickers } from './DatePickers';
 import type { DateSelectionInput } from './types/DateSelectionTypes';
 import { RangeSelectionTab } from './RangeSelectionTab';
 import { DatePickerPresets } from './DatePickerPresets';
@@ -47,7 +47,7 @@ export const DateSelection = () => {
   return (
     <div
       className={classNames(
-        'flex h-full max-w-full flex-row  items-baseline overflow-hidden rounded-t-md border md:rounded-md',
+        'flex h-full max-w-full flex-row items-baseline  overflow-hidden rounded-t-md border md:max-w-sm md:rounded-md',
         lineColorDarkBorder[line ?? 'DEFAULT']
       )}
     >

--- a/common/layouts/EmptyLayout.tsx
+++ b/common/layouts/EmptyLayout.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const EmptyLayout = ({ children }) => {
+  return <>{children}</>;
+};

--- a/common/layouts/MetricsLayout.tsx
+++ b/common/layouts/MetricsLayout.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { BottomNavBar } from '../../modules/navigation/mobile/BottomNavBar';
+import { useBreakpoint } from '../hooks/useBreakpoint';
 import { WidgetPage } from '../components/widgets/Widget';
 import { SideNavBar } from '../../modules/navigation/desktop/SideNavBar';
+import { DataPageHeader } from '../../modules/dashboard/DataPageHeader';
 import { Footer } from './Footer';
 
-export const DashboardLayout = ({ children }) => {
+export const MetricsLayout = ({ children }) => {
+  const isMobile = !useBreakpoint('md');
+
   return (
     <div className="flex min-h-full flex-col justify-between">
       <SideNavBar />
@@ -11,10 +16,18 @@ export const DashboardLayout = ({ children }) => {
         <main className="flex-1">
           <div className="py-2 md:py-6">
             <div className="h-full px-4 sm:px-6 md:px-8">
-              <WidgetPage>{children}</WidgetPage>
+              <WidgetPage>
+                <DataPageHeader />
+                {children}
+              </WidgetPage>
             </div>
           </div>
         </main>
+        {isMobile && (
+          <>
+            <BottomNavBar />
+          </>
+        )}
       </div>
       <Footer />
     </div>

--- a/common/layouts/TripExplorerLayout.tsx
+++ b/common/layouts/TripExplorerLayout.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { BottomNavBar } from '../../modules/navigation/mobile/BottomNavBar';
+import { useBreakpoint } from '../hooks/useBreakpoint';
 import { WidgetPage } from '../components/widgets/Widget';
 import { SideNavBar } from '../../modules/navigation/desktop/SideNavBar';
+import { DateSelection } from '../components/inputs/DateSelection/DateSelection';
 import { Footer } from './Footer';
 
-export const DashboardLayout = ({ children }) => {
+export const TripExplorerLayout = ({ children }) => {
+  const isMobile = !useBreakpoint('md');
+
   return (
     <div className="flex min-h-full flex-col justify-between">
       <SideNavBar />
@@ -11,10 +16,16 @@ export const DashboardLayout = ({ children }) => {
         <main className="flex-1">
           <div className="py-2 md:py-6">
             <div className="h-full px-4 sm:px-6 md:px-8">
+              <DateSelection />
               <WidgetPage>{children}</WidgetPage>
             </div>
           </div>
         </main>
+        {isMobile && (
+          <>
+            <BottomNavBar />
+          </>
+        )}
       </div>
       <Footer />
     </div>

--- a/common/layouts/layoutTypes.ts
+++ b/common/layouts/layoutTypes.ts
@@ -1,0 +1,7 @@
+export enum LayoutType {
+  Dashboards = 'Dashboards',
+  Metrics = 'Metrics',
+  Trips = 'Trips',
+}
+
+export type LayoutNames = LayoutType;

--- a/common/layouts/layoutTypes.ts
+++ b/common/layouts/layoutTypes.ts
@@ -2,6 +2,7 @@ export enum LayoutType {
   Dashboards = 'Dashboards',
   Metrics = 'Metrics',
   Trips = 'Trips',
+  Empty = 'Empty',
 }
 
 export type LayoutNames = LayoutType;

--- a/modules/dashboard/Overview.tsx
+++ b/modules/dashboard/Overview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { LineHealth } from './LineHealth';
 import { TodaysCommute } from './TodaysCommute';
 
@@ -10,3 +11,4 @@ export default function Overview() {
     </div>
   );
 }
+Overview.Layout = LayoutType.Metrics;

--- a/modules/dwells/DwellsDetails.tsx
+++ b/modules/dwells/DwellsDetails.tsx
@@ -12,6 +12,7 @@ import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWi
 import { averageDwells, longestDwells } from '../../common/utils/dwells';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { DwellsSingleChart } from './charts/DwellsSingleChart';
 import { DwellsAggregateChart } from './charts/DwellsAggregateChart';
 
@@ -94,3 +95,4 @@ export default function DwellsDetails() {
     </>
   );
 }
+DwellsDetails.Layout = LayoutType.Metrics;

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -13,6 +13,7 @@ import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWi
 import { averageHeadway, longestHeadway } from '../../common/utils/headways';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { HeadwaysSingleChart } from './charts/HeadwaysSingleChart';
 import { HeadwaysHistogram } from './charts/HeadwaysHistogram';
 import { HeadwaysAggregateChart } from './charts/HeadwaysAggregateChart';
@@ -119,3 +120,4 @@ export default function HeadwaysDetails() {
     </>
   );
 }
+HeadwaysDetails.Layout = LayoutType.Metrics;

--- a/modules/ridership/RidershipDetails.tsx
+++ b/modules/ridership/RidershipDetails.tsx
@@ -7,10 +7,11 @@ import { PercentageWidgetValue, TripsWidgetValue } from '../../common/types/basi
 import type { ServiceDay } from '../../common/types/ridership';
 import { getHighestTphValue, normalizeToPercent } from '../../common/utils/ridership';
 import { useDelimitatedRoute } from '../../common/utils/router';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { ServiceRidershipChart } from './charts/ServiceRidershipChart';
 import { TphChart } from './charts/TphChart';
 
-export default function TravelTimesDetails() {
+export default function RidershipDetails() {
   const allRidership = useRidershipData();
 
   const {
@@ -80,3 +81,4 @@ export default function TravelTimesDetails() {
     </>
   );
 }
+RidershipDetails.Layout = LayoutType.Metrics;

--- a/modules/slowzones/SlowZonesDetails.tsx
+++ b/modules/slowzones/SlowZonesDetails.tsx
@@ -6,6 +6,7 @@ import utc from 'dayjs/plugin/utc';
 import { useQuery } from '@tanstack/react-query';
 
 import { useDelimitatedRoute } from '../../common/utils/router';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { WidgetTitle } from '../dashboard/WidgetTitle';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
 import { fetchAllSlow, fetchDelayTotals } from './api/slowzones';
@@ -74,3 +75,4 @@ export default function SlowZonesDetails() {
     </div>
   );
 }
+SlowZonesDetails.Layout = LayoutType.Metrics;

--- a/modules/traveltimes/TravelTimesDetails.tsx
+++ b/modules/traveltimes/TravelTimesDetails.tsx
@@ -13,6 +13,7 @@ import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWi
 import { averageTravelTime } from '../../common/utils/traveltimes';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { TravelTimesSingleChart } from './charts/TravelTimesSingleChart';
 import { TravelTimesAggregateChart } from './charts/TravelTimesAggregateChart';
 
@@ -111,3 +112,4 @@ export default function TravelTimesDetails() {
     </>
   );
 }
+TravelTimesDetails.Layout = LayoutType.Metrics;

--- a/modules/tripexplorer/TripExplorer.tsx
+++ b/modules/tripexplorer/TripExplorer.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { optionsStation } from '../../common/utils/stations';
+import { LayoutType } from '../../common/layouts/layoutTypes';
 import { TripGraphs } from './TripGraphs';
 
 export const TripExplorer = () => {
@@ -25,3 +26,5 @@ export const TripExplorer = () => {
     </div>
   );
 };
+
+TripExplorer.Layout = LayoutType.Trips;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,17 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { config } from '@fortawesome/fontawesome-svg-core';
-import { DashboardLayout } from '../common/layouts/DashboardLayout';
 import { Layout } from '../common/layouts/Layout';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import '../styles/dashboard.css';
 import '../styles/globals.css';
+import { Layouts } from '../common/components/Layouts';
 
 config.autoAddCss = false;
 
 export default function App({ Component, pageProps }) {
   const [loaded, setLoaded] = useState(false);
-
+  const SecondaryLayout = Layouts[Component.Layout] ?? ((page) => page);
   // Don't load on the server. This prevents hydration errors between mobile/desktop layouts.
   useEffect(() => {
     setLoaded(true);
@@ -20,9 +20,9 @@ export default function App({ Component, pageProps }) {
 
   return (
     <Layout>
-      <DashboardLayout>
+      <SecondaryLayout>
         <Component {...pageProps} />
-      </DashboardLayout>
+      </SecondaryLayout>
     </Layout>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,12 +6,13 @@ import '@fortawesome/fontawesome-svg-core/styles.css';
 import '../styles/dashboard.css';
 import '../styles/globals.css';
 import { Layouts } from '../common/components/Layouts';
+import { LayoutType } from '../common/layouts/layoutTypes';
 
 config.autoAddCss = false;
 
 export default function App({ Component, pageProps }) {
   const [loaded, setLoaded] = useState(false);
-  const SecondaryLayout = Layouts[Component.Layout] ?? ((page) => page);
+  const SecondaryLayout = Layouts[Component.Layout ?? LayoutType.Empty];
   // Don't load on the server. This prevents hydration errors between mobile/desktop layouts.
   useEffect(() => {
     setLoaded(true);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import Link from 'next/link';
+import { LayoutType } from '../common/layouts/layoutTypes';
 
 export default function Home() {
   return (
@@ -28,3 +29,4 @@ export default function Home() {
     </>
   );
 }
+Home.Layout = LayoutType.Dashboards;


### PR DESCRIPTION
Add layouts to all top-level pages. First step of a bit of a navigation revamp. I have it mostly ready if anyone wants to see that.

The idea is to break the pages into section which share the same filters.  Biggest difference with what we have is that now line-wide metrics like Slow zones, ridership, etc. won't be in a group of tabs alongside station-specific metrics like travel times, headways, dwells. They will be in another section of the app, "Trips" which is more like the classic dashboards (open to other names for this). This will also allow us to bring in other types of visualizations like the New Train tracker more easily without having to force it into the same mold.

4 layouts currently (subject to change):

1) MetricsLayout (same as the `DashboardLayout` from before)
2) DashboardLayout -  no header, no date selector
3) TripExplorerLayout - date selector, no header
4) EmptyLayout - nothing. Helps prevent cryptic error if no layout is used. Easier to debug.

The only visual difference is that the `/trips` pages do not have the data page header and neither does the index `/` page 

