### PR TITLE
Setting selected datepicker color to match line

### DIFF
--- a/common/components/inputs/DateSelection/DatePickers.tsx
+++ b/common/components/inputs/DateSelection/DatePickers.tsx
@@ -97,6 +97,7 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
             handleStartDateChange(currentDateString);
           }}
           onMonthChange={() => updateColor(line)}
+          onOpen={() => updateColor(line)}
         />
         {range ? (
           <>
@@ -119,6 +120,7 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
                 handleEndDateChange(currentDateString);
               }}
               onMonthChange={() => updateColor(line)}
+              onOpen={() => updateColor(line)}
             />
           </>
         ) : null}

--- a/common/components/inputs/DateSelection/DatePickers.tsx
+++ b/common/components/inputs/DateSelection/DatePickers.tsx
@@ -9,6 +9,7 @@ import 'flatpickr/dist/themes/light.css';
 import { useDelimitatedRoute, useUpdateQuery } from '../../../utils/router';
 import { FLAT_PICKER_OPTIONS, TODAY_STRING, RANGE_PRESETS } from '../../../constants/dates';
 import { buttonHighlightFocus } from '../../../styles/general';
+import type { Line } from '../../../types/lines';
 import { RangeButton } from './RangeButton';
 
 interface DatePickerProps {
@@ -17,6 +18,15 @@ interface DatePickerProps {
   type: 'combo' | 'range' | 'single';
   clearPreset: () => void;
 }
+
+export const updateColor = (line: Line | undefined) => {
+  const selectedDates = document.querySelectorAll('.flatpickr-day.selected');
+  selectedDates.forEach((selectedDate) => {
+    if (line) {
+      selectedDate?.classList.add(`selected-date-${line}`);
+    }
+  });
+};
 
 export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, clearPreset }) => {
   const updateQueryParams = useUpdateQuery();
@@ -67,11 +77,14 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
     clearPreset();
   };
 
+  React.useEffect(() => {
+    updateColor(line);
+  });
+
   return (
     <div className="-ml-[1px] flex h-10 flex-row justify-center self-stretch rounded-r-md bg-white md:h-7">
       <div className={classNames('flex h-full flex-row self-stretch bg-opacity-80')}>
         <Flatpickr
-          //TODO: Change calendar to line color
           className={classNames(
             'flex w-[6.75rem] cursor-pointer border-none bg-transparent px-2 py-0 text-center text-sm focus:ring-opacity-0',
             line && buttonHighlightFocus[line]
@@ -83,6 +96,7 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
           onChange={(dates, currentDateString) => {
             handleStartDateChange(currentDateString);
           }}
+          onMonthChange={() => updateColor(line)}
         />
         {range ? (
           <>
@@ -93,7 +107,6 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
             </div>
 
             <Flatpickr
-              //TODO: Change calendar to line color
               className={classNames(
                 'flex w-[6.75rem] cursor-pointer border-none bg-transparent px-2 py-0 text-center text-sm focus:ring-opacity-0',
                 line && buttonHighlightFocus[line]
@@ -105,6 +118,7 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
               onChange={(dates, currentDateString) => {
                 handleEndDateChange(currentDateString);
               }}
+              onMonthChange={() => updateColor(line)}
             />
           </>
         ) : null}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,7 +6,6 @@ export default function Document() {
     <Html lang="en" className="font-sans h-full">
       <Head>
         <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content="@transitmatters" />

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -133,3 +133,29 @@
 .tippy-box .tippy-arrow {
     color: var(--incident-tooltip-color);
 }
+
+/* Datepicker Selected Date colors */
+.selected-date-line-red {
+    background: #E89999 !important;
+    border-color: #E89999 !important;
+}
+
+.selected-date-line-orange {
+    background: #F6C580 !important;
+    border-color: #F6C580 !important;
+}
+
+.selected-date-line-blue {
+    background: #809ED2 !important;
+    border-color: #809ED2 !important;
+}
+
+.selected-date-line-green {
+    background: #80C1A6 !important;
+    border-color: #80C1A6 !important;
+}
+
+.selected-date-line-bus {
+    background: #FFE395 !important;
+    border-color: #FFE395 !important;
+}


### PR DESCRIPTION
## Motivation

https://github.com/transitmatters/t-performance-dash/issues/533

Match the current line color

## Changes

Okay this is kinda hacky, but, there's no good interface to change the selected date color cleanly given the way flatpickr sets its styles. So, here's the function that pins a new classname onto the selected date to update the color

<img width="335" alt="Screenshot 2023-05-03 at 8 39 54 PM" src="https://user-images.githubusercontent.com/9310513/236081010-63cf78bf-2f7d-4575-b24d-08df28cdb42e.png">
<img width="336" alt="Screenshot 2023-05-03 at 8 40 01 PM" src="https://user-images.githubusercontent.com/9310513/236081015-a229e3b0-cdea-4262-bb9f-4efb0134dd6c.png">
<img width="343" alt="Screenshot 2023-05-03 at 8 40 06 PM" src="https://user-images.githubusercontent.com/9310513/236081019-ccbf9782-55f5-4472-a1c4-49b9b931b4e8.png">
<img width="333" alt="Screenshot 2023-05-03 at 8 40 12 PM" src="https://user-images.githubusercontent.com/9310513/236081020-6c8b336b-d4a0-4362-a0a2-584b6c359775.png">


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
