### PR TITLE
two small bugs

### DIFF
--- a/common/components/widgets/StationSelectorWidget.tsx
+++ b/common/components/widgets/StationSelectorWidget.tsx
@@ -37,7 +37,7 @@ export const StationSelectorWidget: React.FC<StationSelectorWidgetProps> = ({
   React.useEffect(() => {
     // Update from
     updateQueryParams({ from: fromStopIds?.[0], to: toStopIds?.[0] });
-  }, [fromStation, fromStopIds, toStation, toStopIds]);
+  }, [fromStation, fromStopIds, toStation, toStopIds, updateQueryParams]);
 
   return (
     <div

--- a/common/utils/stations.ts
+++ b/common/utils/stations.ts
@@ -3,7 +3,7 @@ import type { LineShort } from '../../common/types/lines';
 import type { Station } from '../../common/types/stations';
 import type { Location } from '../types/charts';
 import type { Direction } from '../types/dataPoints';
-import { stations, rtStations } from './../constants/stations';
+import { stations, rtStations, busStations } from './../constants/stations';
 
 export const optionsForField = (
   type: 'from' | 'to',
@@ -54,9 +54,9 @@ export const swapStations = (
   setToStation(fromStation);
 };
 
-const createRapidTransitStationIndex = () => {
+const createStationIndex = () => {
   const index: Record<string, Station> = {};
-  Object.values(rtStations).forEach((line) => {
+  Object.values({ ...rtStations, ...busStations }).forEach((line) => {
     line.stations.forEach((station) => {
       index[station.station] = station;
     });
@@ -64,9 +64,9 @@ const createRapidTransitStationIndex = () => {
   return index;
 };
 
-const createParentRapidTransitStationIndex = () => {
+const createParentStationIndex = () => {
   const index: Record<string, Station> = {};
-  Object.values(rtStations).forEach((line) => {
+  Object.values({ ...rtStations, ...busStations }).forEach((line) => {
     line.stations.forEach((station) => {
       const allStopIds = [...(station.stops['0'] || []), ...(station.stops['1'] || [])];
       allStopIds.forEach((stopId) => {
@@ -77,15 +77,15 @@ const createParentRapidTransitStationIndex = () => {
   return index;
 };
 
-const rapidTransitStationIndex = createRapidTransitStationIndex();
-const parentRapidTransitStationIndex = createParentRapidTransitStationIndex();
+const stationIndex = createStationIndex();
+const parentStationIndex = createParentStationIndex();
 
 export const getStationById = (stationStopId: string) => {
-  return rapidTransitStationIndex[stationStopId];
+  return stationIndex[stationStopId];
 };
 
 export const getParentStationForStopId = (stopId: string) => {
-  return parentRapidTransitStationIndex[stopId];
+  return parentStationIndex[stopId];
 };
 
 export const stopIdsForStations = (

--- a/modules/navigation/LineSelection.tsx
+++ b/modules/navigation/LineSelection.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Tab } from '@headlessui/react';
 import { lineColorBackground, lineColorDarkBackground } from '../../common/styles/general';
 import { getLineSelectionItemHref, useDelimitatedRoute } from '../../common/utils/router';
-import type { LineMetadata } from '../../common/types/lines';
+import type { Line, LineMetadata } from '../../common/types/lines';
 
 interface LineSelectionProps {
   lineItems: LineMetadata[];
@@ -13,12 +13,14 @@ interface LineSelectionProps {
 export const LineSelection: React.FC<LineSelectionProps> = ({ lineItems }) => {
   const router = useRouter();
   const route = useDelimitatedRoute();
+  const onChange = (key: Line) => router.push(getLineSelectionItemHref(key, route));
+
   return (
     <Tab.Group
       vertical
       manual
       selectedIndex={lineItems.findIndex((lineItem) => lineItem.key === route.line)}
-      onChange={(index) => router.push(getLineSelectionItemHref(lineItems[index].key, route))}
+      onChange={(index) => onChange(lineItems[index].key)}
     >
       <Tab.List className=" mx-1 flex flex-col gap-y-1">
         {lineItems.map((lineItem) => {
@@ -26,6 +28,7 @@ export const LineSelection: React.FC<LineSelectionProps> = ({ lineItems }) => {
             <Tab key={lineItem.key}>
               {({ selected }) => (
                 <div
+                  onClick={() => onChange(lineItem.key)}
                   key={lineItem.key}
                   className={classNames(
                     'space-between flex w-full cursor-pointer select-none items-center rounded-md bg-opacity-0 py-1 pl-2 text-stone-200  hover:bg-opacity-80',


### PR DESCRIPTION
## Motivation

Two small bug fixes. 
1) this [function ](https://github.com/transitmatters/t-performance-dash/blame/f2edac4e9da5e21730cfe794e15f210dab925602/common/utils/stations.ts#L87-L89) was only set up to work for subway stops, not buses.

2) When selecting the currently selected line, nothing happened. The intended behavior is to return to the `today` page
## Changes

Added `busStations` to code that retrieves parentStationIds (function mentioned above).
Add code to trigger onChange() code for line selection tabs when button is clicked.

## Testing Instructions
1) Go to any page besides `today` and click on the currently selcted line - should return you to `today` page.
2) go to `buses > headways` then `buses > travel times` then back to `buses  > headways` and there will be no issue. Try this on the previous PR (currently live at the beta URL) and it will break.