### PR TITLE
V4/line seg bug

### DIFF
--- a/modules/slowzones/charts/LineSegments.tsx
+++ b/modules/slowzones/charts/LineSegments.tsx
@@ -112,7 +112,7 @@ export const LineSegments: React.FC<LineSegmentsProps> = ({
                 return context[0].label;
               },
               label: (context) => {
-                return 'Delay: ' + data[context.datasetIndex].delay.toFixed(0) + ' sec';
+                return 'Delay: ' + data[context.dataIndex].delay.toFixed(0) + ' sec';
               },
               beforeBody: (context) => {
                 const start = context[0].parsed._custom?.barStart;


### PR DESCRIPTION
Fixing a bug I introduced to the SZ line segment graph a few days ago.

Was using the dataset index rather than the data index in the chartJS tooltip. So it always gave 0 which meant all of the tooltips were using the first entry in the dataset.