### PR TITLE
Eslint `prefer-destructuring` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,13 @@ module.exports = {
         disallowTypeAnnotations: false,
       },
     ],
+    'prefer-destructuring': [
+      'warn',
+      {
+        array: false,
+        object: true,
+      },
+    ],
   },
   settings: {
     react: {

--- a/common/components/alerts/AlertFilter.ts
+++ b/common/components/alerts/AlertFilter.ts
@@ -21,7 +21,7 @@ const anti = [
  * like "Reduced speeds" or "Up to 15 minutes"
  */
 export const findMatch = (alert: OldAlert) => {
-  const text = alert.text;
+  const { text } = alert;
 
   if (anti.some((exp) => text.match(exp))) {
     return false;

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -223,9 +223,9 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
               afterDraw: (chart) => {
                 if ((date === undefined || date.length === 0) && !isLoading) {
                   // No data is present
-                  const ctx = chart.ctx;
-                  const width = chart.width;
-                  const height = chart.height;
+                  const { ctx } = chart;
+                  const { width } = chart;
+                  const { height } = chart;
                   chart.clear();
 
                   ctx.save();

--- a/common/components/charts/Title.tsx
+++ b/common/components/charts/Title.tsx
@@ -44,7 +44,7 @@ const calcLocationWidth = (words: TitleFormat[], ctx: CanvasRenderingContext2D) 
 };
 
 export const drawTitle = (title: string, location: Location, bothStops: boolean, chart: Chart) => {
-  const ctx = chart.ctx;
+  const { ctx } = chart;
   ctx.save();
 
   const leftMargin = chart.scales.x.left;
@@ -103,7 +103,7 @@ export const drawTitle = (title: string, location: Location, bothStops: boolean,
 };
 
 export const drawSimpleTitle = (title: string, chart: Chart) => {
-  const ctx = chart.ctx;
+  const { ctx } = chart;
   ctx.save();
 
   const leftMargin = chart.scales.x.left;

--- a/modules/headways/charts/HeadwaysHistogram.tsx
+++ b/modules/headways/charts/HeadwaysHistogram.tsx
@@ -112,7 +112,7 @@ export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({
                     return '';
                   }
                   const item = items[0];
-                  const x = item.parsed.x;
+                  const { x } = item.parsed;
                   const min = x - 0.5;
                   const max = x + 0.5;
                   return `${min} - ${max} min.`;
@@ -139,9 +139,9 @@ export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({
             afterDraw: (chart) => {
               if ((startDate === undefined || startDate.length === 0) && !isLoading) {
                 // No data is present
-                const ctx = chart.ctx;
-                const width = chart.width;
-                const height = chart.height;
+                const { ctx } = chart;
+                const { width } = chart;
+                const { height } = chart;
                 chart.clear();
 
                 ctx.save();

--- a/modules/speed/SpeedGraph.tsx
+++ b/modules/speed/SpeedGraph.tsx
@@ -137,9 +137,9 @@ export const SpeedGraph: React.FC<SpeedGraphProps> = ({ data, timeRange }) => {
           afterDraw: (chart) => {
             if (startDate === undefined || startDate.length === 0) {
               // No data is present
-              const ctx = chart.ctx;
-              const width = chart.width;
-              const height = chart.height;
+              const { ctx } = chart;
+              const { width } = chart;
+              const { height } = chart;
               chart.clear();
 
               ctx.save();


### PR DESCRIPTION
## Motivation

Noticed there were some spots we could better enforce destructuring, turns out there's a default eslint rule for it

## Changes

- Adds a new rule to eslint to warn on cases where destructuring makes sense (most will be autofixable by vscode or eslint cli)