### PR TITLE
Fix segments view to show 'ongoing' SZs

### DIFF
--- a/common/components/general/ButtonGroup.tsx
+++ b/common/components/general/ButtonGroup.tsx
@@ -15,7 +15,7 @@ export const ButtonGroup: <T extends string>(
 ) => React.ReactElement<ButtonGroupProps<T>> = ({ options, pressFunction }) => {
   const { line } = useDelimitatedRoute();
   return (
-    <Tab.Group onChange={(value) => pressFunction(options[value][0])}>
+    <Tab.Group manual onChange={(value) => pressFunction(options[value][0])}>
       <Tab.List className="isolate inline-flex rounded-md shadow-sm">
         {options.map((option, index) => {
           return (

--- a/common/constants/dates.ts
+++ b/common/constants/dates.ts
@@ -12,8 +12,8 @@ const est = 'America/New_York';
 
 export const DATE_FORMAT = 'YYYY-MM-DD';
 export const TODAY = dayjs().tz(est);
-export const TODAY_UTC = dayjs.utc().startOf('day');
-export const YESTERDAY_UTC = TODAY_UTC.subtract(1, 'day');
+export const TODAY_MIDNIGHT = dayjs().startOf('day');
+export const YESTERDAY_MIDNIGHT = TODAY_MIDNIGHT.subtract(1, 'day');
 export const TODAY_STRING = TODAY.format(DATE_FORMAT);
 export const RANGE_OPTIONS = ['Single Day', 'Range'];
 

--- a/common/utils/slowZoneUtils.ts
+++ b/common/utils/slowZoneUtils.ts
@@ -11,7 +11,7 @@ import type {
   SlowZone,
   SlowZoneResponse,
 } from '../../common/types/dataPoints';
-import { TODAY_UTC } from '../constants/dates';
+import { TODAY_MIDNIGHT } from '../constants/dates';
 import type { LineShort } from '../types/lines';
 import { lookup_station_by_id } from './stations';
 
@@ -140,7 +140,7 @@ export const useSlowZoneQuantityDelta = (
     const end =
       allSlow.filter((sz) => {
         const zoneEnd = dayjs.utc(sz.end);
-        if (endDateUTC.isSame(TODAY_UTC, 'day')) {
+        if (endDateUTC.isSame(TODAY_MIDNIGHT, 'day')) {
           // Our latest SZ data is always 1 day behind. So use yesterday's data.
           return zoneEnd.isSameOrAfter(endDateUTC.subtract(1, 'day'));
         }

--- a/modules/ridership/RidershipDetails.tsx
+++ b/modules/ridership/RidershipDetails.tsx
@@ -10,7 +10,7 @@ import { useDelimitatedRoute } from '../../common/utils/router';
 import { ServiceRidershipChart } from './charts/ServiceRidershipChart';
 import { TphChart } from './charts/TphChart';
 
-export default function TravelTimesDetails() {
+export default function RidershipDetails() {
   const allRidership = useRidershipData();
 
   const {

--- a/modules/slowzones/charts/LineSegments.tsx
+++ b/modules/slowzones/charts/LineSegments.tsx
@@ -17,7 +17,7 @@ dayjs.extend(utc);
 
 import React, { useMemo, useRef } from 'react';
 import { Bar } from 'react-chartjs-2';
-import { YESTERDAY_UTC } from '../../../common/constants/dates';
+import { YESTERDAY_MIDNIGHT } from '../../../common/constants/dates';
 import { COLORS } from '../../../common/constants/colors';
 import type { LineSegmentData, SlowZone } from '../../../common/types/dataPoints';
 import type { LineShort } from '../../../common/types/lines';
@@ -121,7 +121,7 @@ export const LineSegments: React.FC<LineSegmentsProps> = ({
                 const startUTC = dayjs.utc(start);
                 const endUTC = dayjs.utc(end);
                 return `${startUTC.format('MMM D, YYYY')} - ${
-                  dayjs.utc(endUTC).isSame(YESTERDAY_UTC)
+                  dayjs.utc(endUTC).isSame(YESTERDAY_MIDNIGHT)
                     ? 'Ongoing'
                     : dayjs(endUTC).format('MMM D, YYYY')
                 }`;


### PR DESCRIPTION
When a SZ "ends" yesterday, mark it as ongoing. I accidentally broke this a few days ago.


![Screen Shot 2023-04-06 at 2 16 40 PM](https://user-images.githubusercontent.com/46229349/230461914-6b054ea4-acff-40d4-b155-b14954ff70f2.png)
