### PR TITLE
feat: basic system slowzones tab

### DIFF
--- a/common/constants/dashboardTabs.ts
+++ b/common/constants/dashboardTabs.ts
@@ -12,5 +12,5 @@ export const DASHBOARD_TABS: {
     path: '/bus/trips',
     query: { busRoute: '1', queryType: 'single', startDate: BUS_DEFAULTS.tripConfig.startDate },
   },
-  System: { name: 'System', path: '/', disabled: true },
+  System: { name: 'System', path: '/system' },
 };

--- a/common/constants/pages.ts
+++ b/common/constants/pages.ts
@@ -29,8 +29,8 @@ export enum PAGES {
   tripDwells = 'tripDwells',
 }
 
-export type Section = 'today' | 'line' | 'overview' | 'trips';
-export type SectionTitle = 'Today' | 'Line' | 'Overview' | 'Trips';
+export type Section = 'today' | 'line' | 'overview' | 'trips' | 'system';
+export type SectionTitle = 'Today' | 'Line' | 'Overview' | 'Trips' | 'System';
 
 export type PageMetadata = {
   key: string;
@@ -186,3 +186,15 @@ export const SUB_PAGES_MAP = {
     dwells: 'tripDwells',
   },
 };
+
+export const SYSTEM_PAGES: PageMetadata[] = [
+  {
+    key: 'slowzones',
+    path: '/slowzones',
+    name: 'Slow Zones',
+    lines: [],
+    icon: faWarning,
+    section: 'system',
+    sectionTitle: 'System',
+  },
+];

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -34,12 +34,22 @@ const getPage = (pageArray: string[]): string => {
   return pageArray[0];
 };
 
+const getTab = (path: string) => {
+  if (RAIL_LINES.includes(path)) {
+    return 'Subway';
+  } else if (path === 'bus') {
+    return 'Bus';
+  } else {
+    return 'System';
+  }
+};
+
 export const useDelimitatedRoute = (): Route => {
   const router = useRouter();
   const path = router.asPath.split('?');
   const pathItems = path[0].split('/');
   const queryParams = router.query;
-  const tab = RAIL_LINES.includes(pathItems[1]) ? 'Subway' : 'Bus';
+  const tab = getTab(pathItems[1]);
   const page = getPage(pathItems.slice(2)) as Page;
   const newParams = getParams(queryParams);
 
@@ -48,7 +58,7 @@ export const useDelimitatedRoute = (): Route => {
     linePath: pathItems[1] as LinePath, //TODO: Remove as
     lineShort: capitalize(pathItems[1]) as LineShort, //TODO: Remove as
     page: page,
-    tab: tab,
+    tab,
     query: router.isReady ? newParams : {},
   };
 };

--- a/modules/dashboard/DesktopHeader.tsx
+++ b/modules/dashboard/DesktopHeader.tsx
@@ -13,6 +13,7 @@ export const DesktopHeader: React.FC = () => {
     line,
     page,
     query: { queryType, busRoute },
+    tab,
   } = useDelimitatedRoute();
   const section = page ? ALL_PAGES[page]?.section : undefined;
   const lg = useBreakpoint('lg');
@@ -23,6 +24,7 @@ export const DesktopHeader: React.FC = () => {
     if (busRoute) return `Route ${busRoute}`;
     if (line && !lg) return LINE_OBJECTS[line]?.short;
     if (line) return LINE_OBJECTS[line]?.name;
+    if (tab === 'System') return 'System';
   };
   return (
     <div
@@ -39,7 +41,7 @@ export const DesktopHeader: React.FC = () => {
       >
         <div className="flex shrink-0 flex-row items-baseline pl-3">
           <h3 className="text-xl font-semibold">{getLineName()}</h3>
-          {ALL_PAGES[page]?.sectionTitle && (
+          {ALL_PAGES[page]?.sectionTitle && tab !== 'System' && (
             <>
               <span className="px-1 text-xl">•</span>
               <h2 className="select-none text-xl font-semibold">

--- a/modules/navigation/BusNavMenu.tsx
+++ b/modules/navigation/BusNavMenu.tsx
@@ -11,7 +11,7 @@ export const BusNavMenu: React.FC<BusNavMenuProps> = ({ setSidebarOpen }) => {
   return (
     <>
       <BusSelection setSidebarOpen={setSidebarOpen} />
-      <div className="mx-2 flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-4">
         <hr className="h-1 w-full border-stone-400" />
         <SidebarTabs tabs={BUS_OVERVIEW} setSidebarOpen={setSidebarOpen} />
         <SidebarTabs tabs={BUS_PAGES} setSidebarOpen={setSidebarOpen} />

--- a/modules/navigation/LineSelection.tsx
+++ b/modules/navigation/LineSelection.tsx
@@ -24,7 +24,7 @@ export const LineSelection: React.FC<LineSelectionProps> = ({ lineItems, setSide
       selectedIndex={lineItems.findIndex((lineItem) => lineItem.key === route.line)}
       onChange={onChange}
     >
-      <Tab.List className=" mx-1 flex flex-col gap-y-1">
+      <Tab.List className="flex flex-col gap-y-1">
         {lineItems.map((lineItem) => {
           return (
             <Tab key={lineItem.key}>

--- a/modules/navigation/SideNavigation.tsx
+++ b/modules/navigation/SideNavigation.tsx
@@ -4,6 +4,7 @@ import type { Tab } from '../../common/types/router';
 import { DashboardSelection } from './DashboardSelection';
 import { BusNavMenu } from './BusNavMenu';
 import { SubwayNavMenu } from './SubwayNavMenu';
+import { SystemNavMenu } from './SystemNavMenu';
 
 interface SideNavigationProps {
   setSidebarOpen?: React.Dispatch<React.SetStateAction<boolean>>;
@@ -13,6 +14,7 @@ export const SideNavigation: React.FC<SideNavigationProps> = ({ setSidebarOpen }
   const getNavMenu = (tab: Tab) => {
     if (tab === 'Subway') return <SubwayNavMenu setSidebarOpen={setSidebarOpen} />;
     if (tab === 'Bus') return <BusNavMenu setSidebarOpen={setSidebarOpen} />;
+    if (tab === 'System') return <SystemNavMenu setSidebarOpen={setSidebarOpen} />;
   };
   const { tab } = useDelimitatedRoute();
   return (

--- a/modules/navigation/SidebarTabs.tsx
+++ b/modules/navigation/SidebarTabs.tsx
@@ -44,7 +44,7 @@ export const SidebarTabs: React.FC<SidebarTabs> = ({ tabs, setSidebarOpen }) => 
                     : enabled && 'text-stone-300 hover:bg-stone-800 hover:text-white',
                   'group flex select-none items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6',
                   enabled ? 'cursor-pointer' : 'cursor-default  text-stone-600',
-                  tab.sub && 'ml-4 text-xs'
+                  tab.sub && 'ml-2 text-xs'
                 )}
               >
                 <FontAwesomeIcon

--- a/modules/navigation/SubwayNavMenu.tsx
+++ b/modules/navigation/SubwayNavMenu.tsx
@@ -17,7 +17,7 @@ const LINE_ITEMS = [
 export const SubwayNavMenu: React.FC<SubwayNavMenuProps> = ({ setSidebarOpen }) => (
   <>
     <LineSelection lineItems={LINE_ITEMS} setSidebarOpen={setSidebarOpen} />
-    <div className="mx-2 flex flex-col gap-y-4">
+    <div className="flex flex-col gap-y-4">
       <hr className="h-1 w-full border-stone-400" />
       <SidebarTabs tabs={TODAY} setSidebarOpen={setSidebarOpen} />
       <SidebarTabs tabs={LINE_PAGES} setSidebarOpen={setSidebarOpen} />

--- a/modules/navigation/SystemNavMenu.tsx
+++ b/modules/navigation/SystemNavMenu.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { SYSTEM_PAGES } from '../../common/constants/pages';
+import { SidebarTabs } from './SidebarTabs';
+
+interface SystemNavMenuProps {
+  setSidebarOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+export const SystemNavMenu = ({ setSidebarOpen }: SystemNavMenuProps) => {
+  return (
+    <div className="flex flex-col gap-y-4">
+      <hr className="h-1 w-full border-stone-400" />
+      <SidebarTabs tabs={SYSTEM_PAGES} setSidebarOpen={setSidebarOpen} />
+    </div>
+  );
+};

--- a/pages/system/index.tsx
+++ b/pages/system/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { PageWrapper } from '../../common/layouts/PageWrapper';
+
+export default function System() {
+  return <PageWrapper>test</PageWrapper>;
+}

--- a/pages/system/slowzones.tsx
+++ b/pages/system/slowzones.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function slowzones() {
+  return <div>slowzones</div>;
+}


### PR DESCRIPTION
## Motivation
- We want to get started on our `system` page!
<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes
- Adds a basic `index` and `slowzones` pages under `System`
- Changes some padding on the sidenav
<!-- What does this change exactly? Include relevant screenshots, videos, links -->
|Before    | After |
| ----------- | ----------- |
|  ![Screen Shot 2023-05-13 at 1 01 44 PM](https://github.com/transitmatters/t-performance-dash/assets/1361408/61839a42-f742-4397-a517-7851d68716da) |  ![Screen Shot 2023-05-13 at 1 01 53 PM](https://github.com/transitmatters/t-performance-dash/assets/1361408/91fa7f4c-153b-4b67-8dad-37853c6b3298) |

![Screen Shot 2023-05-13 at 1 05 50 PM](https://github.com/transitmatters/t-performance-dash/assets/1361408/084187a9-17d8-4170-a400-ff8bfe29aaa3)

## Testing Instructions
- pull down this branch and run `npm install && npm start`
<!-- How can the reviewer confirm these changes do what you say they do? -->
