### PR TITLE
ci: added optional check for conventional commits

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,13 @@
+name: commit
+
+on:
+- pull_request_target
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Check if pull request commits are conventional
+        uses: webiny/action-conventional-commits@v1.1.0


### PR DESCRIPTION
## Motivation

This PR adds an action for conventional commits, but it will not be required as a prerequisite for merging

## Changes

Adds new action, will begin running against Pull Requests after merge

## Testing Instructions

Tested already with the Slow Zone Bot
