### PR TITLE
V4/delta widget

### DIFF
--- a/common/components/widgets/internal/BasicWidgetDataLayout.tsx
+++ b/common/components/widgets/internal/BasicWidgetDataLayout.tsx
@@ -13,6 +13,7 @@ export type BasicWidgetDataLayoutProps = {
   widgetValue: WidgetValueInterface;
   sentimentDirection?: SentimentDirection;
   layoutKind?: LayoutKind;
+  isLarge?: boolean;
 };
 
 export const BasicWidgetDataLayout: React.FC<BasicWidgetDataLayoutProps> = ({
@@ -21,26 +22,30 @@ export const BasicWidgetDataLayout: React.FC<BasicWidgetDataLayoutProps> = ({
   widgetValue,
   layoutKind = 'total-and-delta',
   sentimentDirection = 'negativeOnIncrease',
+  isLarge = true,
 }) => {
-  const getPrimaryValue = () => {
-    const useDelta = layoutKind === 'delta-and-percent-change';
-    if (useDelta) {
-      return widgetValue.getFormattedDelta();
-    }
-    return widgetValue.getFormattedValue();
-  };
-
   return (
     <>
-      <div className={classNames('relative flex flex-1 bg-white')}>
+      <div className={classNames('relative flex')}>
         {widgetValue.value === undefined && <LoadingSpinner isWidget />}
         <div className={classNames('flex flex-col items-start p-2')}>
-          <p className={classNames('text-base text-gray-500')}>{title}</p>
+          <p className={classNames('text-base text-gray-500', isLarge ? 'text-base' : 'text-sm')}>
+            {title}
+          </p>
           <div className="flex flex-row items-baseline gap-x-1">
-            <p className={classNames('text-3xl font-semibold text-gray-900 ')}>
-              {getPrimaryValue()}
+            <p
+              className={classNames(
+                'font-semibold text-gray-900',
+                isLarge ? 'text-2xl' : 'text-xl'
+              )}
+            >
+              {widgetValue.getFormattedValue()}
             </p>
-            <p className="text-base text-design-subtitleGrey">{widgetValue.getUnits()}</p>
+            <p
+              className={classNames(isLarge ? 'text-base' : 'text-sm', 'text-design-subtitleGrey')}
+            >
+              {widgetValue.getUnits()}
+            </p>
           </div>
           <div className="mt-1 flex flex-row items-baseline gap-x-1">
             {layoutKind !== 'no-delta' && (

--- a/common/types/basicWidgets.ts
+++ b/common/types/basicWidgets.ts
@@ -19,7 +19,7 @@ class BaseWidgetValue {
   delta?: number | undefined;
   percentChange?: number | undefined;
 
-  constructor(value: number | undefined, delta: number | undefined) {
+  constructor(value: number | undefined, delta?: number | undefined) {
     this.value = value;
     this.delta = delta;
     this.percentChange =
@@ -30,8 +30,24 @@ class BaseWidgetValue {
 
   getFormattedPercentChange() {
     if (typeof this.percentChange === 'undefined') return '...';
-    const sign = this.percentChange >= 0 ? '+' : '-';
+    const sign = this.percentChange >= 0 ? '+' : '';
     return `${sign}${Math.floor(this.percentChange)}%`;
+  }
+}
+
+export class DeltaTimeWidgetValue extends BaseWidgetValue implements WidgetValueInterface {
+  getUnits() {
+    if (this.delta === undefined) return '...';
+    return getTimeUnit(this.delta);
+  }
+  getFormattedValue() {
+    if (this.delta === undefined) return '...';
+    const formattedValue = getFormattedTimeValue(this.delta);
+    return `${this.delta > 0 ? '+' : '-'}${formattedValue}`;
+  }
+  getFormattedDelta() {
+    new Error('DeltaWidgets should use `getFormattedValue`');
+    return 'invalid';
   }
 }
 
@@ -43,8 +59,8 @@ export class TimeWidgetValue extends BaseWidgetValue implements WidgetValueInter
   }
 
   getFormattedValue() {
+    if (this.value === undefined) return '...';
     const formattedValue = getFormattedTimeValue(this.value);
-    if (formattedValue === undefined) return '...';
     return formattedValue;
   }
 

--- a/common/utils/time.ts
+++ b/common/utils/time.ts
@@ -60,8 +60,7 @@ export const getTimeUnit = (value: number) => {
   }
 };
 
-export const getFormattedTimeValue = (value: number | undefined) => {
-  if (value === undefined) return undefined;
+export const getFormattedTimeValue = (value: number) => {
   const absValue = Math.abs(value);
   switch (true) {
     case absValue < 100:

--- a/modules/slowzones/map/SlowZonesTooltip.tsx
+++ b/modules/slowzones/map/SlowZonesTooltip.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { getParentStationForStopId } from '../../../common/utils/stations';
 
 import { BasicWidgetDataLayout } from '../../../common/components/widgets/internal/BasicWidgetDataLayout';
-import { TimeWidgetValue } from '../../../common/types/basicWidgets';
+import { DeltaTimeWidgetValue } from '../../../common/types/basicWidgets';
 import type { SlowZoneResponse, SpeedRestriction } from '../../../common/types/dataPoints';
 import { prettyDate } from '../../../common/utils/date';
 
@@ -97,7 +97,9 @@ export const SlowZonesTooltip: React.FC<SlowZonesTooltipProps> = (props) => {
       return (
         <div className={styles.direction}>
           <BasicWidgetDataLayout
-            widgetValue={new TimeWidgetValue(slowZone.delay + slowZone.baseline, slowZone.delay)}
+            widgetValue={
+              new DeltaTimeWidgetValue(slowZone.delay + slowZone.baseline, slowZone.delay)
+            }
             key={`${slowZone.fr_id}${slowZone.to_id}`}
             title={
               <div className={styles.directionTitle}>


### PR DESCRIPTION
## Motivation

1. Upcoming Widget PR needs this.
2. Fixes #561 
3. Improves UX for slow zones map

## Changes

Shrink widget text slightly

Properly use `sec`/`min` labels. Uses the same logic as elsewhere: sub 100 seconds = `sec`, sub 90 min = `min`, anything large =`hrs`

Add a `DeltaTimeWidget` to our widgets classes.

In this screenshot you can see we use seconds instead of minutes for the value below 90. Thee values are different because I am comparing local to beta URL which is out of date.

![Screen Shot 2023-05-17 at 11 20 35 AM](https://github.com/transitmatters/t-performance-dash/assets/46229349/1bf7a61c-241a-42f4-a62e-e0c9590210c5)

## Testing Instructions

Look at all the slow zone tooltips