### PR TITLE
Remove some codeowners for v4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @austinjpaul @skaplan-dev @devinmatte @PatrickCleary
+.github @nathan-weinberg
+deploy.sh @mathcolo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @austinjpaul @mathcolo @friendchris @nathan-weinberg @skaplan-dev @devinmatte @PatrickCleary
+* @austinjpaul @skaplan-dev @devinmatte @PatrickCleary


### PR DESCRIPTION
Removing people who aren't actively working on V4 from the `CODEOWNERS` file.

Will remove this change when merging back into main, but I figured I would save you guys a few hundred emails

@mathcolo @friendchris @nathan-weinberg if any of you don't want to be removed lmk and I can add you back.