### PR TITLE
V4/titles

### DIFF
--- a/common/components/charts/AggregateLineChart.tsx
+++ b/common/components/charts/AggregateLineChart.tsx
@@ -19,11 +19,10 @@ import type { AggregateDataPoint, AggregateLineProps } from '../../types/charts'
 import { prettyDate } from '../../utils/date';
 import { CHART_COLORS } from '../../../common/constants/colors';
 import { DownloadButton } from '../general/DownloadButton';
-import { writeError } from '../../utils/chartError';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { watermarkLayout } from '../../constants/charts';
+import { writeError } from '../../utils/chartError';
 import { LegendLongTerm } from './Legend';
-import { drawTitle } from './Title';
 
 ChartJS.register(
   CategoryScale,
@@ -50,7 +49,6 @@ const xAxisLabel = (startDate: string, endDate: string, hourly: boolean) => {
 
 export const AggregateLineChart: React.FC<AggregateLineProps> = ({
   chartId,
-  title,
   data,
   location,
   pointField,
@@ -170,11 +168,6 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
               legend: {
                 display: false,
               },
-              title: {
-                // empty title to set font and leave room for drawTitle fn
-                display: true,
-                text: '',
-              },
               tooltip: {
                 mode: 'index',
                 position: 'nearest',
@@ -193,7 +186,6 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
                 if (startDate === undefined || endDate === undefined || data.length === 0) {
                   writeError(chart);
                 }
-                drawTitle(title, location, bothStops, chart);
               },
             },
           ]}

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -77,7 +77,6 @@ const departureFromNormalString = (metric: number, benchmark: number) => {
 
 export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
   chartId,
-  title,
   data,
   date,
   metricField,

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -22,10 +22,9 @@ import type { SingleDayLineProps } from '../../../common/types/charts';
 import { prettyDate } from '../../utils/date';
 import { useDelimitatedRoute } from '../../utils/router';
 import { DownloadButton } from '../general/DownloadButton';
-import { writeError } from '../../utils/chartError';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { watermarkLayout } from '../../constants/charts';
-import { drawTitle } from './Title';
+import { writeError } from '../../utils/chartError';
 import { Legend as LegendView } from './Legend';
 
 ChartJS.register(
@@ -171,11 +170,6 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
               legend: {
                 display: false,
               },
-              title: {
-                // empty title to set font and leave room for drawTitle fn
-                display: true,
-                text: '',
-              },
             },
             scales: {
               y: {
@@ -230,7 +224,6 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                 if (date === undefined || date.length === 0 || data.length === 0) {
                   writeError(chart);
                 }
-                drawTitle(title, location, bothStops, chart);
               },
             },
           ]}

--- a/common/components/charts/Title.tsx
+++ b/common/components/charts/Title.tsx
@@ -1,6 +1,5 @@
 import type { Chart } from 'chart.js';
 import type { LineShort } from '../../types/lines';
-import type { Location } from '../../types/charts';
 
 interface TitleFormat {
   text: string;
@@ -15,92 +14,12 @@ export const colorsForLine: Record<LineShort, string> = {
   Bus: '#ffc72c',
 };
 
-const getLineColor = (lineShort: LineShort) => colorsForLine[lineShort] || 'black';
 const titleColor = 'gray';
-
-const parse_location_description = (location: Location, bothStops: boolean) => {
-  const result: TitleFormat[] = [];
-  const lineColor = getLineColor(location.line);
-
-  result.push({ text: location['from'], color: lineColor });
-  if (bothStops) {
-    result.push({ text: ' to ', color: titleColor });
-    result.push({ text: location['to'], color: lineColor });
-  } else {
-    result.push({ text: ` ${location['direction']}`, color: titleColor });
-  }
-  return result;
-};
 
 function font(size_px = 16) {
   // This is the default from chartjs, but now we can adjust size.
   return `bold ${size_px}px "Helvetica Neue", "Helvetica", "Arial", sans-serif`;
 }
-
-const calcLocationWidth = (words: TitleFormat[], ctx: CanvasRenderingContext2D) => {
-  // input: result of parse_location_description
-  // output depends on ctx's current font
-  return words.map((x) => ctx.measureText(x.text).width).reduce((a, b) => a + b, 0);
-};
-
-export const drawTitle = (title: string, location: Location, bothStops: boolean, chart: Chart) => {
-  const { ctx } = chart;
-  ctx.save();
-
-  const leftMargin = chart.scales.x.left;
-  const rightMargin = chart.width - chart.scales.x.right;
-  const minGap = 10;
-  const vpos_row1 = 25;
-  const vpos_row2 = 50;
-
-  let fontSize = 16;
-  ctx.font = font(fontSize);
-
-  let position;
-
-  const locationDescr = parse_location_description(location, bothStops);
-  const titleWidth = ctx.measureText(title).width;
-  let locationWidth = calcLocationWidth(locationDescr, ctx);
-
-  if (leftMargin + titleWidth + minGap + locationWidth + rightMargin > chart.width) {
-    // small screen: centered title stacks vertically
-    ctx.textAlign = 'center';
-    ctx.fillStyle = titleColor;
-    ctx.fillText(title, chart.width / 2, vpos_row1);
-
-    // Location info might be too long. Shrink the font until it fits.
-    while (locationWidth > chart.width && fontSize >= 8) {
-      fontSize -= 1;
-      ctx.font = font(fontSize);
-      locationWidth = calcLocationWidth(locationDescr, ctx);
-    }
-    // we want centered, but have to write 1 word at a time bc colors, so...
-    ctx.textAlign = 'left';
-    position = chart.width / 2 - locationWidth / 2;
-
-    for (const { text, color } of locationDescr) {
-      ctx.fillStyle = color;
-      ctx.fillText(text, position, vpos_row2);
-      position += ctx.measureText(text).width;
-    }
-  } else {
-    // larger screen
-    // Primary chart title goes left
-    ctx.textAlign = 'left';
-    ctx.fillStyle = titleColor;
-    ctx.fillText(title, leftMargin, vpos_row2);
-
-    // location components are aligned right
-    ctx.textAlign = 'right';
-    position = chart.width - rightMargin;
-    for (const { text, color } of locationDescr.reverse()) {
-      ctx.fillStyle = color;
-      ctx.fillText(text, position, vpos_row2);
-      position -= ctx.measureText(text).width;
-    }
-  }
-  ctx.restore();
-};
 
 export const drawSimpleTitle = (title: string, chart: Chart) => {
   const { ctx } = chart;

--- a/common/components/charts/Title.tsx
+++ b/common/components/charts/Title.tsx
@@ -1,11 +1,6 @@
 import type { Chart } from 'chart.js';
 import type { LineShort } from '../../types/lines';
 
-interface TitleFormat {
-  text: string;
-  color: string;
-}
-
 export const colorsForLine: Record<LineShort, string> = {
   Red: '#da291c',
   Orange: '#ed8b00',

--- a/common/types/charts.ts
+++ b/common/types/charts.ts
@@ -1,5 +1,4 @@
 import type { TimeUnit } from 'chart.js';
-import type { LineShort } from './lines';
 import type { Station } from './stations';
 
 export interface SingleDayDataPoint {
@@ -40,7 +39,6 @@ export interface Location {
   to: string;
   from: string;
   direction: Direction;
-  line: LineShort;
 }
 
 export type TravelTimesUnit = 'by_date' | 'by_time';
@@ -72,7 +70,6 @@ export type BenchmarkField = BenchmarkFieldKeys;
 type DataName = 'traveltimes' | 'headways' | 'dwells' | 'traveltimesByHour';
 
 export interface LineProps {
-  title: string;
   chartId: string;
   location: Location;
   pointField: PointField; // X value
@@ -104,7 +101,6 @@ export interface SingleDayLineProps extends LineProps {
 }
 
 export interface HeadwayHistogramProps {
-  title: string;
   chartId: string;
   data: SingleDayDataPoint[];
   date: string | undefined;

--- a/common/utils/stations.ts
+++ b/common/utils/stations.ts
@@ -104,17 +104,15 @@ export const travelDirection = (from: Station, to: Station): Direction => {
   return from.order < to.order ? 'southbound' : 'northbound';
 };
 
-export const locationDetails = (
+export const getLocationDetails = (
   from: Station | undefined,
-  to: Station | undefined,
-  lineShort: LineShort
+  to: Station | undefined
 ): Location => {
   if (to === undefined || from === undefined) {
     return {
       to: to?.stop_name || 'Loading...',
       from: from?.stop_name || 'Loading...',
       direction: 'southbound',
-      line: lineShort,
     };
   }
 
@@ -122,6 +120,5 @@ export const locationDetails = (
     to: to.stop_name,
     from: from.stop_name,
     direction: travelDirection(from, to),
-    line: lineShort,
   };
 };

--- a/modules/dashboard/LocationTitle.tsx
+++ b/modules/dashboard/LocationTitle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { Location } from '../../common/types/charts';
+import type { Line } from '../../common/types/lines';
+import { lineColorText } from '../../common/styles/general';
+
+interface LocationTitleProps {
+  location: Location; //TODO
+  both: boolean;
+  line?: Line;
+}
+
+export const LocationTitle: React.FC<LocationTitleProps> = ({ location, both, line }) => {
+  if (both) {
+    return (
+      <p className="flex gap-1 text-base">
+        <b className={lineColorText[line ?? 'DEFAULT']}>{location['from']}</b>
+        <span className="text-stone-800"> to </span>
+        <b className={lineColorText[line ?? 'DEFAULT']}>{location['to']}</b>
+      </p>
+    );
+  }
+  return (
+    <p className="flex gap-2 text-base">
+      <b className={lineColorText[line ?? 'DEFAULT']}>{location['from']}</b>
+      <span className="text-stone-800">{location['direction']}</span>
+    </p>
+  );
+};

--- a/modules/dashboard/WidgetTitle.tsx
+++ b/modules/dashboard/WidgetTitle.tsx
@@ -1,13 +1,34 @@
 import React from 'react';
 import classNames from 'classnames';
+import type { Location } from '../../common/types/charts';
+import type { Line } from '../../common/types/lines';
+import { LocationTitle } from './LocationTitle';
 
 interface WidgetTitle {
   title: string;
+  subtitle?: string;
+  location?: Location; //TODO
+  both?: boolean;
+  line?: Line;
 }
-export const WidgetTitle: React.FC<WidgetTitle> = ({ title }) => {
+
+export const WidgetTitle: React.FC<WidgetTitle> = ({
+  title,
+  subtitle,
+  both = false,
+  location,
+  line,
+}) => {
   return (
-    <div className="flex w-full flex-row items-center p-2 text-xl">
-      <h3 className={classNames('font-semibold', 'text-gray-800')}>{title}</h3>
+    <div className="flex w-full flex-row items-baseline justify-between p-2 text-xl">
+      <div className="flex flex-col">
+        <h2 className={classNames('font-semibold', 'text-stone-800')}>{title}</h2>
+        {subtitle && <h2 className={classNames('text-sm italic text-stone-600')}>{subtitle}</h2>}
+      </div>
+      <div className="flex flex-col items-end">
+        {location && line && <LocationTitle location={location} line={line} both={both} />}
+        <p className="text-xs italic text-stone-700">{`Date Placeholder`}</p>
+      </div>
     </div>
   );
 };

--- a/modules/dwells/DwellsDetails.tsx
+++ b/modules/dwells/DwellsDetails.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import dayjs from 'dayjs';
 import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
 import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
-import { getParentStationForStopId, stopIdsForStations } from '../../common/utils/stations';
+import {
+  getParentStationForStopId,
+  getLocationDetails,
+  stopIdsForStations,
+} from '../../common/utils/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
 import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWidgetItem';
@@ -16,9 +20,11 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { SingleChartWrapper } from '../../common/components/charts/SingleChartWrapper';
 import { AggregateChartWrapper } from '../../common/components/charts/AggregateChartWrapper';
 import { PageWrapper } from '../../common/layouts/PageWrapper';
+import { WidgetTitle } from '../dashboard/WidgetTitle';
 
 export const DwellsDetails: React.FC = () => {
   const {
+    line,
     query: { startDate, endDate, to, from },
   } = useDelimitatedRoute();
 
@@ -63,6 +69,13 @@ export const DwellsDetails: React.FC = () => {
         />
       </BasicDataWidgetPair>
       <WidgetDiv>
+        <WidgetTitle
+          title="Dwells"
+          subtitle="Time between trains"
+          location={getLocationDetails(fromStation, toStation)}
+          line={line}
+          both={false}
+        />
         {aggregate ? (
           <AggregateChartWrapper
             query={dwellsAggregate}

--- a/modules/dwells/charts/DwellsAggregateChart.tsx
+++ b/modules/dwells/charts/DwellsAggregateChart.tsx
@@ -20,7 +20,6 @@ export const DwellsAggregateChart: React.FC<DwellsAggregateChartProps> = ({
   fromStation,
 }) => {
   const {
-    lineShort,
     query: { startDate, endDate },
   } = useDelimitatedRoute();
 

--- a/modules/dwells/charts/DwellsAggregateChart.tsx
+++ b/modules/dwells/charts/DwellsAggregateChart.tsx
@@ -5,7 +5,7 @@ import type { AggregateDataResponse } from '../../../common/types/charts';
 import { PointFieldKeys } from '../../../common/types/charts';
 import type { Station } from '../../../common/types/stations';
 import { useDelimitatedRoute } from '../../../common/utils/router';
-import { locationDetails } from '../../../common/utils/stations';
+import { getLocationDetails } from '../../../common/utils/stations';
 
 interface DwellsAggregateChartProps {
   dwells: AggregateDataResponse;
@@ -28,7 +28,6 @@ export const DwellsAggregateChart: React.FC<DwellsAggregateChartProps> = ({
     return (
       <AggregateLineChart
         chartId={'dwells_agg'}
-        title={'Time spent at station (dwells)'}
         data={dwells.by_date?.filter((datapoint) => datapoint.peak === 'all')}
         // This is service date when agg by date. dep_time_from_epoch when agg by hour. Can probably remove this prop.
         pointField={PointFieldKeys.serviceDate}
@@ -38,12 +37,12 @@ export const DwellsAggregateChart: React.FC<DwellsAggregateChartProps> = ({
         startDate={startDate}
         endDate={endDate}
         fillColor={CHART_COLORS.FILL}
-        location={locationDetails(fromStation, toStation, lineShort)}
+        location={getLocationDetails(fromStation, toStation)}
         bothStops={false}
         fname="dwells"
       />
     );
-  }, [dwells.by_date, startDate, endDate, fromStation, toStation, lineShort]);
+  }, [dwells.by_date, startDate, endDate, fromStation, toStation]);
 
   return chart;
 };

--- a/modules/dwells/charts/DwellsSingleChart.tsx
+++ b/modules/dwells/charts/DwellsSingleChart.tsx
@@ -4,7 +4,7 @@ import type { SingleDayDataPoint } from '../../../common/types/charts';
 import { PointFieldKeys, MetricFieldKeys } from '../../../common/types/charts';
 import type { Station } from '../../../common/types/stations';
 import { useDelimitatedRoute } from '../../../common/utils/router';
-import { locationDetails } from '../../../common/utils/stations';
+import { getLocationDetails } from '../../../common/utils/stations';
 
 interface DwellsSingleChartProps {
   dwells: SingleDayDataPoint[];
@@ -21,7 +21,6 @@ export const DwellsSingleChart: React.FC<DwellsSingleChartProps> = ({
 }) => {
   const {
     linePath,
-    lineShort,
     query: { startDate },
   } = useDelimitatedRoute();
 
@@ -29,18 +28,17 @@ export const DwellsSingleChart: React.FC<DwellsSingleChartProps> = ({
     return (
       <SingleDayLineChart
         chartId={`dwells-chart-${linePath}`}
-        title={'Time spent at station (dwells)'}
         data={dwells}
         date={startDate}
         metricField={MetricFieldKeys.dwellTimeSec}
         pointField={PointFieldKeys.arrDt}
-        location={locationDetails(fromStation, toStation, lineShort)}
+        location={getLocationDetails(fromStation, toStation)}
         fname={'dwells'}
         showLegend={false}
         isHomescreen={isHomescreen}
       />
     );
-  }, [dwells, fromStation, linePath, lineShort, startDate, toStation, isHomescreen]);
+  }, [dwells, fromStation, linePath, startDate, toStation, isHomescreen]);
 
   return chart;
 };

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -4,7 +4,11 @@ import React from 'react';
 import dayjs from 'dayjs';
 import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
 import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
-import { getParentStationForStopId, stopIdsForStations } from '../../common/utils/stations';
+import {
+  getLocationDetails,
+  getParentStationForStopId,
+  stopIdsForStations,
+} from '../../common/utils/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { BasicDataWidgetPair } from '../../common/components/widgets/BasicDataWidgetPair';
 import { BasicDataWidgetItem } from '../../common/components/widgets/BasicDataWidgetItem';
@@ -19,10 +23,12 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { SingleChartWrapper } from '../../common/components/charts/SingleChartWrapper';
 import { AggregateChartWrapper } from '../../common/components/charts/AggregateChartWrapper';
 import { PageWrapper } from '../../common/layouts/PageWrapper';
+import { WidgetTitle } from '../dashboard/WidgetTitle';
 import { HeadwaysHistogramWrapper } from './charts/HeadwaysHistogramWrapper';
 
 export function HeadwaysDetails() {
   const {
+    line,
     query: { startDate, endDate, to, from },
   } = useDelimitatedRoute();
 
@@ -53,20 +59,29 @@ export function HeadwaysDetails() {
       <BasicDataWidgetPair>
         <BasicDataWidgetItem
           title="Average Headway"
+          layoutKind="no-delta"
           widgetValue={
-            new TimeWidgetValue(headwaysData ? averageHeadway(headwaysData) : undefined, 1)
+            new TimeWidgetValue(headwaysData ? averageHeadway(headwaysData) : undefined, undefined)
           }
           analysis={`from last ${dayjs().format('ddd')}.`}
         />
         <BasicDataWidgetItem
           title="Longest Headway"
+          layoutKind="no-delta"
           widgetValue={
-            new TimeWidgetValue(headwaysData ? longestHeadway(headwaysData) : undefined, 1)
+            new TimeWidgetValue(headwaysData ? longestHeadway(headwaysData) : undefined, undefined)
           }
           analysis={`from last ${dayjs().format('ddd')}.`}
         />
       </BasicDataWidgetPair>
       <WidgetDiv>
+        <WidgetTitle
+          title="Headways"
+          subtitle="Time between trains"
+          location={getLocationDetails(fromStation, toStation)}
+          line={line}
+        />
+
         {aggregate ? (
           <AggregateChartWrapper
             query={headwaysAggregate}
@@ -84,19 +99,15 @@ export function HeadwaysDetails() {
         )}
       </WidgetDiv>
       {!aggregate && (
-        <>
-          <div className="flex w-full flex-row items-center justify-between text-lg">
-            <h3>Headway Variance</h3>
-          </div>
+        <WidgetDiv>
+          <WidgetTitle title="Headway Variance" />
 
-          <WidgetDiv>
-            <HeadwaysHistogramWrapper
-              headways={headways}
-              fromStation={fromStation}
-              toStation={toStation}
-            />
-          </WidgetDiv>
-        </>
+          <HeadwaysHistogramWrapper
+            headways={headways}
+            fromStation={fromStation}
+            toStation={toStation}
+          />
+        </WidgetDiv>
       )}
       <TerminusNotice toStation={toStation} fromStation={fromStation} />
     </PageWrapper>

--- a/modules/headways/charts/HeadwaysAggregateChart.tsx
+++ b/modules/headways/charts/HeadwaysAggregateChart.tsx
@@ -5,7 +5,7 @@ import type { AggregateDataResponse } from '../../../common/types/charts';
 import { PointFieldKeys } from '../../../common/types/charts';
 import type { Station } from '../../../common/types/stations';
 import { useDelimitatedRoute } from '../../../common/utils/router';
-import { locationDetails } from '../../../common/utils/stations';
+import { getLocationDetails } from '../../../common/utils/stations';
 
 interface HeadwaysAggregateChartProps {
   headways: AggregateDataResponse;
@@ -28,7 +28,6 @@ export const HeadwaysAggregateChart: React.FC<HeadwaysAggregateChartProps> = ({
     return (
       <AggregateLineChart
         chartId={'headways_agg'}
-        title={`Time between ${lineShort !== 'Bus' ? 'trains' : 'bus'} (headways)`}
         data={headways.by_date.filter((datapoint) => datapoint.peak === 'all')}
         // This is service date when agg by date. dep_time_from_epoch when agg by hour. Can probably remove this prop.
         pointField={PointFieldKeys.serviceDate}
@@ -38,12 +37,12 @@ export const HeadwaysAggregateChart: React.FC<HeadwaysAggregateChartProps> = ({
         startDate={startDate}
         endDate={endDate}
         fillColor={CHART_COLORS.FILL}
-        location={locationDetails(fromStation, toStation, lineShort)}
+        location={getLocationDetails(fromStation, toStation)}
         bothStops={false}
         fname="headways"
       />
     );
-  }, [headways.by_date, startDate, endDate, fromStation, toStation, lineShort]);
+  }, [headways.by_date, startDate, endDate, fromStation, toStation]);
 
   return chart;
 };

--- a/modules/headways/charts/HeadwaysAggregateChart.tsx
+++ b/modules/headways/charts/HeadwaysAggregateChart.tsx
@@ -20,7 +20,6 @@ export const HeadwaysAggregateChart: React.FC<HeadwaysAggregateChartProps> = ({
   fromStation,
 }) => {
   const {
-    lineShort,
     query: { startDate, endDate },
   } = useDelimitatedRoute();
 

--- a/modules/headways/charts/HeadwaysHistogram.tsx
+++ b/modules/headways/charts/HeadwaysHistogram.tsx
@@ -2,32 +2,19 @@ import { Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, BarController, BarElement, LinearScale, Title, Tooltip } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import React, { useMemo, useRef } from 'react';
-import dayjs from 'dayjs';
 import ChartjsPluginWatermark from 'chartjs-plugin-watermark';
 import { useDelimitatedRoute } from '../../../common/utils/router';
 import { COLORS, LINE_COLORS } from '../../../common/constants/colors';
-import { drawTitle } from '../../../common/components/charts/Title';
-import { locationDetails } from '../../../common/utils/stations';
 import type { HeadwaysChartProps } from '../../../common/types/charts';
 import { MetricFieldKeys } from '../../../common/types/charts';
 import type { HeadwayPoint } from '../../../common/types/dataPoints';
-import { writeError } from '../../../common/utils/chartError';
 import { useBreakpoint } from '../../../common/hooks/useBreakpoint';
 import { watermarkLayout } from '../../../common/constants/charts';
 
 ChartJS.register(BarController, BarElement, LinearScale, ChartjsPluginWatermark, Title, Tooltip);
 
-export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({
-  headways,
-  toStation,
-  fromStation,
-}) => {
-  const {
-    line,
-    linePath,
-    lineShort,
-    query: { startDate },
-  } = useDelimitatedRoute();
+export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({ headways }) => {
+  const { line, linePath, lineShort } = useDelimitatedRoute();
 
   const ref = useRef();
   const isMobile = !useBreakpoint('md');
@@ -53,116 +40,89 @@ export const HeadwaysHistogram: React.FC<HeadwaysChartProps> = ({
 
   const histogram = useMemo(() => {
     return (
-      <Bar
-        id={`headways-histogram-${linePath}`}
-        ref={ref}
-        height={250}
-        redraw={true}
-        data={{
-          datasets: [
-            {
-              backgroundColor: LINE_COLORS[line ?? 'default'],
-              label: lineShort !== 'Bus' ? 'Trains' : 'Buses',
-              data: dataObject,
-            },
-          ],
-        }}
-        options={{
-          responsive: true,
-          maintainAspectRatio: false,
-          scales: {
-            x: {
-              type: 'linear',
-              offset: false,
-              grid: {
-                offset: false,
-              },
-              ticks: {
-                stepSize: 1,
-                color: COLORS.design.subtitleGrey,
-              },
-              title: {
-                display: true,
-                text: `Minutes`,
-                color: COLORS.design.subtitleGrey,
-              },
-            },
-            y: {
-              title: {
-                display: true,
-                text: lineShort !== 'Bus' ? 'Trains' : 'Buses',
-                color: COLORS.design.subtitleGrey,
-              },
-              ticks: {
-                color: COLORS.design.subtitleGrey,
-              },
-            },
-          },
-          layout: {
-            padding: {
-              top: 25,
-            },
-          },
-          // @ts-expect-error The watermark plugin doesn't have typescript support
-          watermark: watermarkLayout(isMobile),
-          plugins: {
-            tooltip: {
-              mode: 'index',
-              callbacks: {
-                title: (items) => {
-                  if (!items.length) {
-                    return '';
-                  }
-                  const item = items[0];
-                  const { x } = item.parsed;
-                  const min = x - 0.5;
-                  const max = x + 0.5;
-                  return `${min} - ${max} min.`;
+      <div className={'relative flex w-full flex-col pr-2'}>
+        <div className="flex h-60 w-full flex-row">
+          <Bar
+            id={`headways-histogram-${linePath}`}
+            ref={ref}
+            height={250}
+            redraw={true}
+            data={{
+              datasets: [
+                {
+                  backgroundColor: LINE_COLORS[line ?? 'default'],
+                  label: lineShort !== 'Bus' ? 'Trains' : 'Buses',
+                  data: dataObject,
+                },
+              ],
+            }}
+            options={{
+              responsive: true,
+              maintainAspectRatio: false,
+              scales: {
+                x: {
+                  type: 'linear',
+                  offset: false,
+                  grid: {
+                    offset: false,
+                  },
+                  ticks: {
+                    stepSize: 1,
+                    color: COLORS.design.subtitleGrey,
+                  },
+                  title: {
+                    display: true,
+                    text: `Minutes`,
+                    color: COLORS.design.subtitleGrey,
+                  },
+                },
+                y: {
+                  title: {
+                    display: true,
+                    text: lineShort !== 'Bus' ? 'Trains' : 'Buses',
+                    color: COLORS.design.subtitleGrey,
+                  },
+                  ticks: {
+                    color: COLORS.design.subtitleGrey,
+                  },
                 },
               },
-            },
-            legend: {
-              display: false,
-            },
-            title: {
-              // empty title to set font and leave room for drawTitle fn
-              display: true,
-              text: '',
-            },
-          },
-          interaction: {
-            mode: 'nearest',
-            intersect: false,
-          },
-        }}
-        plugins={[
-          {
-            id: 'customTitle',
-            afterDraw: (chart) => {
-              if (startDate === undefined || startDate.length === 0 || headways.length === 0) {
-                writeError(chart);
-              }
-              drawTitle(
-                `Headways by train (${dayjs(startDate).format('M/D/YYYY')})`,
-                locationDetails(fromStation, toStation, lineShort),
-                false,
-                chart
-              );
-            },
-          },
-        ]}
-      />
+              layout: {
+                padding: {
+                  top: 25,
+                },
+              },
+              // @ts-expect-error The watermark plugin doesn't have typescript support
+              watermark: watermarkLayout(isMobile),
+              plugins: {
+                tooltip: {
+                  mode: 'index',
+                  callbacks: {
+                    title: (items) => {
+                      if (!items.length) {
+                        return '';
+                      }
+                      const item = items[0];
+                      const { x } = item.parsed;
+                      const min = x - 0.5;
+                      const max = x + 0.5;
+                      return `${min} - ${max} min.`;
+                    },
+                  },
+                },
+                legend: {
+                  display: false,
+                },
+              },
+              interaction: {
+                mode: 'nearest',
+                intersect: false,
+              },
+            }}
+          />
+        </div>
+      </div>
     );
-  }, [
-    dataObject,
-    fromStation,
-    headways.length,
-    isMobile,
-    line,
-    linePath,
-    lineShort,
-    startDate,
-    toStation,
-  ]);
+  }, [dataObject, isMobile, line, linePath, lineShort]);
   return histogram;
 };

--- a/modules/headways/charts/HeadwaysSingleChart.tsx
+++ b/modules/headways/charts/HeadwaysSingleChart.tsx
@@ -3,7 +3,7 @@ import { SingleDayLineChart } from '../../../common/components/charts/SingleDayL
 import type { HeadwaysChartProps } from '../../../common/types/charts';
 import { BenchmarkFieldKeys, PointFieldKeys, MetricFieldKeys } from '../../../common/types/charts';
 import { useDelimitatedRoute } from '../../../common/utils/router';
-import { locationDetails } from '../../../common/utils/stations';
+import { getLocationDetails } from '../../../common/utils/stations';
 
 export const HeadwaysSingleChart: React.FC<HeadwaysChartProps> = ({
   headways,
@@ -26,13 +26,12 @@ export const HeadwaysSingleChart: React.FC<HeadwaysChartProps> = ({
     return (
       <SingleDayLineChart
         chartId={`headways-chart-${linePath}`}
-        title={`Time between ${lineShort !== 'Bus' ? 'trains' : 'bus'} (headways)`}
         data={headways}
         date={startDate}
         metricField={MetricFieldKeys.headwayTimeSec}
         pointField={PointFieldKeys.currentDepDt}
         benchmarkField={BenchmarkFieldKeys.benchmarkHeadwayTimeSec}
-        location={locationDetails(fromStation, toStation, lineShort)}
+        location={getLocationDetails(fromStation, toStation)}
         fname={'headways'}
         showLegend={showLegend && anyHeadwayBenchmarks}
         isHomescreen={isHomescreen}
@@ -44,7 +43,6 @@ export const HeadwaysSingleChart: React.FC<HeadwaysChartProps> = ({
     startDate,
     fromStation,
     toStation,
-    lineShort,
     showLegend,
     anyHeadwayBenchmarks,
     isHomescreen,

--- a/modules/headways/charts/HeadwaysSingleChart.tsx
+++ b/modules/headways/charts/HeadwaysSingleChart.tsx
@@ -14,7 +14,6 @@ export const HeadwaysSingleChart: React.FC<HeadwaysChartProps> = ({
 }) => {
   const {
     linePath,
-    lineShort,
     query: { startDate },
   } = useDelimitatedRoute();
 

--- a/modules/service/ServiceGraph.tsx
+++ b/modules/service/ServiceGraph.tsx
@@ -215,7 +215,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
               ctx.fillText('No data to display', width / 2, height / 2);
               ctx.restore();
             }
-            if (showTitle) drawSimpleTitle(`Daily round trips`, chart);
+            if (showTitle) drawSimpleTitle(`Daily Round Trips`, chart);
           },
         },
         Annotation,

--- a/modules/slowzones/SlowZonesDetails.tsx
+++ b/modules/slowzones/SlowZonesDetails.tsx
@@ -52,7 +52,7 @@ export function SlowZonesDetails() {
     <PageWrapper pageTitle={'Slow Zones'}>
       <div className="flex flex-col gap-4">
         <WidgetDiv>
-          <WidgetTitle title="Total delays" />
+          <WidgetTitle title="Total Slow Time" />
           <div className="relative flex flex-col">
             {totalSlowTimeReady ? (
               <TotalSlowTimeWrapper

--- a/modules/slowzones/SlowZonesWidget.tsx
+++ b/modules/slowzones/SlowZonesWidget.tsx
@@ -35,6 +35,7 @@ export const SlowZonesWidget: React.FC = () => {
             endDateUTC={endDateUTC}
             line={line}
             lineShort={lineShort}
+            showTitle
           />
         ) : (
           <ChartPlaceHolder query={delayTotals} />

--- a/modules/slowzones/TotalSlowTimeWrapper.tsx
+++ b/modules/slowzones/TotalSlowTimeWrapper.tsx
@@ -15,6 +15,7 @@ interface TotalSlowTimeWrapperProps {
   endDateUTC: dayjs.Dayjs;
   line: Line;
   lineShort: LineShort;
+  showTitle?: boolean;
 }
 
 export const TotalSlowTimeWrapper: React.FC<TotalSlowTimeWrapperProps> = ({
@@ -23,6 +24,7 @@ export const TotalSlowTimeWrapper: React.FC<TotalSlowTimeWrapperProps> = ({
   endDateUTC,
   line,
   lineShort,
+  showTitle = false,
 }) => {
   const filteredDelayTotals = useFilteredDelayTotals(data, startDateUTC, endDateUTC);
   const delayDelta = getSlowZoneDelayDelta(filteredDelayTotals, lineShort);
@@ -47,6 +49,7 @@ export const TotalSlowTimeWrapper: React.FC<TotalSlowTimeWrapperProps> = ({
           endDateUTC={endDateUTC}
           line={line}
           lineShort={lineShort}
+          showTitle={showTitle}
         />
       </div>
     </>

--- a/modules/slowzones/charts/TotalSlowTime.tsx
+++ b/modules/slowzones/charts/TotalSlowTime.tsx
@@ -22,6 +22,7 @@ interface TotalSlowTimeProps {
   endDateUTC: dayjs.Dayjs;
   lineShort: LineShort;
   line: TrainLine;
+  showTitle: boolean;
 }
 Chart.register(...registerables, ChartjsPluginWatermark);
 
@@ -31,6 +32,7 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({
   endDateUTC,
   lineShort,
   line,
+  showTitle,
 }) => {
   const ref = useRef();
   const isMobile = !useBreakpoint('md');
@@ -112,7 +114,7 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({
           },
           title: {
             // empty title to set font and leave room for drawTitle fn
-            display: true,
+            display: showTitle,
             text: '',
           },
           legend: {
@@ -124,7 +126,7 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({
         {
           id: 'customTitle',
           afterDraw: (chart) => {
-            drawSimpleTitle('Total Slow Time', chart);
+            if (showTitle) drawSimpleTitle(`Total Slow Time`, chart);
           },
         },
       ]}

--- a/modules/traveltimes/TravelTimesDetails.tsx
+++ b/modules/traveltimes/TravelTimesDetails.tsx
@@ -4,7 +4,11 @@ import React from 'react';
 import dayjs from 'dayjs';
 import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/types/api';
 import { AggregateAPIParams, SingleDayAPIParams } from '../../common/types/api';
-import { getParentStationForStopId, stopIdsForStations } from '../../common/utils/stations';
+import {
+  getLocationDetails,
+  getParentStationForStopId,
+  stopIdsForStations,
+} from '../../common/utils/stations';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { averageTravelTime } from '../../common/utils/traveltimes';
 import { TimeWidgetValue } from '../../common/types/basicWidgets';
@@ -20,15 +24,18 @@ import { SingleChartWrapper } from '../../common/components/charts/SingleChartWr
 import { AggregateChartWrapper } from '../../common/components/charts/AggregateChartWrapper';
 import { PageWrapper } from '../../common/layouts/PageWrapper';
 import { ButtonGroup } from '../../common/components/general/ButtonGroup';
+import { WidgetTitle } from '../dashboard/WidgetTitle';
 
 export function TravelTimesDetails() {
   const {
+    line,
     query: { startDate, endDate, to, from },
   } = useDelimitatedRoute();
 
   const fromStation = from ? getParentStationForStopId(from) : undefined;
   const toStation = to ? getParentStationForStopId(to) : undefined;
   const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
+  const location = getLocationDetails(fromStation, toStation);
 
   const aggregate = Boolean(startDate && endDate);
   const enabled = Boolean(fromStopIds && toStopIds && startDate);
@@ -70,6 +77,7 @@ export function TravelTimesDetails() {
         />
       </BasicDataWidgetPair>
       <WidgetDiv>
+        <WidgetTitle title="Travel Times" location={location} line={line} both />
         {aggregate ? (
           <AggregateChartWrapper
             query={travelTimesAggregate}
@@ -89,6 +97,7 @@ export function TravelTimesDetails() {
       </WidgetDiv>
       {aggregate && (
         <WidgetDiv className="flex flex-col justify-center">
+          <WidgetTitle title="Travel Times By Hour" location={location} line={line} both />
           <AggregateChartWrapper
             query={travelTimesAggregate}
             toStation={toStation}

--- a/modules/traveltimes/charts/TravelTimesAggregateChart.tsx
+++ b/modules/traveltimes/charts/TravelTimesAggregateChart.tsx
@@ -5,7 +5,7 @@ import type { AggregateDataResponse, TravelTimesUnit } from '../../../common/typ
 import { PointFieldKeys } from '../../../common/types/charts';
 import type { Station } from '../../../common/types/stations';
 import { useDelimitatedRoute } from '../../../common/utils/router';
-import { locationDetails } from '../../../common/utils/stations';
+import { getLocationDetails } from '../../../common/utils/stations';
 
 interface TravelTimesAggregateChartProps {
   traveltimes: AggregateDataResponse;
@@ -23,7 +23,6 @@ export const TravelTimesAggregateChart: React.FC<TravelTimesAggregateChartProps>
   peakTime = true,
 }) => {
   const {
-    lineShort,
     query: { startDate, endDate },
   } = useDelimitatedRoute();
 
@@ -33,15 +32,10 @@ export const TravelTimesAggregateChart: React.FC<TravelTimesAggregateChartProps>
     ? traveltimes.by_date.filter((datapoint) => datapoint.peak === 'all')
     : traveltimes.by_time.filter((datapoint) => datapoint.is_peak_day === peakTime);
 
-  const title = timeUnitByDate
-    ? 'Travel times'
-    : `Travel times by hour (${peakTime ? 'Weekday' : 'Weekend/Holiday'})`;
-
   const chart = useMemo(() => {
     return (
       <AggregateLineChart
         chartId={'travel_times_agg'}
-        title={title}
         data={traveltimesData}
         // This is service date when agg by date. dep_time_from_epoch when agg by hour
         pointField={timeUnitByDate ? PointFieldKeys.serviceDate : PointFieldKeys.depTimeFromEpoch}
@@ -52,21 +46,12 @@ export const TravelTimesAggregateChart: React.FC<TravelTimesAggregateChartProps>
         startDate={startDate}
         endDate={endDate}
         fillColor={timeUnitByDate ? CHART_COLORS.FILL : CHART_COLORS.FILL_HOURLY}
-        location={locationDetails(fromStation, toStation, lineShort)}
+        location={getLocationDetails(fromStation, toStation)}
         bothStops={true}
         fname="traveltimes"
       />
     );
-  }, [
-    title,
-    traveltimesData,
-    timeUnitByDate,
-    startDate,
-    endDate,
-    fromStation,
-    toStation,
-    lineShort,
-  ]);
+  }, [traveltimesData, timeUnitByDate, startDate, endDate, fromStation, toStation]);
 
   return chart;
 };

--- a/modules/traveltimes/charts/TravelTimesSingleChart.tsx
+++ b/modules/traveltimes/charts/TravelTimesSingleChart.tsx
@@ -4,7 +4,7 @@ import type { SingleDayDataPoint } from '../../../common/types/charts';
 import { BenchmarkFieldKeys, PointFieldKeys, MetricFieldKeys } from '../../../common/types/charts';
 import type { Station } from '../../../common/types/stations';
 import { useDelimitatedRoute } from '../../../common/utils/router';
-import { locationDetails } from '../../../common/utils/stations';
+import { getLocationDetails } from '../../../common/utils/stations';
 
 interface TravelTimesSingleChartProps {
   traveltimes: SingleDayDataPoint[];
@@ -35,14 +35,13 @@ export const TravelTimesSingleChart: React.FC<TravelTimesSingleChartProps> = ({
     return (
       <SingleDayLineChart
         chartId={`traveltimes-chart-${linePath}`}
-        title={'Travel Times'}
         data={traveltimes}
         date={startDate}
         metricField={MetricFieldKeys.travelTimeSec}
         pointField={PointFieldKeys.depDt}
         benchmarkField={BenchmarkFieldKeys.benchmarkTravelTimeSec}
         bothStops={true}
-        location={locationDetails(fromStation, toStation, lineShort)}
+        location={getLocationDetails(fromStation, toStation)}
         fname={'traveltimes'}
         showLegend={showLegend && anyTravelBenchmarks}
         isHomescreen={isHomescreen}
@@ -54,7 +53,6 @@ export const TravelTimesSingleChart: React.FC<TravelTimesSingleChartProps> = ({
     startDate,
     fromStation,
     toStation,
-    lineShort,
     showLegend,
     anyTravelBenchmarks,
     isHomescreen,

--- a/modules/traveltimes/charts/TravelTimesSingleChart.tsx
+++ b/modules/traveltimes/charts/TravelTimesSingleChart.tsx
@@ -23,7 +23,6 @@ export const TravelTimesSingleChart: React.FC<TravelTimesSingleChartProps> = ({
 }) => {
   const {
     linePath,
-    lineShort,
     query: { startDate },
   } = useDelimitatedRoute();
 

--- a/modules/tripexplorer/BusTripGraphs.tsx
+++ b/modules/tripexplorer/BusTripGraphs.tsx
@@ -5,6 +5,9 @@ import type { AggregateAPIOptions, SingleDayAPIOptions } from '../../common/type
 import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { SingleChartWrapper } from '../../common/components/charts/SingleChartWrapper';
 import { AggregateChartWrapper } from '../../common/components/charts/AggregateChartWrapper';
+import { WidgetTitle } from '../dashboard/WidgetTitle';
+import { getLocationDetails } from '../../common/utils/stations';
+import type { Line } from '../../common/types/lines';
 
 interface BusTripGraphsProps {
   fromStation: Station;
@@ -12,6 +15,7 @@ interface BusTripGraphsProps {
   parameters: AggregateAPIOptions | SingleDayAPIOptions; // TODO
   aggregate: boolean;
   enabled: boolean;
+  line: Line | undefined;
 }
 
 export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
@@ -20,6 +24,7 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
   parameters,
   aggregate,
   enabled,
+  line,
 }) => {
   const { traveltimes, headways } = useTripExplorerQueries(
     'bus',
@@ -28,12 +33,15 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
     aggregate,
     enabled
   );
+  const location = getLocationDetails(fromStation, toStation);
 
   return (
     <div className="flex flex-col gap-4">
       {aggregate ? (
         <>
           <WidgetDiv>
+            <WidgetTitle title="Travel Times" location={location} line={line} />
+
             <AggregateChartWrapper
               query={traveltimes}
               toStation={toStation}
@@ -42,6 +50,12 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
             />
           </WidgetDiv>
           <WidgetDiv>
+            <WidgetTitle
+              title="Headways"
+              subtitle="Time between buses"
+              location={location}
+              line={line}
+            />
             <AggregateChartWrapper
               query={headways}
               toStation={toStation}
@@ -53,6 +67,7 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
       ) : (
         <>
           <WidgetDiv>
+            <WidgetTitle title="Travel Times" location={location} line={line} />
             <SingleChartWrapper
               query={traveltimes}
               toStation={toStation}
@@ -61,6 +76,12 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
             />
           </WidgetDiv>
           <WidgetDiv>
+            <WidgetTitle
+              title="Headways"
+              subtitle="Time between buses"
+              location={location}
+              line={line}
+            />
             <SingleChartWrapper
               query={headways}
               toStation={toStation}

--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -6,6 +6,9 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { SingleChartWrapper } from '../../common/components/charts/SingleChartWrapper';
 import { AggregateChartWrapper } from '../../common/components/charts/AggregateChartWrapper';
 import { ButtonGroup } from '../../common/components/general/ButtonGroup';
+import { WidgetTitle } from '../dashboard/WidgetTitle';
+import { getLocationDetails } from '../../common/utils/stations';
+import type { Line } from '../../common/types/lines';
 
 interface SubwayTripGraphsProps {
   fromStation: Station;
@@ -13,6 +16,7 @@ interface SubwayTripGraphsProps {
   parameters: SingleDayAPIOptions | AggregateAPIOptions; // TODO
   aggregate: boolean;
   enabled: boolean;
+  line: Line | undefined;
 }
 
 export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
@@ -21,6 +25,7 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
   parameters,
   aggregate,
   enabled,
+  line,
 }) => {
   const [peakTime, setPeakTime] = React.useState<'weekday' | 'weekend'>('weekday');
 
@@ -31,12 +36,14 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
     aggregate,
     enabled
   );
+  const location = getLocationDetails(fromStation, toStation);
 
   return (
     <div className="flex flex-col gap-4">
       {aggregate ? (
         <>
           <WidgetDiv>
+            <WidgetTitle title="Travel Times" location={location} line={line} both />
             <AggregateChartWrapper
               query={traveltimes}
               toStation={toStation}
@@ -46,6 +53,13 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
             />
           </WidgetDiv>
           <WidgetDiv>
+            <WidgetTitle
+              title="Headways"
+              subtitle="Time between trains"
+              location={location}
+              line={line}
+            />
+
             <AggregateChartWrapper
               query={headways}
               toStation={toStation}
@@ -54,6 +68,13 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
             />
           </WidgetDiv>
           <WidgetDiv>
+            <WidgetTitle
+              title="Dwells"
+              subtitle="Time spent at station"
+              location={location}
+              line={line}
+            />
+
             <AggregateChartWrapper
               query={dwells}
               toStation={toStation}
@@ -62,6 +83,7 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
             />
           </WidgetDiv>
           <WidgetDiv className="flex flex-col justify-center">
+            <WidgetTitle title="Travel Times By Hour" location={location} line={line} both />
             <AggregateChartWrapper
               query={traveltimes}
               toStation={toStation}
@@ -86,6 +108,7 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
       ) : (
         <>
           <WidgetDiv>
+            <WidgetTitle title="Travel Times" location={location} line={line} both />
             <SingleChartWrapper
               query={traveltimes}
               toStation={toStation}
@@ -95,6 +118,12 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
           </WidgetDiv>
 
           <WidgetDiv>
+            <WidgetTitle
+              title="Headways"
+              subtitle="Time between trains"
+              location={location}
+              line={line}
+            />
             <SingleChartWrapper
               query={headways}
               toStation={toStation}
@@ -103,6 +132,12 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
             />
           </WidgetDiv>
           <WidgetDiv>
+            <WidgetTitle
+              title="Dwells"
+              subtitle="Time spent at station"
+              location={location}
+              line={line}
+            />
             <SingleChartWrapper
               query={dwells}
               toStation={toStation}

--- a/modules/tripexplorer/TripGraphs.tsx
+++ b/modules/tripexplorer/TripGraphs.tsx
@@ -16,6 +16,7 @@ export const TripGraphs: React.FC<TripGraphsProps> = ({ fromStation, toStation }
   const {
     query: { startDate, endDate },
     tab,
+    line,
   } = useDelimitatedRoute();
 
   const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
@@ -43,6 +44,7 @@ export const TripGraphs: React.FC<TripGraphsProps> = ({ fromStation, toStation }
         parameters={parameters}
         aggregate={aggregate}
         enabled={enabled}
+        line={line}
       />
     );
   return (
@@ -52,6 +54,7 @@ export const TripGraphs: React.FC<TripGraphsProps> = ({ fromStation, toStation }
       parameters={parameters}
       aggregate={aggregate}
       enabled={enabled}
+      line={line}
     />
   );
 };


### PR DESCRIPTION
## Motivation

Our graph titles were a bit scattered. This consolidates the style, adds a subtitle, and moves the location information to the widget rather than the individual graph.

The rationale to move the location information is that we want to put the widgets associated with a graph inside the same widget. So the location should look like it applies to the whole widget, rather than just the graph. It is set up to do ticket #408 

We are still using the old title style on the `Lines` page because the widget title is not always the same as the graph title.

## Changes
**Before**
![Screen Shot 2023-05-15 at 11 28 18 AM](https://github.com/transitmatters/t-performance-dash/assets/46229349/fa84baef-1547-47ad-a819-280fa8497927)

**After**
![Screen Shot 2023-05-15 at 11 27 43 AM](https://github.com/transitmatters/t-performance-dash/assets/46229349/b4620579-3ba5-4ba2-896f-c36cc9f7b35b)

Subtitles
![Screen Shot 2023-05-15 at 11 28 44 AM](https://github.com/transitmatters/t-performance-dash/assets/46229349/d95f1dd8-b263-4aed-982e-5b551a6b1b2f)


## Testing Instructions
Click around 😄 