### PR TITLE
Shrink Legend

### DIFF
--- a/common/components/charts/Legend.tsx
+++ b/common/components/charts/Legend.tsx
@@ -9,9 +9,9 @@ export const Legend: React.FC = () => {
     >
       <div className="col-span-2 flex flex-row items-baseline gap-2 pb-1 lg:pb-0">
         <p>
-          Compare to (
-          <span className="top-[1px] inline-block h-2.5 w-2.5 items-center border-t-2 border-[#bbb] bg-[#ddd]"></span>{' '}
-          MBTA benchmark):
+          Compare to{' '}
+          <span className="top-[1px] inline-block h-2.5 w-2.5 items-center border-t-2 border-[#bbb] bg-[#ddd] shadow-sm"></span>{' '}
+          MBTA benchmark:
         </p>
       </div>
       <p>

--- a/common/components/charts/Legend.tsx
+++ b/common/components/charts/Legend.tsx
@@ -16,7 +16,7 @@ export const Legend: React.FC = () => {
       </div>
       <p>
         <span className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#57945B] bg-[#64b96a]"></span>
-        {'Below 125%'}
+        {'On time'}
       </p>
       <p>
         <span className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#D9D31E] bg-[#f5ed00]"></span>

--- a/common/components/charts/Legend.tsx
+++ b/common/components/charts/Legend.tsx
@@ -4,32 +4,35 @@ export const Legend: React.FC = () => {
   return (
     <div
       className={
-        'grid w-full grid-cols-2 items-baseline gap-2 p-1 text-left text-xs sm:flex sm:flex-row sm:gap-4'
+        'grid w-full grid-cols-2 items-baseline p-1 text-left text-xs lg:flex lg:flex-row lg:gap-4'
       }
     >
+      <div className="col-span-2 flex flex-row items-baseline gap-2 pb-1 lg:pb-0">
+        <p>
+          Compare to (
+          <span className="top-[1px] inline-block h-2.5 w-2.5 items-center border-t-2 border-[#bbb] bg-[#ddd]"></span>{' '}
+          MBTA benchmark):
+        </p>
+      </div>
       <p>
         <span className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#57945B] bg-[#64b96a]"></span>
-        {'On time'}
+        {'Below 125%'}
       </p>
       <p>
         <span className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#D9D31E] bg-[#f5ed00]"></span>
-        {'25%+ over Benchmark'}
+        {'25%+ above'}
       </p>
       <p>
         <span
           className={`mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#A1384A] bg-[#c33149]`}
         ></span>{' '}
-        {'50%+ over Benchmark'}
+        {'50%+ above'}
       </p>
       <p>
         <span
           className={`mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#925396] bg-[#bb5cc1]`}
         ></span>{' '}
-        {'100%+ over Benchmark'}
-      </p>
-      <p>
-        <span className="mr-1 inline-block h-2.5 w-2.5 items-center border-t-2 border-[#bbb] bg-[#ddd] align-middle"></span>{' '}
-        MBTA Benchmark
+        {'100%+ above'}
       </p>
     </div>
   );
@@ -37,7 +40,7 @@ export const Legend: React.FC = () => {
 
 export const LegendLongTerm: React.FC = () => {
   return (
-    <div className="grid w-full grid-cols-2  items-baseline gap-2 p-1 text-left text-xs sm:flex sm:flex-row sm:gap-4">
+    <div className="flex w-full flex-row items-baseline gap-2 p-1 text-left text-xs sm:gap-4">
       <p>
         <span className={'mr-1 inline-block h-2.5 w-2.5 rounded-full bg-[#000]'}></span> Median
       </p>


### PR DESCRIPTION
## Motivation

The legend was taking up a bit too much space on mobile. We're trying to pack a lot in, so every pixel counts. Also, I think it looked a bit scattered.

## Changes
Before / After
![Screen Shot 2023-05-16 at 4 47 25 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/d627f603-9447-4d86-964d-5f3b800ec395)


## Testing Instructions

Look at various screen sizes
