### PR TITLE
Fix chart flicker

### DIFF
--- a/modules/traveltimes/charts/TravelTimesAggregateChart.tsx
+++ b/modules/traveltimes/charts/TravelTimesAggregateChart.tsx
@@ -27,20 +27,19 @@ export const TravelTimesAggregateChart: React.FC<TravelTimesAggregateChartProps>
     query: { startDate, endDate },
   } = useDelimitatedRoute();
 
-  const timeUnitByDate = timeUnit === 'by_date';
-
-  const traveltimesData = timeUnitByDate
-    ? traveltimes.by_date.filter((datapoint) => datapoint.peak === 'all')
-    : traveltimes.by_time.filter((datapoint) => datapoint.is_peak_day === peakTime);
-
-  const title = timeUnitByDate
-    ? 'Travel times'
-    : `Travel times by hour (${peakTime ? 'Weekday' : 'Weekend/Holiday'})`;
-
   const chart = useMemo(() => {
+    const timeUnitByDate = timeUnit === 'by_date';
+
+    const title = timeUnitByDate
+      ? 'Travel times'
+      : `Travel times by hour (${peakTime ? 'Weekday' : 'Weekend/Holiday'})`;
+
+    const traveltimesData = timeUnitByDate
+      ? traveltimes.by_date.filter((datapoint) => datapoint.peak === 'all')
+      : traveltimes.by_time.filter((datapoint) => datapoint.is_peak_day === peakTime);
     return (
       <AggregateLineChart
-        chartId={'travel_times_agg'}
+        chartId={`travel_times_agg_${timeUnitByDate ? 'by_date' : 'by_time'}`}
         title={title}
         data={traveltimesData}
         // This is service date when agg by date. dep_time_from_epoch when agg by hour
@@ -57,16 +56,7 @@ export const TravelTimesAggregateChart: React.FC<TravelTimesAggregateChartProps>
         fname="traveltimes"
       />
     );
-  }, [
-    title,
-    traveltimesData,
-    timeUnitByDate,
-    startDate,
-    endDate,
-    fromStation,
-    toStation,
-    lineShort,
-  ]);
+  }, [timeUnit, peakTime, traveltimes, startDate, endDate, fromStation, toStation, lineShort]);
 
   return chart;
 };


### PR DESCRIPTION
## Motivation

Our travel times agg charts were rerendering repeatedly, causing a flicker effect.

## Changes

Fix the bug by moving data transformation into the `useMemo` call.

Also moved a couple other things inside the `useMemo` to reduce the dep array.

Lastely, updated the `id` so it is not the same for tt by date and tt by hour charts.

## Testing Instructions

Go to aggregate trips page and adjust the date parameters repeatedly (take a few seconds between changing them). Do this on current V4 beta URL and this branch. This branch will not flicker.