### PR TITLE
better scroll visual for alerts

### DIFF
--- a/modules/commute/alerts/Alerts.tsx
+++ b/modules/commute/alerts/Alerts.tsx
@@ -16,7 +16,7 @@ export const Alerts: React.FC = () => {
   const alerts = useAlertsData(lineShort, busRoute);
 
   const divStyle = classNames(
-    'flex flex-col rounded-md p-4 text-white shadow-dataBox w-full xl:w-1/3 gap-y-2 md:max-h-[309px] md:overflow-y-auto',
+    'flex flex-col rounded-md py-4 text-white shadow-dataBox w-full xl:w-1/3 gap-y-2 md:max-h-[309px] md:overflow-y-auto',
     lineColorBackground[line ?? 'DEFAULT']
   );
 
@@ -25,15 +25,15 @@ export const Alerts: React.FC = () => {
   if (!alertsReady) {
     return (
       <div className={divStyle}>
-        <h3 className="w-full text-2xl font-semibold md:w-auto">Alerts</h3>
+        <h3 className="w-full px-4 text-2xl font-semibold md:w-auto">Alerts</h3>
         <ChartPlaceHolder query={alerts} isInverse />
       </div>
     );
   }
   return (
     <div className={divStyle}>
-      <h3 className="w-full text-2xl font-semibold md:w-auto">Alerts</h3>
-      <div className="flex w-full flex-row gap-x-4 overflow-x-scroll pb-2 md:flex-col md:gap-x-0 md:overflow-x-auto">
+      <h3 className="w-full px-4 text-2xl font-semibold md:w-auto">Alerts</h3>
+      <div className="flex w-full flex-row gap-x-4 overflow-x-scroll px-4 md:flex-col md:gap-x-0 md:overflow-x-auto">
         <div className="md:w-full">
           <Divider title="Today" line={line} />
 


### PR DESCRIPTION
## Motivation

Did some usability testing with a friend. Alerts didn't look scrollable on mobile since they didn't go up to the edge.
## Changes
**Before**
<img width="590" alt="Screen Shot 2023-05-07 at 6 36 57 PM" src="https://user-images.githubusercontent.com/46229349/236715567-b7f115c3-883d-491d-86fc-35d784e85018.png">
**After**
<img width="592" alt="Screen Shot 2023-05-07 at 6 37 45 PM" src="https://user-images.githubusercontent.com/46229349/236715570-ab94b58b-51f6-486a-a4a3-e77b4b72e198.png">
