### PR TITLE
No unused props eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     'react/react-in-jsx-scope': 'warn',
+    'react/no-unused-prop-types': 'warn',
     'unused-imports/no-unused-imports': 'error',
     'no-console': 'error',
     '@typescript-eslint/ban-ts-comment': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,13 @@ module.exports = {
         disallowTypeAnnotations: false,
       },
     ],
+    'prefer-destructuring': [
+      'warn',
+      {
+        array: false,
+        object: true,
+      },
+    ],
   },
   settings: {
     react: {

--- a/common/components/alerts/AlertFilter.ts
+++ b/common/components/alerts/AlertFilter.ts
@@ -21,7 +21,7 @@ const anti = [
  * like "Reduced speeds" or "Up to 15 minutes"
  */
 export const findMatch = (alert: OldAlert) => {
-  const text = alert.text;
+  const { text } = alert;
 
   if (anti.some((exp) => text.match(exp))) {
     return false;

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -223,9 +223,9 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
               afterDraw: (chart) => {
                 if ((date === undefined || date.length === 0) && !isLoading) {
                   // No data is present
-                  const ctx = chart.ctx;
-                  const width = chart.width;
-                  const height = chart.height;
+                  const { ctx } = chart;
+                  const { width } = chart;
+                  const { height } = chart;
                   chart.clear();
 
                   ctx.save();

--- a/common/components/charts/Title.tsx
+++ b/common/components/charts/Title.tsx
@@ -44,7 +44,7 @@ const calcLocationWidth = (words: TitleFormat[], ctx: CanvasRenderingContext2D) 
 };
 
 export const drawTitle = (title: string, location: Location, bothStops: boolean, chart: Chart) => {
-  const ctx = chart.ctx;
+  const { ctx } = chart;
   ctx.save();
 
   const leftMargin = chart.scales.x.left;
@@ -103,7 +103,7 @@ export const drawTitle = (title: string, location: Location, bothStops: boolean,
 };
 
 export const drawSimpleTitle = (title: string, chart: Chart) => {
-  const ctx = chart.ctx;
+  const { ctx } = chart;
   ctx.save();
 
   const leftMargin = chart.scales.x.left;

--- a/modules/headways/charts/HeadwaysHistogram.tsx
+++ b/modules/headways/charts/HeadwaysHistogram.tsx
@@ -112,7 +112,7 @@ export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({
                     return '';
                   }
                   const item = items[0];
-                  const x = item.parsed.x;
+                  const { x } = item.parsed;
                   const min = x - 0.5;
                   const max = x + 0.5;
                   return `${min} - ${max} min.`;
@@ -139,9 +139,9 @@ export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({
             afterDraw: (chart) => {
               if ((startDate === undefined || startDate.length === 0) && !isLoading) {
                 // No data is present
-                const ctx = chart.ctx;
-                const width = chart.width;
-                const height = chart.height;
+                const { ctx } = chart;
+                const { width } = chart;
+                const { height } = chart;
                 chart.clear();
 
                 ctx.save();

--- a/modules/speed/SpeedGraph.tsx
+++ b/modules/speed/SpeedGraph.tsx
@@ -137,9 +137,9 @@ export const SpeedGraph: React.FC<SpeedGraphProps> = ({ data, timeRange }) => {
           afterDraw: (chart) => {
             if (startDate === undefined || startDate.length === 0) {
               // No data is present
-              const ctx = chart.ctx;
-              const width = chart.width;
-              const height = chart.height;
+              const { ctx } = chart;
+              const { width } = chart;
+              const { height } = chart;
               chart.clear();
 
               ctx.save();


### PR DESCRIPTION
## Motivation

Ensure we don't have any unused props on components

## Changes

- Adds `react/no-unused-prop-types` as a warn

## Testing Instructions

Remove all usage of a prop, ensure that the interface line is now a warning for that component