### PR TITLE
API Cleanup and Ridership fixes

### DIFF
--- a/common/api/datadashboard.ts
+++ b/common/api/datadashboard.ts
@@ -11,6 +11,7 @@ import { QUERIES, AggregateAPIParams, QueryNameKeys, SingleDayAPIParams } from '
 import { APP_DATA_BASE_PATH } from '../../common/utils/constants';
 import { getCurrentDate } from '../utils/date';
 import type { AggregateDataResponse, SingleDayDataPoint } from '../types/charts';
+import { ONE_MINUTE } from '../constants/time';
 
 // Fetch data for all single day charts.
 export const fetchSingleDayData = async (
@@ -115,7 +116,7 @@ export const useCustomQueries: UseQueriesOverload = (
             ? fetchAggregateData(name, queries[name].params)
             : fetchSingleDayData(name, queries[name].params),
         enabled,
-        staleTime: 30000, // Don't refetch within 30 seconds
+        staleTime: ONE_MINUTE,
       };
     }),
   });

--- a/common/api/hooks/alerts.ts
+++ b/common/api/hooks/alerts.ts
@@ -1,7 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchAlerts } from '../alerts';
 import type { LineShort } from '../../types/lines';
+import { ONE_MINUTE } from '../../constants/time';
 
 export const useAlertsData = (route: LineShort, busRoute?: string) => {
-  return useQuery(['alerts', route, busRoute], () => fetchAlerts(route, busRoute));
+  return useQuery(['alerts', route, busRoute], () => fetchAlerts(route, busRoute), {
+    staleTime: ONE_MINUTE,
+  });
 };

--- a/common/api/hooks/alerts.ts
+++ b/common/api/hooks/alerts.ts
@@ -1,0 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAlerts } from '../alerts';
+import type { LineShort } from '../../types/lines';
+
+export const useAlertsData = (route: LineShort, busRoute?: string) => {
+  return useQuery(['alerts', route, busRoute], () => fetchAlerts(route, busRoute));
+};

--- a/common/api/hooks/dwells.ts
+++ b/common/api/hooks/dwells.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import type {
+  AggregateAPIOptions,
+  AggregateAPIParams,
+  SingleDayAPIOptions,
+  SingleDayAPIParams,
+} from '../../types/api';
+import { QueryNameKeys } from '../../types/api';
+import { ONE_MINUTE } from '../../constants/time';
+import { fetchAggregateData, fetchSingleDayData } from '../datadashboard';
+
+type DwellsSingleDayOptions = Pick<
+  SingleDayAPIOptions,
+  SingleDayAPIParams.stop | SingleDayAPIParams.date
+>;
+
+type DwellsAggregateOptions = Pick<
+  AggregateAPIOptions,
+  AggregateAPIParams.stop | AggregateAPIParams.startDate | AggregateAPIParams.endDate
+>;
+
+export const useDwellsSingleDayData = (options: DwellsSingleDayOptions, enabled?: boolean) => {
+  return useQuery(
+    [QueryNameKeys.dwells, options],
+    () => {
+      return fetchSingleDayData(QueryNameKeys.dwells, options);
+    },
+    { staleTime: ONE_MINUTE, enabled }
+  );
+};
+
+export const useDwellsAggregateData = (options: DwellsAggregateOptions, enabled?: boolean) => {
+  return useQuery(
+    [QueryNameKeys.dwells, options],
+    () => {
+      return fetchAggregateData(QueryNameKeys.dwells, options);
+    },
+    { staleTime: ONE_MINUTE, enabled }
+  );
+};

--- a/common/api/hooks/headways.ts
+++ b/common/api/hooks/headways.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import type {
+  AggregateAPIOptions,
+  AggregateAPIParams,
+  SingleDayAPIOptions,
+  SingleDayAPIParams,
+} from '../../types/api';
+import { QueryNameKeys } from '../../types/api';
+import { ONE_MINUTE } from '../../constants/time';
+import { fetchAggregateData, fetchSingleDayData } from '../datadashboard';
+
+type HeadwaysSingleDayOptions = Pick<
+  SingleDayAPIOptions,
+  SingleDayAPIParams.stop | SingleDayAPIParams.date
+>;
+
+type HeadwaysAggregateOptions = Pick<
+  AggregateAPIOptions,
+  AggregateAPIParams.stop | AggregateAPIParams.startDate | AggregateAPIParams.endDate
+>;
+
+export const useHeadwaysSingleDayData = (options: HeadwaysSingleDayOptions, enabled?: boolean) => {
+  return useQuery(
+    [QueryNameKeys.headways, options],
+    () => {
+      return fetchSingleDayData(QueryNameKeys.headways, options);
+    },
+    { staleTime: ONE_MINUTE, enabled }
+  );
+};
+
+export const useHeadwaysAggregateData = (options: HeadwaysAggregateOptions, enabled?: boolean) => {
+  return useQuery(
+    [QueryNameKeys.headways, options],
+    () => {
+      return fetchAggregateData(QueryNameKeys.headways, options);
+    },
+    { staleTime: ONE_MINUTE, enabled }
+  );
+};

--- a/common/api/hooks/ridership.ts
+++ b/common/api/hooks/ridership.ts
@@ -1,0 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAllRidership } from '../ridership';
+import { TWELVE_HOURS } from '../../constants/time';
+
+export const useRidershipData = () => {
+  return useQuery(['allRidership'], fetchAllRidership, { staleTime: TWELVE_HOURS });
+};

--- a/common/api/hooks/slowzones.ts
+++ b/common/api/hooks/slowzones.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAllSlow, fetchDelayTotals } from '../slowzones';
+import { ONE_HOUR } from '../../constants/time';
+
+export const useSlowzoneAllData = () => {
+  return useQuery(['allSlow'], fetchAllSlow, { staleTime: ONE_HOUR });
+};
+
+export const useSlowzoneDelayTotalData = () => {
+  return useQuery(['delayTotals'], fetchDelayTotals, { staleTime: ONE_HOUR });
+};

--- a/common/api/hooks/speed.ts
+++ b/common/api/hooks/speed.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchSpeeds } from '../speed';
+import type { FetchSpeedsOptions } from '../../types/api';
+import { FIVE_MINUTES } from '../../constants/time';
+
+export const useSpeedData = (params: FetchSpeedsOptions) => {
+  return useQuery(['speed', params], () => fetchSpeeds(params), {
+    enabled: params.line != undefined,
+    staleTime: FIVE_MINUTES,
+  });
+};

--- a/common/api/hooks/traveltimes.ts
+++ b/common/api/hooks/traveltimes.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import type {
+  AggregateAPIOptions,
+  AggregateAPIParams,
+  SingleDayAPIOptions,
+  SingleDayAPIParams,
+} from '../../types/api';
+import { QueryNameKeys } from '../../types/api';
+import { ONE_MINUTE } from '../../constants/time';
+import { fetchAggregateData, fetchSingleDayData } from '../datadashboard';
+
+type TravelTimesSingleDayOptions = Pick<
+  SingleDayAPIOptions,
+  SingleDayAPIParams.fromStop | SingleDayAPIParams.toStop | SingleDayAPIParams.date
+>;
+
+type TravelTimesAggregateOptions = Pick<
+  AggregateAPIOptions,
+  | AggregateAPIParams.fromStop
+  | AggregateAPIParams.toStop
+  | AggregateAPIParams.startDate
+  | AggregateAPIParams.endDate
+>;
+
+export const useTravelTimesSingleDayData = (
+  options: TravelTimesSingleDayOptions,
+  enabled?: boolean
+) => {
+  return useQuery(
+    [QueryNameKeys.traveltimes, options],
+    () => {
+      return fetchSingleDayData(QueryNameKeys.traveltimes, options);
+    },
+    { staleTime: ONE_MINUTE, enabled }
+  );
+};
+
+export const useTravelTimesAggregateData = (
+  options: TravelTimesAggregateOptions,
+  enabled?: boolean
+) => {
+  return useQuery(
+    [QueryNameKeys.traveltimes, options],
+    () => {
+      return fetchAggregateData(QueryNameKeys.traveltimes, options);
+    },
+    { staleTime: ONE_MINUTE, enabled }
+  );
+};

--- a/common/api/ridership.ts
+++ b/common/api/ridership.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import type { LineData, SummaryData } from '../types/ridership';
 
 export const fetchAllRidership = (): Promise<{
@@ -7,8 +6,4 @@ export const fetchAllRidership = (): Promise<{
 }> => {
   const all_ridership_url = new URL(`/ridership.json`, window.location.origin);
   return fetch(all_ridership_url.toString()).then((resp) => resp.json());
-};
-
-export const useRidershipData = () => {
-  return useQuery(['allRidership'], fetchAllRidership);
 };

--- a/common/api/slowzones.ts
+++ b/common/api/slowzones.ts
@@ -1,4 +1,4 @@
-import type { DayDelayTotals, SlowZoneResponse } from '../../../common/types/dataPoints';
+import type { DayDelayTotals, SlowZoneResponse } from '../../common/types/dataPoints';
 
 export const fetchDelayTotals = (): Promise<DayDelayTotals[]> => {
   const url = new URL(`/static/slowzones/delay_totals.json`, window.location.origin);

--- a/common/components/inputs/RadioList.tsx
+++ b/common/components/inputs/RadioList.tsx
@@ -1,0 +1,59 @@
+import classNames from 'classnames';
+import React from 'react';
+import { useDelimitatedRoute } from '../../utils/router';
+import { buttonHighlightFocus, lineColorText } from '../../styles/general';
+
+interface RadioListProps {
+  title?: React.ReactNode;
+  legendText: React.ReactNode;
+  defaultValue?: string;
+  value: string;
+  setValue: (value: string) => void;
+  options: { value: string; label: string }[];
+}
+
+export const RadioList: React.FC<RadioListProps> = ({
+  title,
+  legendText,
+  value,
+  setValue,
+  defaultValue,
+  options,
+}) => {
+  const { line } = useDelimitatedRoute();
+
+  return (
+    <div>
+      <label className="text-base font-semibold text-gray-900">{title}</label>
+      <fieldset className="mt-4">
+        <legend className="sr-only">{legendText}</legend>
+        <div className="space-y-2">
+          {options.map((option) => (
+            <div key={option.value} className="flex items-center">
+              <input
+                id={option.value}
+                name="notification-method"
+                type="radio"
+                defaultChecked={option.value === defaultValue}
+                checked={option.value === value}
+                className={classNames(
+                  'ml-2 h-3 w-3 border-gray-300',
+                  line && `${lineColorText[line]} ${buttonHighlightFocus[line]}`
+                )}
+                onClick={() => {
+                  setValue(option.value);
+                }}
+              />
+              <label
+                htmlFor={option.value}
+                className="ml-2 block text-sm font-normal leading-6 text-gray-900"
+              >
+                {option.label}
+              </label>
+            </div>
+          ))}
+        </div>
+      </fieldset>
+    </div>
+  );
+};

--- a/common/components/inputs/ServiceDayPicker.tsx
+++ b/common/components/inputs/ServiceDayPicker.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { ServiceDay } from '../../types/ridership';
+import { RadioList } from './RadioList';
+
+interface ServiceDayPickerProps {
+  serviceDay: ServiceDay;
+  setServiceDay: (serviceDay: ServiceDay) => void;
+}
+
+export const ServiceDayPicker: React.FC<ServiceDayPickerProps> = ({
+  serviceDay,
+  setServiceDay,
+}) => {
+  const options: { value: ServiceDay; label: string }[] = [
+    { value: 'weekday', label: 'Weekday' },
+    { value: 'saturday', label: 'Saturday' },
+    { value: 'sunday', label: 'Sunday' },
+  ];
+
+  return (
+    <div className={'flex w-auto items-center'}>
+      <RadioList
+        legendText={'Service Day for Ridership'}
+        options={options}
+        defaultValue="weekday"
+        value={serviceDay}
+        setValue={setServiceDay}
+      />
+    </div>
+  );
+};

--- a/common/constants/time.ts
+++ b/common/constants/time.ts
@@ -1,0 +1,13 @@
+export const ONE_SECOND = 1000;
+export const TEN_SECONDS = 10 * ONE_SECOND;
+export const ONE_MINUTE = 60 * ONE_SECOND;
+export const TWO_MINUTES = 2 * ONE_MINUTE;
+export const FIVE_MINUTES = 5 * ONE_MINUTE;
+export const TEN_MINUTES = 10 * ONE_MINUTE;
+export const FIFTEEN_MINUTES = 15 * ONE_MINUTE;
+export const THIRTY_MINUTES = 30 * ONE_MINUTE;
+export const ONE_HOUR = 60 * ONE_MINUTE;
+export const TWO_HOURS = 2 * ONE_HOUR;
+export const THREE_HOURS = 3 * ONE_HOUR;
+export const FOUR_HOURS = 4 * ONE_HOUR;
+export const TWELVE_HOURS = 12 * ONE_HOUR;

--- a/modules/commute/alerts/Alerts.tsx
+++ b/modules/commute/alerts/Alerts.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
-import { fetchAlerts } from '../../../common/api/alerts';
 import { useDelimitatedRoute } from '../../../common/utils/router';
 import { lineColorBackground } from '../../../common/styles/general';
 import { Divider } from '../../../common/components/general/Divider';
 import { ChartPlaceHolder } from '../../../common/components/graphics/ChartPlaceHolder';
+import { useAlertsData } from '../../../common/api/hooks/alerts';
 import { AlertBox } from './AlertBox';
 
 export const Alerts: React.FC = () => {
-  const { line, lineShort, query } = useDelimitatedRoute();
-  const alerts = useQuery(['alerts', lineShort, query.busRoute], () =>
-    fetchAlerts(lineShort, query.busRoute)
-  );
+  const {
+    line,
+    lineShort,
+    query: { busRoute },
+  } = useDelimitatedRoute();
+  const alerts = useAlertsData(lineShort, busRoute);
 
   const divStyle = classNames(
     'flex flex-col rounded-md p-4 text-white shadow-dataBox w-full xl:w-1/3 gap-y-2 md:max-h-[309px] md:overflow-y-auto',
@@ -40,7 +41,7 @@ export const Alerts: React.FC = () => {
             alerts={alerts.data}
             lineShort={lineShort}
             line={line}
-            busRoute={query.busRoute}
+            busRoute={busRoute}
             type={'current'}
           />
         </div>
@@ -51,7 +52,7 @@ export const Alerts: React.FC = () => {
             alerts={alerts.data}
             lineShort={lineShort}
             line={line}
-            busRoute={query.busRoute}
+            busRoute={busRoute}
             type={'upcoming'}
           />
         </div>

--- a/modules/commute/speed/Speed.tsx
+++ b/modules/commute/speed/Speed.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import { useDelimitatedRoute } from '../../../common/utils/router';
 import { lineColorBackground } from '../../../common/styles/general';
-import { fetchSpeeds } from '../../../common/api/speed';
+import { useSpeedData } from '../../../common/api/hooks/speed';
 import { InfoTooltip } from '../../../common/components/general/InfoTooltip';
 import { CompWidget } from '../../../common/components/widgets/internal/CompWidget';
 import { DATE_FORMAT } from '../../../common/constants/dates';
@@ -17,15 +16,8 @@ export const Speed: React.FC = () => {
   const today = dayjs().format(DATE_FORMAT);
   const { agg, endDate, startDate } = DELAYS_RANGE_PARAMS_MAP['week'];
 
-  const speed = useQuery(['todaySpeed', line], () =>
-    fetchSpeeds({ start_date: today, end_date: today, agg: 'daily', line: line })
-  );
-
-  const weekly = useQuery(
-    ['speed', line, startDate, endDate, agg],
-    () => fetchSpeeds({ start_date: startDate, end_date: endDate, agg, line }),
-    { enabled: line != undefined }
-  );
+  const speed = useSpeedData({ line, start_date: today, end_date: today, agg: 'daily' });
+  const weekly = useSpeedData({ line, start_date: startDate, end_date: endDate, agg });
 
   const speedReady = line && weekly.data && speed.data && !speed.isLoading && !speed.isError;
 

--- a/modules/dwells/DwellsDetails.tsx
+++ b/modules/dwells/DwellsDetails.tsx
@@ -1,10 +1,8 @@
 'use client';
 import React, { useState } from 'react';
 import dayjs from 'dayjs';
-import { useQuery } from '@tanstack/react-query';
-import { fetchAggregateData, fetchSingleDayData } from '../../common/api/datadashboard';
 import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
-import { AggregateAPIParams, QueryNameKeys, SingleDayAPIParams } from '../../common/types/api';
+import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
 import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
@@ -14,6 +12,7 @@ import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
 import { ErrorNotice } from '../../common/components/notices/ErrorNotice';
 import { TerminusNotice } from '../../common/components/notices/TerminusNotice';
+import { useDwellsAggregateData, useDwellsSingleDayData } from '../../common/api/hooks/dwells';
 import { DwellsSingleChart } from './charts/DwellsSingleChart';
 import { DwellsAggregateChart } from './charts/DwellsAggregateChart';
 
@@ -43,16 +42,8 @@ export default function DwellsDetails() {
         [SingleDayAPIParams.date]: startDate,
       };
 
-  const dwells = useQuery({
-    queryKey: [QueryNameKeys.dwells, aggregate, fromStopIds, startDate],
-    enabled: !aggregate && enabled,
-    queryFn: () => fetchSingleDayData(QueryNameKeys.dwells, parameters),
-  });
-  const dwellsAggregate = useQuery({
-    queryKey: [QueryNameKeys.dwells, aggregate, fromStopIds, startDate, endDate],
-    enabled: aggregate && enabled,
-    queryFn: () => fetchAggregateData(QueryNameKeys.dwells, parameters),
-  });
+  const dwells = useDwellsSingleDayData(parameters, !aggregate && enabled);
+  const dwellsAggregate = useDwellsAggregateData(parameters, aggregate && enabled);
 
   const dwellsData = aggregate ? dwellsAggregate?.data?.by_date : dwells?.data;
 

--- a/modules/dwells/DwellsWidget.tsx
+++ b/modules/dwells/DwellsWidget.tsx
@@ -2,16 +2,14 @@
 import React from 'react';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
-import { useQuery } from '@tanstack/react-query';
 import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
-import { fetchSingleDayData } from '../../common/api/datadashboard';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
-import { QueryNameKeys } from '../../common/types/api';
 import { averageDwells, longestDwells } from '../../common/utils/dwells';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
+import { useDwellsSingleDayData } from '../../common/api/hooks/dwells';
 import { DwellsSingleChart } from './charts/DwellsSingleChart';
 
 export const DwellsWidget: React.FC = () => {
@@ -28,9 +26,7 @@ export const DwellsWidget: React.FC = () => {
 
   const { fromStopIds } = stopIdsForStations(fromStation, toStation);
 
-  const dwells = useQuery([QueryNameKeys.dwells, fromStopIds, startDate], () =>
-    fetchSingleDayData(QueryNameKeys.dwells, { date: startDate, stop: fromStopIds })
-  );
+  const dwells = useDwellsSingleDayData({ date: startDate, stop: fromStopIds });
 
   const dwellsReady = !dwells.isError && dwells.data && line && lineShort && linePath;
 

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -2,10 +2,8 @@
 
 import React, { useState } from 'react';
 import dayjs from 'dayjs';
-import { useQuery } from '@tanstack/react-query';
-import { fetchAggregateData, fetchSingleDayData } from '../../common/api/datadashboard';
 import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
-import { AggregateAPIParams, QueryNameKeys, SingleDayAPIParams } from '../../common/types/api';
+import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
 import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
@@ -15,6 +13,10 @@ import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
 import { ErrorNotice } from '../../common/components/notices/ErrorNotice';
 import { TerminusNotice } from '../../common/components/notices/TerminusNotice';
+import {
+  useHeadwaysAggregateData,
+  useHeadwaysSingleDayData,
+} from '../../common/api/hooks/headways';
 import { HeadwaysSingleChart } from './charts/HeadwaysSingleChart';
 import { HeadwaysHistogram } from './charts/HeadwaysHistogram';
 import { HeadwaysAggregateChart } from './charts/HeadwaysAggregateChart';
@@ -45,16 +47,8 @@ export default function HeadwaysDetails() {
         [SingleDayAPIParams.date]: startDate,
       };
 
-  const headways = useQuery({
-    queryKey: [QueryNameKeys.headways, aggregate, fromStopIds, startDate],
-    enabled: !aggregate && enabled,
-    queryFn: () => fetchSingleDayData(QueryNameKeys.headways, parameters),
-  });
-  const headwaysAggregate = useQuery({
-    queryKey: [QueryNameKeys.headways, aggregate, fromStopIds, startDate, endDate],
-    enabled: aggregate && enabled,
-    queryFn: () => fetchAggregateData(QueryNameKeys.headways, parameters),
-  });
+  const headways = useHeadwaysSingleDayData(parameters, enabled);
+  const headwaysAggregate = useHeadwaysAggregateData(parameters, enabled);
 
   const headwaysData = aggregate ? headwaysAggregate?.data?.by_date : headways?.data;
 

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -47,8 +47,8 @@ export default function HeadwaysDetails() {
         [SingleDayAPIParams.date]: startDate,
       };
 
-  const headways = useHeadwaysSingleDayData(parameters, enabled);
-  const headwaysAggregate = useHeadwaysAggregateData(parameters, enabled);
+  const headways = useHeadwaysSingleDayData(parameters, !aggregate && enabled);
+  const headwaysAggregate = useHeadwaysAggregateData(parameters, aggregate && enabled);
 
   const headwaysData = aggregate ? headwaysAggregate?.data?.by_date : headways?.data;
 

--- a/modules/headways/HeadwaysWidget.tsx
+++ b/modules/headways/HeadwaysWidget.tsx
@@ -2,16 +2,14 @@
 import React from 'react';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
-import { useQuery } from '@tanstack/react-query';
-import { QueryNameKeys } from '../../common/types/api';
 import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
-import { fetchSingleDayData } from '../../common/api/datadashboard';
 import { averageHeadway, longestHeadway } from '../../common/utils/headways';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
+import { useHeadwaysSingleDayData } from '../../common/api/hooks/headways';
 import { HeadwaysSingleChart } from './charts/HeadwaysSingleChart';
 
 export const HeadwaysWidget: React.FC = () => {
@@ -26,9 +24,7 @@ export const HeadwaysWidget: React.FC = () => {
   const fromStation = stations?.[3];
 
   const { fromStopIds } = stopIdsForStations(fromStation, toStation);
-  const headways = useQuery([QueryNameKeys.headways, fromStopIds, startDate], () =>
-    fetchSingleDayData(QueryNameKeys.headways, { date: startDate, stop: fromStopIds })
-  );
+  const headways = useHeadwaysSingleDayData({ stop: fromStopIds, date: startDate });
 
   const headwaysReady = !headways.isError && headways.data && lineShort && linePath;
 

--- a/modules/ridership/RidershipDetails.tsx
+++ b/modules/ridership/RidershipDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useRidershipData } from '../../common/api/ridership';
+import { useRidershipData } from '../../common/api/hooks/ridership';
 import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWidgetItem';
 import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
 import { LINE_COLORS } from '../../common/constants/colors';
@@ -7,8 +7,9 @@ import { PercentageWidgetValue, TripsWidgetValue } from '../../common/types/basi
 import type { ServiceDay } from '../../common/types/ridership';
 import { getHighestTphValue, normalizeToPercent } from '../../common/utils/ridership';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import { ServiceRidershipChart } from './charts/ServiceRidershipChart';
+import { ServiceDayPicker } from '../../common/components/inputs/ServiceDayPicker';
 import { TphChart } from './charts/TphChart';
+import { ServiceRidershipChart } from './charts/ServiceRidershipChart';
 
 export default function RidershipDetails() {
   const allRidership = useRidershipData();
@@ -31,6 +32,26 @@ export default function RidershipDetails() {
   );
   const ridershipPercentage = normalizeToPercent(lineData?.ridershipHistory ?? []);
   const serviceHistory = lineData?.serviceHistory ?? [];
+
+  // Only re-render chart when necesarry
+  const serviceRidershipChart = useMemo(() => {
+    return <ServiceRidershipChart lineData={lineData} startDate={startDate} color={color} />;
+  }, [color, lineData, startDate]);
+
+  // Only re-render chart when necesarry
+  const serviceLevelChart = useMemo(() => {
+    return (
+      <>
+        <TphChart
+          lineData={lineData}
+          serviceDay={serviceDay}
+          color={color}
+          highestTph={highestTph}
+        />
+        <ServiceDayPicker serviceDay={serviceDay} setServiceDay={setServiceDay} />
+      </>
+    );
+  }, [color, highestTph, lineData, serviceDay]);
 
   return (
     <>
@@ -64,19 +85,18 @@ export default function RidershipDetails() {
         <h3>Weekday ridership and service levels</h3>
       </div>
       <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
-        <ServiceRidershipChart lineData={lineData} startDate={startDate} color={color} />
+        {serviceRidershipChart}
       </div>
 
       <div className="flex w-full flex-row items-center justify-between text-lg">
         <h3>Service Levels</h3>
       </div>
-      <div className="h-full rounded-lg border-design-lightGrey bg-white p-2 shadow-dataBox">
-        <TphChart
-          lineData={lineData}
-          serviceDay={serviceDay}
-          color={color}
-          highestTph={highestTph}
-        />
+      <div
+        className={
+          'flex h-full rounded-lg border-design-lightGrey bg-white p-2 pr-3 shadow-dataBox'
+        }
+      >
+        {serviceLevelChart}
       </div>
     </>
   );

--- a/modules/ridership/RidershipWidget.tsx
+++ b/modules/ridership/RidershipWidget.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { useMemo, useState } from 'react';
-import { useRidershipData } from '../../common/api/ridership';
+import { useRidershipData } from '../../common/api/hooks/ridership';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { LINE_COLORS } from '../../common/constants/colors';
 import { PercentageWidgetValue, TripsWidgetValue } from '../../common/types/basicWidgets';
@@ -8,6 +8,7 @@ import type { ServiceDay } from '../../common/types/ridership';
 import { getHighestTphValue, normalizeToPercent } from '../../common/utils/ridership';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
+import { ServiceDayPicker } from '../../common/components/inputs/ServiceDayPicker';
 import { ServiceRidershipChart } from './charts/ServiceRidershipChart';
 import { TphChart } from './charts/TphChart';
 
@@ -28,6 +29,26 @@ export const RidershipWidget: React.FC = () => {
   );
   const ridershipPercentage = normalizeToPercent(lineData?.ridershipHistory ?? []);
   const serviceHistory = lineData?.serviceHistory ?? [];
+
+  // Only re-render chart when necesarry
+  const serviceRidershipChart = useMemo(() => {
+    return <ServiceRidershipChart lineData={lineData} startDate={startDate} color={color} />;
+  }, [color, lineData, startDate]);
+
+  // Only re-render chart when necesarry
+  const serviceLevelChart = useMemo(() => {
+    return (
+      <>
+        <TphChart
+          lineData={lineData}
+          serviceDay={serviceDay}
+          color={color}
+          highestTph={highestTph}
+        />
+        <ServiceDayPicker serviceDay={serviceDay} setServiceDay={setServiceDay} />
+      </>
+    );
+  }, [color, highestTph, lineData, serviceDay]);
 
   return (
     <div className={classNames('h-full rounded-lg bg-white p-2 shadow-dataBox')}>
@@ -59,17 +80,8 @@ export const RidershipWidget: React.FC = () => {
           sentimentDirection={'positiveOnIncrease'}
         />
       </div>
-      <div className={classNames('h-50 pr-4')}>
-        <ServiceRidershipChart lineData={lineData} startDate={startDate} color={color} />
-      </div>
-      <div className={classNames('h-50 pr-4')}>
-        <TphChart
-          lineData={lineData}
-          serviceDay={serviceDay}
-          color={color}
-          highestTph={highestTph}
-        />
-      </div>
+      <div className={classNames('h-50 pr-4')}>{serviceRidershipChart}</div>
+      <div className={classNames('h-50 flex pr-3')}>{serviceLevelChart}</div>
     </div>
   );
 };

--- a/modules/ridership/charts/TphChart.tsx
+++ b/modules/ridership/charts/TphChart.tsx
@@ -45,7 +45,7 @@ export const TphChart: React.FC<TphChartProps> = ({ color, lineData, serviceDay,
   ];
 
   return (
-    <div>
+    <div className={'w-full'}>
       <Line
         height={200}
         data={{

--- a/modules/slowzones/SlowZonesDetails.tsx
+++ b/modules/slowzones/SlowZonesDetails.tsx
@@ -3,20 +3,19 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { useQuery } from '@tanstack/react-query';
 
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { WidgetTitle } from '../dashboard/WidgetTitle';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
-import { fetchAllSlow, fetchDelayTotals } from './api/slowzones';
+import { useSlowzoneAllData, useSlowzoneDelayTotalData } from '../../common/api/hooks/slowzones';
 import { SlowZonesSegmentsWrapper } from './SlowZonesSegmentsWrapper';
 import { TotalSlowTimeWrapper } from './TotalSlowTimeWrapper';
 import { SlowZonesMap } from './map';
 dayjs.extend(utc);
 
 export default function SlowZonesDetails() {
-  const delayTotals = useQuery(['delayTotals'], fetchDelayTotals);
-  const allSlow = useQuery(['allSlow'], fetchAllSlow);
+  const delayTotals = useSlowzoneDelayTotalData();
+  const allSlow = useSlowzoneAllData();
   const {
     lineShort,
     line,

--- a/modules/slowzones/SlowZonesWidget.tsx
+++ b/modules/slowzones/SlowZonesWidget.tsx
@@ -1,19 +1,18 @@
 'use client';
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
-import { fetchDelayTotals } from './api/slowzones';
+import { useSlowzoneDelayTotalData } from '../../common/api/hooks/slowzones';
 import { TotalSlowTimeWrapper } from './TotalSlowTimeWrapper';
 dayjs.extend(utc);
 
 export default function SlowZonesWidget() {
   const { line, linePath, lineShort } = useDelimitatedRoute();
-  const delayTotals = useQuery(['delayTotals'], fetchDelayTotals);
+  const delayTotals = useSlowzoneDelayTotalData();
 
   const startDateUTC = dayjs.utc('2022-01-01').startOf('day');
   const endDateUTC = dayjs.utc().startOf('day');

--- a/modules/speed/SpeedWidget.tsx
+++ b/modules/speed/SpeedWidget.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { useQuery } from '@tanstack/react-query';
-import { fetchSpeeds } from '../../common/api/speed';
+import { useSpeedData } from '../../common/api/hooks/speed';
 import type { TimeRange } from '../../common/types/inputs';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
@@ -18,22 +17,13 @@ export const SpeedWidget: React.FC<SpeedWidgetProps> = ({ timeRange }) => {
   const { agg, endDate, startDate, comparisonStartDate, comparisonEndDate } =
     DELAYS_RANGE_PARAMS_MAP[timeRange];
 
-  const speeds = useQuery(
-    ['speed', line, startDate, endDate, agg],
-    () => fetchSpeeds({ start_date: startDate, end_date: endDate, agg, line }),
-    { enabled: line != undefined }
-  );
-  const compSpeeds = useQuery(
-    ['speedComparison', line, comparisonStartDate, startDate, agg],
-    () =>
-      fetchSpeeds({
-        start_date: comparisonStartDate,
-        end_date: comparisonEndDate,
-        agg,
-        line,
-      }),
-    { enabled: line != undefined }
-  );
+  const speeds = useSpeedData({ start_date: startDate, end_date: endDate, agg, line });
+  const compSpeeds = useSpeedData({
+    start_date: comparisonStartDate,
+    end_date: comparisonEndDate,
+    agg,
+    line,
+  });
   const speedReady =
     !compSpeeds.isError && !speeds.isError && speeds.data && compSpeeds.data && line;
 

--- a/modules/traveltimes/TravelTimesDetails.tsx
+++ b/modules/traveltimes/TravelTimesDetails.tsx
@@ -2,10 +2,8 @@
 
 import React, { useState } from 'react';
 import dayjs from 'dayjs';
-import { useQuery } from '@tanstack/react-query';
 import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
-import { fetchAggregateData, fetchSingleDayData } from '../../common/api/datadashboard';
-import { QueryNameKeys, AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
+import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
 import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
@@ -15,6 +13,10 @@ import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { StationSelectorWidget } from '../../common/components/widgets/StationSelectorWidget';
 import { ErrorNotice } from '../../common/components/notices/ErrorNotice';
 import { TerminusNotice } from '../../common/components/notices/TerminusNotice';
+import {
+  useTravelTimesAggregateData,
+  useTravelTimesSingleDayData,
+} from '../../common/api/hooks/traveltimes';
 import { TravelTimesSingleChart } from './charts/TravelTimesSingleChart';
 import { TravelTimesAggregateChart } from './charts/TravelTimesAggregateChart';
 
@@ -53,16 +55,8 @@ export default function TravelTimesDetails() {
         [SingleDayAPIParams.date]: startDate,
       };
 
-  const travelTimesAggregate = useQuery({
-    queryKey: [QueryNameKeys.traveltimes, aggregate, fromStopIds, toStopIds, startDate, endDate],
-    enabled: aggregate && enabled,
-    queryFn: () => fetchAggregateData(QueryNameKeys.traveltimes, parameters),
-  });
-  const travelTimesSingle = useQuery({
-    queryKey: [QueryNameKeys.traveltimes, aggregate, fromStopIds, toStopIds, startDate, endDate],
-    enabled: !aggregate && enabled,
-    queryFn: () => fetchSingleDayData(QueryNameKeys.traveltimes, parameters),
-  });
+  const travelTimesSingle = useTravelTimesSingleDayData(parameters, !aggregate && enabled);
+  const travelTimesAggregate = useTravelTimesAggregateData(parameters, aggregate && enabled);
 
   const traveltimes = aggregate ? travelTimesAggregate : travelTimesSingle;
   const travelTimeValues = aggregate

--- a/modules/traveltimes/TravelTimesWidget.tsx
+++ b/modules/traveltimes/TravelTimesWidget.tsx
@@ -2,16 +2,14 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import classNames from 'classnames';
-import { useQuery } from '@tanstack/react-query';
-import { QueryNameKeys } from '../../common/types/api';
 import { optionsStation, stopIdsForStations } from '../../common/utils/stations';
-import { fetchSingleDayData } from '../../common/api/datadashboard';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { HomescreenWidgetTitle } from '../dashboard/HomescreenWidgetTitle';
 import { BasicWidgetDataLayout } from '../../common/components/widgets/internal/BasicWidgetDataLayout';
 import { averageTravelTime } from '../../common/utils/traveltimes';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
 import { ChartPlaceHolder } from '../../common/components/graphics/ChartPlaceHolder';
+import { useTravelTimesSingleDayData } from '../../common/api/hooks/traveltimes';
 import { TravelTimesSingleChart } from './charts/TravelTimesSingleChart';
 
 export const TravelTimesWidget: React.FC = () => {
@@ -26,13 +24,11 @@ export const TravelTimesWidget: React.FC = () => {
   const fromStation = stations?.[3];
 
   const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
-  const traveltimes = useQuery([QueryNameKeys.traveltimes, fromStopIds, toStopIds, startDate], () =>
-    fetchSingleDayData(QueryNameKeys.traveltimes, {
-      date: startDate,
-      from_stop: fromStopIds,
-      to_stop: toStopIds,
-    })
-  );
+  const traveltimes = useTravelTimesSingleDayData({
+    date: startDate,
+    from_stop: fromStopIds,
+    to_stop: toStopIds,
+  });
   const travelTimeValues = traveltimes?.data?.map((tt) => tt.travel_time_sec);
   const traveltimesReady = !traveltimes.isError && traveltimes.data && lineShort && linePath;
 


### PR DESCRIPTION
## Motivation

We want to reduce API calls, especially when data has not changed since last fetch

## Changes

- Moves API calls into reusable hooks and defaults reasonable staleTimes
- Adds the ridership dayselector
<img width="1252" alt="Screenshot 2023-04-10 at 1 59 52 PM" src="https://user-images.githubusercontent.com/9310513/230962697-a627f732-ba07-4c88-a653-7e9082804bfb.png">


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
