### PR TITLE
Quick follow-up for Slow Zones map label styling

### DIFF
--- a/common/components/maps/LineMap.stories.tsx
+++ b/common/components/maps/LineMap.stories.tsx
@@ -22,24 +22,24 @@ const redLineSegments: SegmentRenderOptions[] = [
       { offset: -2, stroke: 'red', opacity: 0.6 },
       { offset: -3, stroke: 'red', opacity: 0.8 },
     ],
-    labels: {
-      '0': {
-        widthWhenVertical: 40,
-        heightWhenHorizontal: 40,
+    labels: [
+      {
+        mapSide: '0',
+        boundingSize: 40,
         content: (
           <div style={{ fontSize: 4 }}>
             Greetings amigos thank you for inviting me into your SVG
           </div>
         ),
       },
-      '1': {
-        widthWhenVertical: 40,
-        heightWhenHorizontal: 40,
+      {
+        mapSide: '1',
+        boundingSize: 40,
         content: (
           <div style={{ fontSize: 4 }}>And on this side too! I also like being on this side!</div>
         ),
       },
-    },
+    ],
   },
   {
     location: {
@@ -62,14 +62,14 @@ export const Testing = () => {
         diagram={redLine}
         getStationLabel={(options) => options.stationId}
         strokeOptions={{ stroke: 'red' }}
-        getSegments={redLineSegments}
+        getSegments={() => redLineSegments}
       />
       <LineMap
         direction="vertical"
         diagram={redLine}
         getStationLabel={(options) => options.stationId}
         strokeOptions={{ stroke: 'red' }}
-        getSegments={redLineSegments}
+        getSegments={() => redLineSegments}
       />
     </>
   );

--- a/common/components/maps/LineMap.stories.tsx
+++ b/common/components/maps/LineMap.stories.tsx
@@ -62,14 +62,14 @@ export const Testing = () => {
         diagram={redLine}
         getStationLabel={(options) => options.stationId}
         strokeOptions={{ stroke: 'red' }}
-        segments={redLineSegments}
+        getSegments={redLineSegments}
       />
       <LineMap
         direction="vertical"
         diagram={redLine}
         getStationLabel={(options) => options.stationId}
         strokeOptions={{ stroke: 'red' }}
-        segments={redLineSegments}
+        getSegments={redLineSegments}
       />
     </>
   );

--- a/modules/slowzones/map/SlowSegmentLabel.module.css
+++ b/modules/slowzones/map/SlowSegmentLabel.module.css
@@ -6,11 +6,11 @@
     width: 100%;
     height: 100%;
     /* This is in weird SVG values btw */
-    font-size: 2pt;
+    font-size: 2.5pt;
 }
 
 .slowZoneLabel {
     display: flex;
     align-items: baseline;
-    gap: 1px;
+    gap: 1.5px;
 }

--- a/modules/slowzones/map/SlowSegmentLabel.tsx
+++ b/modules/slowzones/map/SlowSegmentLabel.tsx
@@ -27,7 +27,7 @@ const SlowZoneLabel: React.FC<SlowZoneLabelProps> = ({
   direction,
   isHorizontal,
   color,
-  slowZone: { delay },
+  slowZone: { delay, baseline },
 }) => {
   const delayString = useMemo(
     () =>
@@ -39,9 +39,14 @@ const SlowZoneLabel: React.FC<SlowZoneLabelProps> = ({
     [delay]
   );
 
+  const fractionOverBaseline = -1 + (delay + baseline) / baseline;
+
   return (
     <div
-      style={{ flexDirection: isHorizontal && direction === '0' ? 'row-reverse' : 'row' }}
+      style={{
+        flexDirection: isHorizontal && direction === '0' ? 'row-reverse' : 'row',
+        fontWeight: fractionOverBaseline >= 0.5 ? 'bold' : 'normal',
+      }}
       className={styles.slowZoneLabel}
     >
       <DirectionIndicator
@@ -50,7 +55,7 @@ const SlowZoneLabel: React.FC<SlowZoneLabelProps> = ({
         isHorizontal={isHorizontal}
         size={2}
       />
-      {delayString}
+      +{delayString}
     </div>
   );
 };
@@ -58,7 +63,7 @@ const SlowZoneLabel: React.FC<SlowZoneLabelProps> = ({
 export const SlowSegmentLabel: React.FC<SlowSegmentLabelProps> = (props) => {
   const { isHorizontal, slowZonesByDirection, line } = props;
   return (
-    <div className={styles.slowSegmentLabel} style={{ marginBottom: isHorizontal ? 1 : 0 }}>
+    <div className={styles.slowSegmentLabel}>
       {DIRECTIONS.map((direction) => {
         const zone = slowZonesByDirection[direction];
         if (!zone) {

--- a/modules/slowzones/map/SlowZonesMap.tsx
+++ b/modules/slowzones/map/SlowZonesMap.tsx
@@ -5,8 +5,8 @@ import type { SegmentLocation } from '../../../common/components/maps';
 import { LineMap, createDefaultDiagramForLine } from '../../../common/components/maps';
 import type { SlowZoneResponse } from '../../../common/types/dataPoints';
 import type { SlowZonesLineName } from '../types';
-import type { SegmentRenderOptions } from '../../../common/components/maps/LineMap';
 
+import type { SegmentLabel } from '../../../common/components/maps/LineMap';
 import { segmentSlowZones } from './segment';
 import { SlowSegmentLabel } from './SlowSegmentLabel';
 import { SlowZonesTooltip } from './SlowZonesTooltip';
@@ -27,7 +27,29 @@ const abbreviateStationName = ({ stationName }) => {
     .replace('Government Center', "Gov't Center")
     .replace('Northeastern University', 'Northeastern')
     .replace('Museum of Fine Arts', 'MFA')
-    .replace('Massachusetts Avenue', 'Mass Ave');
+    .replace('Massachusetts Avenue', 'Mass Ave')
+    .replace('North Quincy', 'N. Quincy');
+};
+
+const getSegmentLabelOverrides = (
+  segmentLocation: SegmentLocation,
+  isHorizontal: boolean
+): null | Partial<SegmentLabel> => {
+  const { toStationId } = segmentLocation;
+  // JFK to Savin Hill — on a steep curve
+  if (toStationId === 'place-shmnl') {
+    return {
+      mapSide: '1',
+      offset: isHorizontal ? { x: -12, y: -5 } : { x: 0, y: 0 },
+    };
+  }
+  // Shawmut to Ashmont — obscured by "North Quincy" label
+  if (!isHorizontal && toStationId === 'place-asmnl') {
+    return {
+      mapSide: '1',
+    };
+  }
+  return null;
 };
 
 const getSlownessFactor = (zones: SlowZoneResponse | SlowZoneResponse[]) => {
@@ -61,16 +83,16 @@ export const SlowZonesMap: React.FC<SlowZonesMapProps> = ({ lineName, slowZones,
     [slowZones, line]
   );
 
-  const segmentsForSlowZones: SegmentRenderOptions[] = useMemo(() => {
+  const getSegmentsForSlowZones = ({ isHorizontal }: { isHorizontal: boolean }) => {
     return segmentedSlowZones.map((segment) => {
-      const side = segment.segmentLocation.toStationId === 'place-shmnl' ? '1' : '0';
       return {
         location: segment.segmentLocation,
-        labels: {
-          [side]: {
-            heightWhenHorizontal: 10,
-            widthWhenVertical: 15,
-            content: ({ isHorizontal }) => (
+        labels: [
+          {
+            mapSide: '0',
+            boundingSize: isHorizontal ? 15 : 20,
+            ...getSegmentLabelOverrides(segment.segmentLocation, isHorizontal),
+            content: (
               <SlowSegmentLabel
                 isHorizontal={isHorizontal}
                 slowZonesByDirection={segment.slowZonesByDirection}
@@ -78,7 +100,7 @@ export const SlowZonesMap: React.FC<SlowZonesMapProps> = ({ lineName, slowZones,
               />
             ),
           },
-        },
+        ],
         strokes: Object.entries(segment.slowZonesByDirection).map(([direction, zone]) => {
           const offset = direction === '0' ? 1 : -1;
           return {
@@ -90,7 +112,7 @@ export const SlowZonesMap: React.FC<SlowZonesMapProps> = ({ lineName, slowZones,
         }),
       };
     });
-  }, [line, segmentedSlowZones]);
+  };
 
   const diagram = useMemo(() => {
     return createDefaultDiagramForLine(lineName, { pxPerStation: 15 });
@@ -123,10 +145,10 @@ export const SlowZonesMap: React.FC<SlowZonesMapProps> = ({ lineName, slowZones,
   return (
     <LineMap
       diagram={diagram}
-      getStationLabel={abbreviateStationName}
       strokeOptions={{ stroke: line.color }}
-      segments={segmentsForSlowZones}
       direction={direction}
+      getSegments={getSegmentsForSlowZones}
+      getStationLabel={abbreviateStationName}
       tooltip={{ snapToSegment: true, maxDistance: 20, render: renderSlowZonesTooltip }}
     />
   );

--- a/modules/slowzones/map/SlowZonesMap.tsx
+++ b/modules/slowzones/map/SlowZonesMap.tsx
@@ -39,14 +39,14 @@ const getSegmentLabelOverrides = (
   // JFK to Savin Hill — on a steep curve
   if (toStationId === 'place-shmnl') {
     return {
-      mapSide: '1',
+      mapSide: '1' as const,
       offset: isHorizontal ? { x: -12, y: -5 } : { x: 0, y: 0 },
     };
   }
   // Shawmut to Ashmont — obscured by "North Quincy" label
   if (!isHorizontal && toStationId === 'place-asmnl') {
     return {
-      mapSide: '1',
+      mapSide: '1' as const,
     };
   }
   return null;
@@ -89,7 +89,7 @@ export const SlowZonesMap: React.FC<SlowZonesMapProps> = ({ lineName, slowZones,
         location: segment.segmentLocation,
         labels: [
           {
-            mapSide: '0',
+            mapSide: '0' as const,
             boundingSize: isHorizontal ? 15 : 20,
             ...getSegmentLabelOverrides(segment.segmentLocation, isHorizontal),
             content: (


### PR DESCRIPTION
## Motivation

We got some good feedback in #campaign_tmlabs about the labels on the SZ map, and I wanted to respond to those while everything is fresh in my mind. I also decided to address the issue of some slow time labels overlapping with station labels

## Changes

- Slow zones that are >=50% above baseline will have their times shown in bold
- Station labels are now slightly bigger
- I revamped the API for passing segment labels into `<LineMap>` to make it easier to control, and in particular to let you manually offset labels whose default position isn't working (cough cough Savin Hill)

## Testing Instructions

Check the RL in desktop and mobile layout and make sure the segment labels look correct!
