### PR TITLE
convert to Next Links, add shallow routing

### DIFF
--- a/common/components/inputs/DateSelection/OverviewDateSelection.tsx
+++ b/common/components/inputs/DateSelection/OverviewDateSelection.tsx
@@ -17,7 +17,7 @@ export const OverviewDateSelection = () => {
     overviewPresetChange({ view: value });
     setDatePreset(value, 'line', true);
     router.query.view = value;
-    router.push({ pathname: router.pathname, query: router.query });
+    router.push({ pathname: router.pathname, query: router.query }, undefined, { shallow: true });
   };
 
   return (

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -125,6 +125,7 @@ export const getLineSelectionItemHref = (newLine: Line, route: Route): string =>
 
 export const getBusRouteSelectionItemHref = (newRoute: string, route: Route): string => {
   const { query, page } = route;
+  if (!page) return ''; // TODO: remove this. Only needed bc this loads on root URL at the moment.
   const currentPage = ALL_PAGES[page];
   const currentPath = currentPage.path;
   const validPage = currentPage.lines.includes('line-bus');

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -1,6 +1,5 @@
 import type { ParsedUrlQuery } from 'querystring';
 import { capitalize, isEqual, pickBy } from 'lodash';
-import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import type { Line, LinePath, LineShort } from '../types/lines';
@@ -93,7 +92,7 @@ export const useUpdateQuery = () => {
 
       if (!isEqual(router.query, newQuery)) {
         const query = pickBy(newQuery, (attr) => attr !== undefined);
-        router.push({ pathname: router.pathname, query });
+        router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
       }
     },
     [router]
@@ -143,37 +142,41 @@ export const getBusRouteSelectionItemHref = (newRoute: string, route: Route): st
   return href;
 };
 
+export const getHref = (
+  dashboardConfig: DashboardConfig,
+  newPage: PageMetadata,
+  currentPage: Page,
+  query: QueryParams,
+  linePath: LinePath
+) => {
+  const pageObject = ALL_PAGES[currentPage];
+  if (pageObject?.section === newPage.section) {
+    return navigateWithinSection(linePath, newPage, query);
+  }
+  return navigateToNewSection(linePath, newPage, query, dashboardConfig);
+};
+
 export const useHandlePageNavigation = () => {
-  const router = useRouter();
-  const { page, query, linePath } = useDelimitatedRoute();
+  const { page, query } = useDelimitatedRoute();
   const pageObject = ALL_PAGES[page];
   const dashboardConfig = useDashboardConfig();
 
   const handlePageNavigation = useCallback(
     (page: PageMetadata) => {
-      if (pageObject?.section === page.section) {
-        navigateWithinSection(router, linePath, page, query);
-        return;
+      if (!(pageObject?.section === page.section)) {
+        saveDashboardConfig(pageObject.section, query, dashboardConfig);
       }
-      saveDashboardConfig(pageObject.section, query, dashboardConfig);
-      navigateToNewSection(router, linePath, page, query, dashboardConfig);
     },
-    [router, query, linePath, pageObject, dashboardConfig]
+    [query, pageObject, dashboardConfig]
   );
   return handlePageNavigation;
 };
 
-const navigateWithinSection = (
-  router: NextRouter,
-  linePath: LinePath,
-  page: PageMetadata,
-  query: QueryParams
-) => {
-  router.push({ pathname: `/${linePath}${page.path}`, query: query });
+const navigateWithinSection = (linePath: LinePath, page: PageMetadata, query: QueryParams) => {
+  return { pathname: `/${linePath}${page.path}`, query: query };
 };
 
 const navigateToNewSection = (
-  router: NextRouter,
   linePath: LinePath,
   page: PageMetadata,
   query: QueryParams,
@@ -182,5 +185,5 @@ const navigateToNewSection = (
   const params = getDashboardConfig(page.section, dashboardConfig);
   const busRouteOnly = query.busRoute ?? undefined;
   const newQuery = busRouteOnly ? { ...params, busRoute: busRouteOnly } : params;
-  router.push({ pathname: `/${linePath}${page.path}`, query: newQuery });
+  return { pathname: `/${linePath}${page.path}`, query: newQuery };
 };

--- a/modules/dashboard/HomescreenWidgetTitle.tsx
+++ b/modules/dashboard/HomescreenWidgetTitle.tsx
@@ -1,22 +1,26 @@
 import React from 'react';
 import classNames from 'classnames';
+import Link from 'next/link';
 import { mbtaTextConfig } from '../../common/components/inputs/styles/tailwind';
-import { useDelimitatedRoute, useHandlePageNavigation } from '../../common/utils/router';
+import { getHref, useDelimitatedRoute, useHandlePageNavigation } from '../../common/utils/router';
 import ExploreArrow from '../../public/Icons/Components/ExploreArrow.svg';
 import { LINE_COLORS } from '../../common/constants/colors';
 import type { Page } from '../../common/constants/pages';
 import { ALL_PAGES } from '../../common/constants/pages';
+import { useDashboardConfig } from '../../common/state/dashboardConfig';
 
 interface HomescreenWidgetTitle {
   title: string;
   tab: Page;
 }
 export const HomescreenWidgetTitle: React.FC<HomescreenWidgetTitle> = ({ title, tab }) => {
-  const { line } = useDelimitatedRoute();
+  const { line, page, query, linePath } = useDelimitatedRoute();
   const handlePageNavigation = useHandlePageNavigation();
+  const dashboardConfig = useDashboardConfig();
+  const href = getHref(dashboardConfig, ALL_PAGES[tab], page, query, linePath);
   return (
     <div className="flex w-full items-baseline justify-between p-2">
-      <button onClick={() => handlePageNavigation(ALL_PAGES[tab])}>
+      <Link onClick={() => handlePageNavigation(ALL_PAGES[tab])} href={href}>
         <div className="flex w-full cursor-pointer flex-row items-center text-xl">
           <h3
             className={classNames(
@@ -28,7 +32,7 @@ export const HomescreenWidgetTitle: React.FC<HomescreenWidgetTitle> = ({ title, 
           </h3>
           <ExploreArrow fill={LINE_COLORS[line ?? 'default']} className="h-4 w-auto pl-2" />
         </div>
-      </button>
+      </Link>
       <p className="text-xs italic text-stone-700">{`Date Placeholder`}</p>
     </div>
   );

--- a/modules/navigation/BusSelection.tsx
+++ b/modules/navigation/BusSelection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { Tab } from '@headlessui/react';
 import { getBusRoutes } from '../../common/constants/stations';
 import { getBusRouteSelectionItemHref, useDelimitatedRoute } from '../../common/utils/router';
@@ -11,11 +11,9 @@ interface BusSelectionProps {
 
 export const BusSelection: React.FC<BusSelectionProps> = ({ setSidebarOpen }) => {
   const route = useDelimitatedRoute();
-  const router = useRouter();
   const busRoutes = getBusRoutes();
 
-  const handleChange = (key: string) => {
-    router.push(getBusRouteSelectionItemHref(key, route));
+  const handleChange = () => {
     setSidebarOpen && setSidebarOpen(false);
   };
 
@@ -23,15 +21,16 @@ export const BusSelection: React.FC<BusSelectionProps> = ({ setSidebarOpen }) =>
     <Tab.Group
       manual
       selectedIndex={busRoutes.findIndex((key) => key === route.query.busRoute)}
-      onChange={(index) => handleChange(busRoutes[index])}
+      onChange={handleChange}
     >
       <Tab.List className="relative grid grid-cols-3 gap-2">
         {busRoutes.map((key) => {
           const selected = route.query.busRoute === key;
           return (
             <Tab key={key}>
-              <span
-                onClick={() => handleChange(key)}
+              <Link
+                href={getBusRouteSelectionItemHref(key, route)}
+                onClick={handleChange}
                 key={key}
                 className={classNames(
                   'flex w-full cursor-pointer items-center justify-center rounded-md border border-mbta-bus bg-mbta-bus p-2 text-sm font-medium',
@@ -43,7 +42,7 @@ export const BusSelection: React.FC<BusSelectionProps> = ({ setSidebarOpen }) =>
                 <p title={key} className="overflow-hidden text-ellipsis whitespace-nowrap">
                   {key}
                 </p>
-              </span>
+              </Link>
             </Tab>
           );
         })}

--- a/modules/navigation/DashboardSelection.tsx
+++ b/modules/navigation/DashboardSelection.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import { Tab } from '@headlessui/react';
 import classNames from 'classnames';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { DASHBOARD_TABS } from '../../common/constants/dashboardTabs';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { useDashboardConfig } from '../../common/state/dashboardConfig';
 
 export const DashboardSelection: React.FC = () => {
   const { tab } = useDelimitatedRoute();
-  const router = useRouter();
   const swapDashboardTabs = useDashboardConfig((state) => state.swapDashboardTabs);
   const dashboardTabs = Object.values(DASHBOARD_TABS);
   return (
     <Tab.Group
       manual
       onChange={(index) => {
-        router.push({ pathname: dashboardTabs[index].path, query: dashboardTabs[index].query });
         swapDashboardTabs(dashboardTabs[index].name);
       }}
       selectedIndex={dashboardTabs.findIndex((currTab) => tab === currTab.name)}
@@ -24,7 +22,8 @@ export const DashboardSelection: React.FC = () => {
         {dashboardTabs.map((tab, index) => (
           <Tab key={tab.name} className="w-full" disabled={tab.disabled}>
             {({ selected }) => (
-              <div
+              <Link
+                href={{ pathname: dashboardTabs[index].path, query: dashboardTabs[index].query }}
                 className={classNames(
                   'flex items-center justify-center border border-stone-200 py-1 text-sm font-semibold',
                   selected && 'bg-stone-200 text-stone-900',
@@ -36,7 +35,7 @@ export const DashboardSelection: React.FC = () => {
                 )}
               >
                 <p>{tab.name}</p>
-              </div>
+              </Link>
             )}
           </Tab>
         ))}

--- a/modules/navigation/LineSelection.tsx
+++ b/modules/navigation/LineSelection.tsx
@@ -1,10 +1,10 @@
-import { useRouter } from 'next/router';
 import React from 'react';
 import classNames from 'classnames';
 import { Tab } from '@headlessui/react';
+import Link from 'next/link';
 import { lineColorBackground, lineColorDarkBackground } from '../../common/styles/general';
 import { getLineSelectionItemHref, useDelimitatedRoute } from '../../common/utils/router';
-import type { Line, LineMetadata } from '../../common/types/lines';
+import type { LineMetadata } from '../../common/types/lines';
 
 interface LineSelectionProps {
   lineItems: LineMetadata[];
@@ -12,10 +12,8 @@ interface LineSelectionProps {
 }
 
 export const LineSelection: React.FC<LineSelectionProps> = ({ lineItems, setSidebarOpen }) => {
-  const router = useRouter();
   const route = useDelimitatedRoute();
-  const onChange = (key: Line) => {
-    router.push(getLineSelectionItemHref(key, route));
+  const onChange = () => {
     setSidebarOpen && setSidebarOpen(false);
   };
 
@@ -24,15 +22,16 @@ export const LineSelection: React.FC<LineSelectionProps> = ({ lineItems, setSide
       vertical
       manual
       selectedIndex={lineItems.findIndex((lineItem) => lineItem.key === route.line)}
-      onChange={(index) => onChange(lineItems[index].key)}
+      onChange={onChange}
     >
       <Tab.List className=" mx-1 flex flex-col gap-y-1">
         {lineItems.map((lineItem) => {
           return (
             <Tab key={lineItem.key}>
               {({ selected }) => (
-                <div
-                  onClick={() => onChange(lineItem.key)}
+                <Link
+                  href={getLineSelectionItemHref(lineItem.key, route)}
+                  onClick={onChange}
                   key={lineItem.key}
                   className={classNames(
                     'space-between flex w-full cursor-pointer select-none items-center rounded-md bg-opacity-0 py-1 pl-2 text-stone-200  hover:bg-opacity-80',
@@ -54,7 +53,7 @@ export const LineSelection: React.FC<LineSelectionProps> = ({ lineItems, setSide
                   >
                     {lineItem.name}
                   </p>
-                </div>
+                </Link>
               )}
             </Tab>
           );

--- a/modules/navigation/SidebarTabs.tsx
+++ b/modules/navigation/SidebarTabs.tsx
@@ -1,8 +1,10 @@
 import classNames from 'classnames';
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useDelimitatedRoute, useHandlePageNavigation } from '../../common/utils/router';
+import Link from 'next/link';
+import { getHref, useDelimitatedRoute, useHandlePageNavigation } from '../../common/utils/router';
 import type { PageMetadata } from '../../common/constants/pages';
+import { useDashboardConfig } from '../../common/state/dashboardConfig';
 
 interface SidebarTabs {
   tabs: PageMetadata[];
@@ -10,9 +12,9 @@ interface SidebarTabs {
 }
 
 export const SidebarTabs: React.FC<SidebarTabs> = ({ tabs, setSidebarOpen }) => {
-  const { line, page } = useDelimitatedRoute();
-
+  const { line, page, query, linePath } = useDelimitatedRoute();
   const handlePageNavigation = useHandlePageNavigation();
+  const dashboardConfig = useDashboardConfig();
 
   const handleChange = (enabled: boolean, tab: PageMetadata) => {
     if (!enabled) return null;
@@ -26,9 +28,11 @@ export const SidebarTabs: React.FC<SidebarTabs> = ({ tabs, setSidebarOpen }) => 
         {tabs.map((tab: PageMetadata) => {
           const enabled = line ? tab.lines.includes(line) : true;
           const selected = page === tab.key;
+          const href = getHref(dashboardConfig, tab, page, query, linePath);
           return (
             <li key={tab.key}>
-              <a
+              <Link
+                href={href}
                 tabIndex={enabled ? 0 : undefined}
                 onKeyUp={(e) => {
                   if (e.key === 'enter' || e.key === ' ') handleChange(enabled, tab);
@@ -54,7 +58,7 @@ export const SidebarTabs: React.FC<SidebarTabs> = ({ tabs, setSidebarOpen }) => 
                   )}
                 />
                 <span className="truncate">{tab.name}</span>
-              </a>
+              </Link>
             </li>
           );
         })}

--- a/modules/navigation/utils/rangeTabUtils.ts
+++ b/modules/navigation/utils/rangeTabUtils.ts
@@ -10,7 +10,7 @@ export const switchToSingleDay = (router: NextRouter, dashboardConfig: Dashboard
   router.query.queryType = 'single';
   router.query.startDate = router.query.endDate;
   delete router.query.endDate;
-  router.push(router);
+  router.push(router, undefined, { shallow: true });
   return;
 };
 
@@ -27,7 +27,7 @@ export const switchToRange = (router: NextRouter, dashboardConfig: DashboardConf
 export const returnToPreviousRange = (router: NextRouter, tripConfig: TripsSectionParams) => {
   router.query.endDate = tripConfig.endDate;
   router.query.startDate = tripConfig.startDate;
-  router.push({ pathname: router.pathname, query: router.query });
+  router.push({ pathname: router.pathname, query: router.query }, undefined, { shallow: true });
 };
 
 export const createNewRange = (router: NextRouter) => {
@@ -40,5 +40,5 @@ export const createNewRange = (router: NextRouter) => {
     router.query.endDate = TODAY_STRING;
   }
   router.query.queryType = 'range';
-  router.push(router);
+  router.push(router, undefined, { shallow: true });
 };


### PR DESCRIPTION
## Motivation

All of our nav was using button with onClick behavior, and not `<a>` tags or `<Link>` tags (nextJS <a> tag). This meant the browser was not treating these links as links and actions such as cmd + click to open in new tab did not work.

Also, changed some routing to be "shallow"  - this does not refresh the page, just updates the URL. Good for stuff like `Lines` page to keep your scroll position when updating date range.

## Changes

Things like this URL showing up on hover only work with <a> tags:
![Screen Shot 2023-05-12 at 3 15 03 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/e8966dd1-3d01-4470-992a-616cc1a371b0)

## Testing Instructions
I am most concerned that this will have an impact on global state management. Like saving date ranges across page sections. I didn't find any issues, but that would be a good place to look for edge cases.