### PR TITLE
Add logic for system tab

### DIFF
--- a/common/constants/pages.ts
+++ b/common/constants/pages.ts
@@ -16,6 +16,7 @@ import type { Line } from '../types/lines';
 export type Page = keyof typeof PAGES;
 
 export enum PAGES {
+  landing = 'landing',
   today = 'today',
   overview = 'overview',
   speed = 'speed',
@@ -29,7 +30,7 @@ export enum PAGES {
   tripDwells = 'tripDwells',
 }
 
-export type Section = 'today' | 'line' | 'overview' | 'trips' | 'system';
+export type Section = 'landing' | 'today' | 'line' | 'overview' | 'trips' | 'system';
 export type SectionTitle = 'Today' | 'Line' | 'Overview' | 'Trips' | 'System';
 
 export type PageMetadata = {
@@ -49,6 +50,14 @@ export type PageMap = {
 };
 
 export const ALL_PAGES: PageMap = {
+  landing: {
+    key: 'landing',
+    path: '/',
+    name: 'Home',
+    lines: [],
+    icon: faHouse,
+    section: 'landing',
+  },
   today: {
     key: 'today',
     path: '/',
@@ -188,4 +197,12 @@ export const SUB_PAGES_MAP = {
   },
 };
 
-export const SYSTEM_PAGES: PageMetadata[] = [ALL_PAGES.systemSlowzones];
+export const SYSTEM_PAGES_MAP = {
+  system: {
+    slowzones: 'systemSlowzones',
+  },
+};
+
+export const LANDING_PAGE = [ALL_PAGES.landing];
+
+export const SYSTEM_SLOWZONES_PAGE = [ALL_PAGES.systemSlowzones];

--- a/common/state/dashboardConfig.ts
+++ b/common/state/dashboardConfig.ts
@@ -5,33 +5,35 @@ import { BUS_DEFAULTS, SUBWAY_DEFAULTS } from './defaults/dashboardDefaults';
 import type {
   LineSectionParams,
   OverviewPresetParams,
+  SystemSectionParams,
   TripsSectionParams,
 } from './types/dashboardConfigTypes';
 
 export interface DashboardConfig {
   lineConfig: LineSectionParams;
   tripConfig: TripsSectionParams;
+  systemConfig: SystemSectionParams;
   overviewPreset: OverviewPresetParams;
   swapDashboardTabs: (newTab: Tab) => void;
   setLineConfig: (lineConfig: LineSectionParams) => void;
   setTripConfig: (tripConfig: TripsSectionParams) => void;
+  setSystemConfig: (systemConfig: SystemSectionParams) => void;
   overviewPresetChange: (overviewConfig: OverviewPresetParams) => void;
 }
 
 export const useDashboardConfig = create<DashboardConfig>((set) => ({
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: TODAY_STRING, queryType: 'single' },
+  systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   overviewPreset: { view: 'year' },
   setLineConfig: (lineParams) => set(() => ({ lineConfig: lineParams })),
   setTripConfig: (tripParams) => set(() => ({ tripConfig: tripParams })),
+  setSystemConfig: (systemParams) => set(() => ({ systemConfig: systemParams })),
   swapDashboardTabs: (newTab) =>
     set(() => {
-      if (newTab === 'Subway') {
-        return SUBWAY_DEFAULTS;
-      }
-      if (newTab === 'Bus') {
-        return BUS_DEFAULTS;
-      }
+      if (newTab === 'Subway') return SUBWAY_DEFAULTS;
+      if (newTab === 'Bus') return BUS_DEFAULTS;
+      if (newTab === 'System') return BUS_DEFAULTS;
       return {};
     }),
   overviewPresetChange: (overviewConfig) =>

--- a/common/state/defaults/dashboardDefaults.ts
+++ b/common/state/defaults/dashboardDefaults.ts
@@ -4,11 +4,20 @@ import type { FullDashboardConfig } from '../types/dashboardConfigTypes';
 export const SUBWAY_DEFAULTS: FullDashboardConfig = {
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: TODAY_STRING, queryType: 'single' },
+  systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   overviewPreset: { view: 'year' },
 };
 
 export const BUS_DEFAULTS: FullDashboardConfig = {
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: BUS_MAX_DATE, queryType: 'single' },
+  systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
+  overviewPreset: undefined,
+};
+
+export const SYSTEM_DEFAULTS: FullDashboardConfig = {
+  lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
+  tripConfig: { startDate: BUS_MAX_DATE, queryType: 'single' },
+  systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   overviewPreset: undefined,
 };

--- a/common/state/types/dashboardConfigTypes.ts
+++ b/common/state/types/dashboardConfigTypes.ts
@@ -14,6 +14,11 @@ export type TripsSectionParams = Partial<{
   to: string;
 }>;
 
+export type SystemSectionParams = Partial<{
+  startDate: string;
+  endDate: string;
+}>;
+
 export type OverviewPresetParams = {
   view: OverviewDatePresetKey;
 };
@@ -21,5 +26,6 @@ export type OverviewPresetParams = {
 export interface FullDashboardConfig {
   lineConfig: LineSectionParams;
   tripConfig: TripsSectionParams;
+  systemConfig: SystemSectionParams;
   overviewPreset?: OverviewPresetParams;
 }

--- a/common/state/utils/dashboardUtils.ts
+++ b/common/state/utils/dashboardUtils.ts
@@ -22,15 +22,11 @@ export const saveDashboardConfig = (
 };
 
 export const getDashboardConfig = (section: Section, dashboardConfig: DashboardConfig) => {
-  if (section === 'trips' || section === 'system') {
-    return dashboardConfig.tripConfig;
-  }
-  if (section === 'line') {
-    return dashboardConfig.lineConfig;
-  }
-  if (section === 'overview') {
-    return dashboardConfig.overviewPreset;
-  }
+  if (section === 'trips') return dashboardConfig.tripConfig;
+  if (section === 'system') return dashboardConfig.systemConfig;
+  if (section === 'line') return dashboardConfig.lineConfig;
+  if (section === 'overview') return dashboardConfig.overviewPreset;
+  return {};
 };
 
 export const getSelectedDates = (dateConfig: {

--- a/modules/navigation/SystemNavMenu.tsx
+++ b/modules/navigation/SystemNavMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SYSTEM_PAGES } from '../../common/constants/pages';
+import { LANDING_PAGE, SYSTEM_SLOWZONES_PAGE } from '../../common/constants/pages';
 import { SidebarTabs } from './SidebarTabs';
 
 interface SystemNavMenuProps {
@@ -9,7 +9,8 @@ export const SystemNavMenu = ({ setSidebarOpen }: SystemNavMenuProps) => {
   return (
     <div className="flex flex-col gap-y-4">
       <hr className="h-1 w-full border-stone-400" />
-      <SidebarTabs tabs={SYSTEM_PAGES} setSidebarOpen={setSidebarOpen} />
+      <SidebarTabs tabs={LANDING_PAGE} setSidebarOpen={setSidebarOpen} />
+      <SidebarTabs tabs={SYSTEM_SLOWZONES_PAGE} setSidebarOpen={setSidebarOpen} />
     </div>
   );
 };


### PR DESCRIPTION
## Motivation

We wanted to set up auto date filling on slow zones system page. Required some system tab setup.

## Changes
Added logic to handle system tab in routing

## Testing Instructions
Navigate around. I was running into an error going from `/` to `/system/slowzones`. It seemed to stop happening but I'm not convinced.