### PR TITLE
Add dates to widget titles

### DIFF
--- a/common/state/utils/dashboardUtils.ts
+++ b/common/state/utils/dashboardUtils.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import type { OverviewDatePresetKey } from '../../constants/dates';
+import { PRETTY_DATE_FORMAT, RANGE_PRESETS } from '../../constants/dates';
 import type { Section } from '../../constants/pages';
 import type { QueryParams } from '../../types/router';
 import { getParams } from '../../utils/router';
@@ -28,4 +31,25 @@ export const getDashboardConfig = (section: Section, dashboardConfig: DashboardC
   if (section === 'overview') {
     return dashboardConfig.overviewPreset;
   }
+};
+
+export const getSelectedDates = (dateConfig: {
+  startDate?: string;
+  endDate?: string;
+  view?: OverviewDatePresetKey;
+}) => {
+  const { startDate, endDate, view } = dateConfig;
+  const startDateDayjs = startDate ? dayjs(startDate) : undefined;
+  const endDateDayjs = endDate ? dayjs(endDate) : undefined;
+  const viewInput = view ? RANGE_PRESETS[view]?.input : undefined;
+  if (viewInput)
+    return `${dayjs(viewInput.startDate).format(PRETTY_DATE_FORMAT)} - ${dayjs(
+      viewInput.endDate
+    ).format(PRETTY_DATE_FORMAT)}`;
+  if (startDateDayjs && endDateDayjs)
+    return `${startDateDayjs.format(PRETTY_DATE_FORMAT)} - ${endDateDayjs.format(
+      PRETTY_DATE_FORMAT
+    )}`;
+  if (startDateDayjs) return startDateDayjs.format(PRETTY_DATE_FORMAT);
+  return undefined;
 };

--- a/modules/dashboard/HomescreenWidgetTitle.tsx
+++ b/modules/dashboard/HomescreenWidgetTitle.tsx
@@ -8,6 +8,7 @@ import { LINE_COLORS } from '../../common/constants/colors';
 import type { Page } from '../../common/constants/pages';
 import { ALL_PAGES } from '../../common/constants/pages';
 import { useDashboardConfig } from '../../common/state/dashboardConfig';
+import { getSelectedDates } from '../../common/state/utils/dashboardUtils';
 
 interface HomescreenWidgetTitle {
   title: string;
@@ -18,6 +19,11 @@ export const HomescreenWidgetTitle: React.FC<HomescreenWidgetTitle> = ({ title, 
   const handlePageNavigation = useHandlePageNavigation();
   const dashboardConfig = useDashboardConfig();
   const href = getHref(dashboardConfig, ALL_PAGES[tab], page, query, linePath);
+  const date = getSelectedDates({
+    startDate: query.startDate,
+    endDate: query.endDate,
+    view: query.view,
+  });
   return (
     <div className="flex w-full items-baseline justify-between p-2">
       <Link onClick={() => handlePageNavigation(ALL_PAGES[tab])} href={href}>
@@ -33,7 +39,7 @@ export const HomescreenWidgetTitle: React.FC<HomescreenWidgetTitle> = ({ title, 
           <ExploreArrow fill={LINE_COLORS[line ?? 'default']} className="h-4 w-auto pl-2" />
         </div>
       </Link>
-      <p className="text-xs italic text-stone-700">{`Date Placeholder`}</p>
+      <p className="text-xs italic text-stone-700">{date}</p>
     </div>
   );
 };

--- a/modules/dashboard/WidgetTitle.tsx
+++ b/modules/dashboard/WidgetTitle.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
-import classNames from 'classnames';
+import { useDelimitatedRoute } from '../../common/utils/router';
+import { getSelectedDates } from '../../common/state/utils/dashboardUtils';
 
 interface WidgetTitle {
   title: string;
 }
 export const WidgetTitle: React.FC<WidgetTitle> = ({ title }) => {
+  const { query } = useDelimitatedRoute();
+  const date = getSelectedDates({
+    startDate: query.startDate,
+    endDate: query.endDate,
+    view: query.view,
+  });
+
   return (
-    <div className="flex w-full flex-row items-center p-2 text-xl">
-      <h3 className={classNames('font-semibold', 'text-gray-800')}>{title}</h3>
+    <div className="flex w-full items-baseline justify-between p-2">
+      <h3 className={'font-semibold text-stone-800'}>{title}</h3>
+      <p className="text-xs italic text-stone-700">{date}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Motivation

We want dates on every graph for screenshotting purposes.
Closes #545 

## Changes
![Screen Shot 2023-05-18 at 7 51 36 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/c0b5e03f-6ccb-4abe-9b15-d435be99bb25)

## Testing Instructions

