### PR TITLE
Small bug

### DIFF
--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -56,6 +56,7 @@ export const useUpdateQuery = () => {
   const updateQueryParams = useCallback(
     (newQueryParams: QueryParams, range?: boolean) => {
       if (!newQueryParams) return;
+      if (!router.isReady) return;
 
       const { startDate, endDate, to, from } = newQueryParams;
 


### PR DESCRIPTION
## Motivation

There was a bug with query params. If you go to the `trips` section of the live dasboard and select a stop pair and a date range [(like this)](https://dashboard-v4-beta.labs.transitmatters.org/red/trips/traveltimes/?to=70101&from=70067&startDate=2023-04-05&endDate=2023-04-12) and then refresh, the date range disappears.

## Changes

Check to see if the `router.isReady` before updating queryParams.

This was caused by the StationSelectorWidget having an `updateQueryParams` in a `useEffect` which got called immediately on load. So in updateQueryParams, the router was not ready and didn't have the query yet. So it would set the query to be just `to` and `from` which would remove the date range.

## Testing Instructions
Follow instructions in **motivation** section on live dashboard, and this branch