### PR TITLE
Eslint - Prefer named exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
     'import/named': 'warn',
     'import/no-unresolved': 'warn',
     'import/no-self-import': 'error',
-    'import/no-default-export': 'off',
+    'import/no-default-export': 'warn',
     'import/order': 'error',
     'prettier/prettier': 'error',
     'react/prop-types': 'warn',
@@ -69,7 +69,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['app/**/*.tsx'],
+      files: ['pages/**/*.tsx'],
       rules: {
         'import/no-default-export': 'off',
       },

--- a/common/components/general/Device/index.tsx
+++ b/common/components/general/Device/index.tsx
@@ -2,6 +2,4 @@
 
 import dynamic from 'next/dynamic';
 
-const Device = dynamic(() => import('./Device'), { ssr: false });
-
-export default Device;
+export const Device = dynamic(() => import('./Device'), { ssr: false });

--- a/modules/dashboard/Overview.tsx
+++ b/modules/dashboard/Overview.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import SlowZonesWidget from '../slowzones/SlowZonesWidget';
+import { SlowZonesWidget } from '../slowzones/SlowZonesWidget';
 import { SpeedWidget } from '../speed/SpeedWidget';
 import { RidershipWidget } from '../ridership/RidershipWidget';
 
-export default function Overview() {
+export const Overview: React.FC = () => {
   const { tab, line } = useDelimitatedRoute();
   return (
     <div className="flex flex-col pt-2">
@@ -15,4 +15,4 @@ export default function Overview() {
       </div>
     </div>
   );
-}
+};

--- a/modules/dashboard/TodayContainer.tsx
+++ b/modules/dashboard/TodayContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { Today } from './Today';
 
-export default function TodayContainer() {
+export function TodayContainer() {
   const { tab, lineShort } = useDelimitatedRoute();
 
   if (tab !== 'Subway' || lineShort === 'Bus') {

--- a/modules/dwells/DwellsDetails.tsx
+++ b/modules/dwells/DwellsDetails.tsx
@@ -16,7 +16,7 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { DwellsSingleChart } from './charts/DwellsSingleChart';
 import { DwellsAggregateChart } from './charts/DwellsAggregateChart';
 
-export default function DwellsDetails() {
+export const DwellsDetails: React.FC = () => {
   const {
     query: { startDate, endDate, to, from },
   } = useDelimitatedRoute();
@@ -75,4 +75,4 @@ export default function DwellsDetails() {
       <TerminusNotice toStation={toStation} fromStation={fromStation} />
     </>
   );
-}
+};

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -21,7 +21,7 @@ import { HeadwaysSingleChart } from './charts/HeadwaysSingleChart';
 import { HeadwaysHistogram } from './charts/HeadwaysHistogram';
 import { HeadwaysAggregateChart } from './charts/HeadwaysAggregateChart';
 
-export default function HeadwaysDetails() {
+export function HeadwaysDetails() {
   const {
     query: { startDate, endDate, to, from },
   } = useDelimitatedRoute();

--- a/modules/ridership/RidershipDetails.tsx
+++ b/modules/ridership/RidershipDetails.tsx
@@ -13,7 +13,7 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { TphChart } from './charts/TphChart';
 import { ServiceRidershipChart } from './charts/ServiceRidershipChart';
 
-export default function RidershipDetails() {
+export function RidershipDetails() {
   const allRidership = useRidershipData();
 
   const {

--- a/modules/ridership/RidershipWidget.tsx
+++ b/modules/ridership/RidershipWidget.tsx
@@ -16,7 +16,7 @@ import { TphChart } from './charts/TphChart';
 export const RidershipWidget: React.FC = () => {
   const allRidership = useRidershipData();
 
-  const { line, linePath, lineShort, query } = useDelimitatedRoute();
+  const { line, lineShort, query } = useDelimitatedRoute();
   const routeOrLine = line === 'line-bus' ? query.busRoute : lineShort;
   // Get the proper line- index, replace slashes for 114/116/117 route
   const lineData = allRidership.data?.lineData[`line-${routeOrLine?.replace(/\//g, '')}`];

--- a/modules/slowzones/SlowZonesDetails.tsx
+++ b/modules/slowzones/SlowZonesDetails.tsx
@@ -17,7 +17,7 @@ import { SlowZonesMap } from './map';
 import { DirectionObject } from './constants/constants';
 dayjs.extend(utc);
 
-export default function SlowZonesDetails() {
+export function SlowZonesDetails() {
   const delayTotals = useSlowzoneDelayTotalData();
   const [direction, setDirection] = useState<Direction>('northbound');
   const allSlow = useSlowzoneAllData();

--- a/modules/slowzones/SlowZonesWidget.tsx
+++ b/modules/slowzones/SlowZonesWidget.tsx
@@ -11,7 +11,7 @@ import { OVERVIEW_OPTIONS } from '../../common/constants/dates';
 import { TotalSlowTimeWrapper } from './TotalSlowTimeWrapper';
 dayjs.extend(utc);
 
-export default function SlowZonesWidget() {
+export const SlowZonesWidget: React.FC = () => {
   const { line, query, lineShort } = useDelimitatedRoute();
   const delayTotals = useSlowzoneDelayTotalData();
   const { startDate } = OVERVIEW_OPTIONS[query.view ?? 'year'];
@@ -42,4 +42,4 @@ export default function SlowZonesWidget() {
       </WidgetDiv>
     </>
   );
-}
+};

--- a/modules/slowzones/map/DirectionIndicator.tsx
+++ b/modules/slowzones/map/DirectionIndicator.tsx
@@ -4,14 +4,19 @@ import type { SlowZoneDirection } from './segment';
 
 import styles from './DirectionIndicator.module.css';
 
-interface Props {
+interface DirectionIndicatorProps {
   direction: SlowZoneDirection;
   color: string;
   isHorizontal: boolean;
   size?: number;
 }
 
-const DirectionIndicator: React.FC<Props> = ({ direction, color, isHorizontal, size = 5 }) => {
+export const DirectionIndicator: React.FC<DirectionIndicatorProps> = ({
+  direction,
+  color,
+  isHorizontal,
+  size = 5,
+}) => {
   const rotation = isHorizontal ? (direction === '1' ? 90 : 270) : direction === '1' ? 180 : 0;
   return (
     <div
@@ -26,5 +31,3 @@ const DirectionIndicator: React.FC<Props> = ({ direction, color, isHorizontal, s
     />
   );
 };
-
-export default DirectionIndicator;

--- a/modules/slowzones/map/SlowSegmentLabel.tsx
+++ b/modules/slowzones/map/SlowSegmentLabel.tsx
@@ -8,7 +8,7 @@ import type { SlowZoneDirection, SlowZonesByDirection } from './segment';
 import { DIRECTIONS } from './segment';
 
 import styles from './SlowSegmentLabel.module.css';
-import DirectionIndicator from './DirectionIndicator';
+import { DirectionIndicator } from './DirectionIndicator';
 
 interface SlowSegmentLabelProps {
   slowZonesByDirection: SlowZonesByDirection;

--- a/modules/slowzones/map/SlowZonesTooltip.tsx
+++ b/modules/slowzones/map/SlowZonesTooltip.tsx
@@ -9,7 +9,7 @@ import type { SlowZoneDirection, SlowZonesSegment } from './segment';
 import { DIRECTIONS } from './segment';
 
 import styles from './SlowZonesTooltip.module.css';
-import DirectionIndicator from './DirectionIndicator';
+import { DirectionIndicator } from './DirectionIndicator';
 
 interface SlowZonesTooltipProps {
   segment: SlowZonesSegment;

--- a/modules/speed/SpeedDetails.tsx
+++ b/modules/speed/SpeedDetails.tsx
@@ -10,7 +10,7 @@ import { getSpeedGraphConfig } from './constants/speeds';
 import { SpeedDetailsWrapper } from './SpeedDetailsWrapper';
 dayjs.extend(utc);
 
-export default function SpeedDetails() {
+export function SpeedDetails() {
   const {
     line,
     query: { startDate, endDate },

--- a/modules/traveltimes/TravelTimesDetails.tsx
+++ b/modules/traveltimes/TravelTimesDetails.tsx
@@ -20,7 +20,7 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { TravelTimesSingleChart } from './charts/TravelTimesSingleChart';
 import { TravelTimesAggregateChart } from './charts/TravelTimesAggregateChart';
 
-export default function TravelTimesDetails() {
+export function TravelTimesDetails() {
   const {
     linePath,
     query: { startDate, endDate, to, from },

--- a/pages/[line]/dwells.tsx
+++ b/pages/[line]/dwells.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS } from '../../common/types/lines';
-import DwellsDetails from '../../modules/dwells/DwellsDetails';
+import { DwellsDetails } from '../../modules/dwells/DwellsDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/index.tsx
+++ b/pages/[line]/index.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS } from '../../common/types/lines';
-import TodayContainer from '../../modules/dashboard/TodayContainer';
+import { TodayContainer } from '../../modules/dashboard/TodayContainer';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/overview.tsx
+++ b/pages/[line]/overview.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
-import Overview from '../../modules/dashboard/Overview';
+import { Overview } from '../../modules/dashboard/Overview';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/ridership.tsx
+++ b/pages/[line]/ridership.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
-import RidershipDetails from '../../modules/ridership/RidershipDetails';
+import { RidershipDetails } from '../../modules/ridership/RidershipDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/slowzones.tsx
+++ b/pages/[line]/slowzones.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS } from '../../common/types/lines';
-import SlowZonesDetails from '../../modules/slowzones/SlowZonesDetails';
+import { SlowZonesDetails } from '../../modules/slowzones/SlowZonesDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/speed.tsx
+++ b/pages/[line]/speed.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS } from '../../common/types/lines';
-import SpeedDetails from '../../modules/speed/SpeedDetails';
+import { SpeedDetails } from '../../modules/speed/SpeedDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/traveltimes.tsx
+++ b/pages/[line]/traveltimes.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS, BUS_PATH } from '../../common/types/lines';
-import TravelTimesDetails from '../../modules/traveltimes/TravelTimesDetails';
+import { TravelTimesDetails } from '../../modules/traveltimes/TravelTimesDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/trips/dwells.tsx
+++ b/pages/[line]/trips/dwells.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS } from '../../../common/types/lines';
-import DwellsDetails from '../../../modules/dwells/DwellsDetails';
+import { DwellsDetails } from '../../../modules/dwells/DwellsDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/trips/headways.tsx
+++ b/pages/[line]/trips/headways.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS, BUS_PATH } from '../../../common/types/lines';
-import HeadwaysDetails from '../../../modules/headways/HeadwaysDetails';
+import { HeadwaysDetails } from '../../../modules/headways/HeadwaysDetails';
 
 export async function getStaticProps() {
   return { props: {} };

--- a/pages/[line]/trips/traveltimes.tsx
+++ b/pages/[line]/trips/traveltimes.tsx
@@ -1,5 +1,5 @@
 import { ALL_LINE_PATHS, BUS_PATH } from '../../../common/types/lines';
-import TravelTimesDetails from '../../../modules/traveltimes/TravelTimesDetails';
+import { TravelTimesDetails } from '../../../modules/traveltimes/TravelTimesDetails';
 
 export async function getStaticProps() {
   return { props: {} };


### PR DESCRIPTION
## Motivation

We had a few spots on inconsistent named exports

## Changes

- Adds rule to prefer named exports
- Excludes `pages` code since they need defaults

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
