### PR TITLE
Fix Bus trip explorer page

### DIFF
--- a/common/types/api.ts
+++ b/common/types/api.ts
@@ -5,11 +5,12 @@ export enum QueryNameKeys {
 }
 export type QueryNameOptions = QueryNameKeys;
 
-export const QUERIES: QueryNameOptions[] = [
-  QueryNameKeys.traveltimes,
-  QueryNameKeys.headways,
-  QueryNameKeys.dwells,
-];
+export type BusOrSubway = 'bus' | 'subway';
+
+export const QUERIES: { [key in BusOrSubway]: QueryNameOptions[] } = {
+  subway: [QueryNameKeys.traveltimes, QueryNameKeys.headways, QueryNameKeys.dwells],
+  bus: [QueryNameKeys.traveltimes, QueryNameKeys.headways],
+};
 
 export enum SingleDayAPIParams {
   stop = 'stop',

--- a/modules/tripexplorer/BusTripGraphs.tsx
+++ b/modules/tripexplorer/BusTripGraphs.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useTripExplorerQueries } from '../../common/api/datadashboard';
+import type { Station } from '../../common/types/stations';
+import { HeadwaysAggregateChart } from '../headways/charts/HeadwaysAggregateChart';
+import { HeadwaysSingleChart } from '../headways/charts/HeadwaysSingleChart';
+import { TravelTimesAggregateChart } from '../traveltimes/charts/TravelTimesAggregateChart';
+import { TravelTimesSingleChart } from '../traveltimes/charts/TravelTimesSingleChart';
+import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
+
+interface BusTripGraphsProps {
+  fromStation: Station;
+  toStation: Station;
+  parameters: AggregateAPIOptions | SingleDayAPIOptions; // TODO
+  aggregate: boolean;
+  enabled: boolean;
+}
+
+export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
+  fromStation,
+  toStation,
+  parameters,
+  aggregate,
+  enabled,
+}) => {
+  const { traveltimes, headways } = useTripExplorerQueries(
+    'bus',
+    parameters,
+    // @ts-expect-error The overloading doesn't seem to handle this const
+    aggregate,
+    enabled
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {aggregate ? (
+        <>
+          <TravelTimesAggregateChart
+            traveltimes={traveltimes}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+          <HeadwaysAggregateChart
+            headways={headways}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+        </>
+      ) : (
+        <>
+          <TravelTimesSingleChart
+            traveltimes={traveltimes}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+
+          <HeadwaysSingleChart
+            headways={headways}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useTripExplorerQueries } from '../../common/api/datadashboard';
+import type { Station } from '../../common/types/stations';
+import { HeadwaysAggregateChart } from '../headways/charts/HeadwaysAggregateChart';
+import { HeadwaysSingleChart } from '../headways/charts/HeadwaysSingleChart';
+import { TravelTimesAggregateChart } from '../traveltimes/charts/TravelTimesAggregateChart';
+import { TravelTimesSingleChart } from '../traveltimes/charts/TravelTimesSingleChart';
+import { DwellsAggregateChart } from '../dwells/charts/DwellsAggregateChart';
+import { DwellsSingleChart } from '../dwells/charts/DwellsSingleChart';
+import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
+
+interface SubwayTripGraphsProps {
+  fromStation: Station;
+  toStation: Station;
+  parameters: SingleDayAPIOptions | AggregateAPIOptions; // TODO
+  aggregate: boolean;
+  enabled: boolean;
+}
+
+export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
+  fromStation,
+  toStation,
+  parameters,
+  aggregate,
+  enabled,
+}) => {
+  const { traveltimes, headways, dwells } = useTripExplorerQueries(
+    'subway',
+    parameters,
+    // @ts-expect-error The overloading doesn't seem to handle this const
+    aggregate,
+    enabled
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {aggregate ? (
+        <>
+          <TravelTimesAggregateChart
+            traveltimes={traveltimes}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+          <HeadwaysAggregateChart
+            headways={headways}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+          <DwellsAggregateChart dwells={dwells} fromStation={fromStation} toStation={toStation} />
+        </>
+      ) : (
+        <>
+          <TravelTimesSingleChart
+            traveltimes={traveltimes}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+
+          <HeadwaysSingleChart
+            headways={headways}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+          <DwellsSingleChart dwells={dwells} fromStation={fromStation} toStation={toStation} />
+        </>
+      )}
+    </div>
+  );
+};

--- a/modules/tripexplorer/TripExplorer.tsx
+++ b/modules/tripexplorer/TripExplorer.tsx
@@ -8,10 +8,10 @@ import { TripGraphs } from './TripGraphs';
 export const TripExplorer = () => {
   const {
     lineShort,
-    query: { to, from },
+    query: { to, from, busRoute },
   } = useDelimitatedRoute();
 
-  const stations = optionsStation(lineShort);
+  const stations = optionsStation(lineShort, busRoute);
   const [toStation, setToStation] = useState(
     to ? getParentStationForStopId(to) : stations?.[stations.length - 2]
   );
@@ -20,21 +20,22 @@ export const TripExplorer = () => {
   );
 
   useEffect(() => {
-    if (!from) setFromStation(stations?.[3]);
-    if (!to) setToStation(stations?.[stations.length - 3]);
+    if (!from) setFromStation(stations?.[1]);
+    if (!to) setToStation(stations?.[stations.length - 2]);
   }, [lineShort, from, to, stations, setFromStation, setToStation]);
-
   if (!(fromStation && toStation)) {
     return null;
   }
   return (
     <div>
-      <StationSelectorWidget
-        fromStation={fromStation}
-        toStation={toStation}
-        setFromStation={setFromStation}
-        setToStation={setToStation}
-      />
+      {fromStation && toStation && (
+        <StationSelectorWidget
+          fromStation={fromStation}
+          toStation={toStation}
+          setFromStation={setFromStation}
+          setToStation={setToStation}
+        />
+      )}
       <TripGraphs fromStation={fromStation} toStation={toStation} />
       <TerminusNotice toStation={toStation} fromStation={fromStation} />
     </div>

--- a/modules/tripexplorer/TripGraphs.tsx
+++ b/modules/tripexplorer/TripGraphs.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import { useCustomQueries } from '../../common/api/datadashboard';
-import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
-import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
 import type { Station } from '../../common/types/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { stopIdsForStations } from '../../common/utils/stations';
-import { DwellsAggregateChart } from '../dwells/charts/DwellsAggregateChart';
-import { DwellsSingleChart } from '../dwells/charts/DwellsSingleChart';
-import { HeadwaysAggregateChart } from '../headways/charts/HeadwaysAggregateChart';
-import { HeadwaysSingleChart } from '../headways/charts/HeadwaysSingleChart';
-import { TravelTimesAggregateChart } from '../traveltimes/charts/TravelTimesAggregateChart';
-import { TravelTimesSingleChart } from '../traveltimes/charts/TravelTimesSingleChart';
+import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
+import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
+import { BusTripGraphs } from './BusTripGraphs';
+import { SubwayTripGraphs } from './SubwayTripGraphs';
 
 interface TripGraphsProps {
   fromStation: Station;
@@ -20,12 +15,12 @@ interface TripGraphsProps {
 export const TripGraphs: React.FC<TripGraphsProps> = ({ fromStation, toStation }) => {
   const {
     query: { startDate, endDate },
+    tab,
   } = useDelimitatedRoute();
 
   const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
-  const aggregate = Boolean(startDate && endDate);
   const enabled = Boolean(startDate && fromStopIds && toStopIds);
-
+  const aggregate = Boolean(startDate && endDate);
   const parameters: SingleDayAPIOptions | AggregateAPIOptions = aggregate
     ? {
         [AggregateAPIParams.stop]: fromStopIds,
@@ -40,46 +35,23 @@ export const TripGraphs: React.FC<TripGraphsProps> = ({ fromStation, toStation }
         [SingleDayAPIParams.toStop]: toStopIds,
         [SingleDayAPIParams.date]: startDate,
       };
-
-  const { traveltimes, headways, dwells } = useCustomQueries(
-    parameters,
-    // @ts-expect-error The overloading doesn't seem to handle this const
-    aggregate,
-    enabled
-  );
-
+  if (tab === 'Bus')
+    return (
+      <BusTripGraphs
+        fromStation={fromStation}
+        toStation={toStation}
+        parameters={parameters}
+        aggregate={aggregate}
+        enabled={enabled}
+      />
+    );
   return (
-    <div className="flex flex-col gap-4">
-      {aggregate ? (
-        <>
-          <TravelTimesAggregateChart
-            traveltimes={traveltimes}
-            fromStation={fromStation}
-            toStation={toStation}
-          />
-          <HeadwaysAggregateChart
-            headways={headways}
-            fromStation={fromStation}
-            toStation={toStation}
-          />
-          <DwellsAggregateChart dwells={dwells} fromStation={fromStation} toStation={toStation} />
-        </>
-      ) : (
-        <>
-          <TravelTimesSingleChart
-            traveltimes={traveltimes}
-            fromStation={fromStation}
-            toStation={toStation}
-          />
-
-          <HeadwaysSingleChart
-            headways={headways}
-            fromStation={fromStation}
-            toStation={toStation}
-          />
-          <DwellsSingleChart dwells={dwells} fromStation={fromStation} toStation={toStation} />
-        </>
-      )}
-    </div>
+    <SubwayTripGraphs
+      fromStation={fromStation}
+      toStation={toStation}
+      parameters={parameters}
+      aggregate={aggregate}
+      enabled={enabled}
+    />
   );
 };


### PR DESCRIPTION
## Motivation

fixes #452 

## Changes

1. Main issue is that the trip explorer was not getting passed the `busRoute`. Fixed that

2. We also had no way to differentiate between bus and subway in `useCustomQueries` so I reworked that to take `BusOrSubway` as a parameter so we're not searching for non-existent bus dwell data.

3. Separated bus and subway trip graphs into two components.

## Testing Instructions

Go to bus trip explorer page without `from`/`to` in the URL. This didn't work previously, now it does.