### PR TITLE
Station Selector UX change

### DIFF
--- a/common/components/inputs/StationSelector.tsx
+++ b/common/components/inputs/StationSelector.tsx
@@ -32,7 +32,6 @@ export const StationSelector: React.FC<StationSelector> = ({
   } = useDelimitatedRoute();
   const mdBreakpoint = useBreakpoint('md');
   const station = type === 'from' ? fromStation : toStation;
-
   const stationOptions = optionsForField(type, lineShort, fromStation, toStation, busRoute);
 
   return (
@@ -69,13 +68,19 @@ export const StationSelector: React.FC<StationSelector> = ({
                 {stationOptions?.map((station, stationIndex) => (
                   <Listbox.Option
                     key={stationIndex}
-                    className={({ active, selected }) =>
+                    disabled={
+                      type === 'from'
+                        ? station.station === toStation.station
+                        : station.station === fromStation.station
+                    }
+                    className={({ active, selected, disabled }) =>
                       classNames(
-                        'relative cursor-pointer select-none items-center px-4 py-2',
+                        'relative select-none items-center px-4 py-2',
                         active ? selectConfig[linePath] : 'text-gray-900',
                         selected
                           ? `bg-opacity-20 font-semibold ${lineColorBackground[line ?? 'DEFAULT']}`
-                          : 'font-normal'
+                          : 'font-normal',
+                        disabled ? 'cursor-default bg-stone-200 text-stone-600' : 'cursor-pointer'
                       )
                     }
                     value={station}

--- a/common/utils/stations.ts
+++ b/common/utils/stations.ts
@@ -13,13 +13,10 @@ export const optionsForField = (
   busRoute?: string
 ) => {
   if (type === 'from') {
-    return optionsStation(line, busRoute)?.filter((entry) => entry !== toStation);
+    return optionsStation(line, busRoute);
   }
   if (type === 'to') {
     return optionsStation(line, busRoute)?.filter((entry) => {
-      if (entry === fromStation) {
-        return false;
-      }
       if (fromStation && fromStation.branches && entry.branches) {
         return entry.branches.some((entryBranch) => fromStation.branches?.includes(entryBranch));
       }


### PR DESCRIPTION
## Motivation
When selecting a `to` station in the station selector, the `from` station disappears (and vice versa). Can be confusing and removing items from a list without explanation is typically bad UX.

The greyed out station can be a good anchor to figure out where you are. Also it is more clear why it is missing. If you aren't paying attention and are trying to select the same station and it is missing, that can be disorienting.


## Changes

Make station disabled rather than not showing it.
![Screen Shot 2023-04-30 at 9 31 51 PM](https://user-images.githubusercontent.com/46229349/235407240-cb504b24-9c5f-489c-9281-5e1aca9e5013.png)


## Testing Instructions

Select stations