### PR TITLE
Station can sometimes be undefined

### DIFF
--- a/modules/commute/alerts/AlertUtils.ts
+++ b/modules/commute/alerts/AlertUtils.ts
@@ -2,17 +2,19 @@ import { stations } from '../../../common/constants/stations';
 import type { BusRoute, LineShort } from '../../../common/types/lines';
 import type { Station } from '../../../common/types/stations';
 
-export const getEndStations = (stations: Station[]) => {
+export const getEndStations = (stations: (Station | undefined)[]) => {
   let min = stations[0];
   let max = stations[0];
 
   stations.forEach((station) => {
-    if (station.station === 'place-jfk') station.stop_name = 'JFK/UMass'; // Sub out branch names of JFK
-    if (station.order < min.order) {
-      min = station;
-    }
-    if (station.order > max.order) {
-      max = station;
+    if (station) {
+      if (station?.station === 'place-jfk') station.stop_name = 'JFK/UMass'; // Sub out branch names of JFK
+      if (min && station?.order < min.order) {
+        min = station;
+      }
+      if (max && station?.order > max.order) {
+        max = station;
+      }
     }
   });
   return { min, max };

--- a/modules/commute/alerts/DelayAlert.tsx
+++ b/modules/commute/alerts/DelayAlert.tsx
@@ -20,9 +20,9 @@ const getDescription = (alert: FormattedAlert, lineShort: LineShort, busRoute?: 
     return (
       <>
         <p className="mr-1 ">Delays</p>
-        <p className="font-bold">{min.stop_name}</p>
+        <p className="font-bold">{min?.stop_name}</p>
         <BetweenArrow className="mx-2 h-4 w-4" />
-        <p className="font-bold">{max.stop_name}</p>
+        <p className="font-bold">{max?.stop_name}</p>
       </>
     );
   }

--- a/modules/commute/alerts/ShuttleAlert.tsx
+++ b/modules/commute/alerts/ShuttleAlert.tsx
@@ -16,9 +16,9 @@ export const ShuttleAlert: React.FC<ShuttleAlertProps> = ({ alert, lineShort, ty
   return (
     <AlertBoxInner header={alert.header} Icon={ShuttleIcon} type={type} alert={alert}>
       <p className="mr-1 ">Shuttling</p>
-      <p className="font-bold">{min.stop_name}</p>
+      <p className="font-bold">{min?.stop_name}</p>
       <BetweenArrow className="mx-2 h-4 w-4" />
-      <p className="font-bold">{max.stop_name}</p>
+      <p className="font-bold">{max?.stop_name}</p>
     </AlertBoxInner>
   );
 };

--- a/modules/commute/alerts/SuspensionAlert.tsx
+++ b/modules/commute/alerts/SuspensionAlert.tsx
@@ -19,9 +19,9 @@ const getDescription = (alert: FormattedAlert, lineShort: LineShort) => {
     return (
       <>
         <p className="mr-1 ">No service</p>
-        <p className="font-bold">{min.stop_name}</p>
+        <p className="font-bold">{min?.stop_name}</p>
         <BetweenArrow className="mx-2 h-4 w-4" />
-        <p className="font-bold">{max.stop_name}</p>
+        <p className="font-bold">{max?.stop_name}</p>
       </>
     );
   }


### PR DESCRIPTION
## Motivation

![Screenshot 2023-04-13 at 2 45 42 PM](https://user-images.githubusercontent.com/9310513/231855820-0d14e88b-9f2a-4e47-9cff-5531b1493990.png)
![Screenshot 2023-04-13 at 2 46 07 PM](https://user-images.githubusercontent.com/9310513/231855824-28374c39-d3c1-451b-8883-f9ab92559215.png)


## Changes

Reflects the reality, that `stations` can be a list of `(Station | undefined)[]`. We probably should ensure that can't happen, but, in the meantime, that is the reality and we need to handle it

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
