### PR TITLE
Rename dashboardConfig -> dateConfig

### DIFF
--- a/common/components/controls/ControlPanel.tsx
+++ b/common/components/controls/ControlPanel.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import classNames from 'classnames';
 import { lineColorBorder } from '../../styles/general';
 import type { BusRoute, Line } from '../../types/lines';
-import type { Section } from '../../constants/pages';
+import type { DateConfigOptions } from '../../constants/pages';
 import type { QueryTypeOptions } from '../../types/router';
 import { StationSelectorWidget } from '../widgets/StationSelectorWidget';
 import { DateControl } from './DateControl';
 
 interface ControlPanelProps {
-  section: Section;
+  section: DateConfigOptions;
   line?: Line;
   busRoute?: BusRoute;
   queryType?: QueryTypeOptions;

--- a/common/components/controls/DateControl.tsx
+++ b/common/components/controls/DateControl.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { DateSelection } from '../inputs/DateSelection/DateSelection';
 import { OverviewDateSelection } from '../inputs/DateSelection/OverviewDateSelection';
-import type { Section } from '../../constants/pages';
+import type { DateConfigOptions } from '../../constants/pages';
 import type { QueryTypeOptions } from '../../types/router';
 
 interface DateControlProps {
-  section: Section;
+  section: DateConfigOptions;
   queryType: QueryTypeOptions;
 }
 

--- a/common/components/controls/MobileControlPanel.tsx
+++ b/common/components/controls/MobileControlPanel.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import type { BusRoute, Line } from '../../types/lines';
-import type { Section } from '../../constants/pages';
+import type { DateConfigOptions } from '../../constants/pages';
 import type { QueryTypeOptions } from '../../types/router';
 import { StationSelectorWidget } from '../widgets/StationSelectorWidget';
 import { DateControl } from './DateControl';
 
 interface MobileControlPanelProps {
-  section: Section;
+  section: DateConfigOptions;
   line: Line;
   busRoute: BusRoute | undefined;
   queryType?: QueryTypeOptions;

--- a/common/components/inputs/DateSelection/OverviewDateSelection.tsx
+++ b/common/components/inputs/DateSelection/OverviewDateSelection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { ButtonGroup } from '../../general/ButtonGroup';
-import { useDashboardConfig } from '../../../state/dashboardConfig';
+import { useDateConfig } from '../../../state/dateConfig';
 import { useDatePresetConfig } from '../../../state/datePresetConfig';
 import type { OverviewDatePresetKey } from '../../../constants/dates';
 import { OverviewRangeTypes } from '../../../constants/dates';
@@ -12,7 +12,7 @@ export const OverviewDateSelection = () => {
   const selectedView = router.query.view ?? 'year';
   const selectedIndex = Object.keys(OverviewRangeTypes).findIndex((view) => view === selectedView);
 
-  const overviewPresetChange = useDashboardConfig((state) => state.overviewPresetChange);
+  const overviewPresetChange = useDateConfig((state) => state.overviewPresetChange);
   const handlePresetSelection = (value: OverviewDatePresetKey) => {
     overviewPresetChange({ view: value });
     setDatePreset(value, 'line', true);

--- a/common/constants/pages.ts
+++ b/common/constants/pages.ts
@@ -30,7 +30,7 @@ export enum PAGES {
   tripDwells = 'tripDwells',
 }
 
-export type Section = 'landing' | 'today' | 'line' | 'overview' | 'trips' | 'system';
+export type DateConfigOptions = 'landing' | 'today' | 'line' | 'overview' | 'trips' | 'system';
 export type SectionTitle = 'Today' | 'Line' | 'Overview' | 'Trips' | 'System';
 
 export type PageMetadata = {
@@ -39,7 +39,7 @@ export type PageMetadata = {
   name: string;
   lines: Line[];
   icon: IconDefinition;
-  section: Section;
+  section: DateConfigOptions;
   sectionTitle?: SectionTitle;
   sub?: boolean;
   title?: string;

--- a/common/state/dateConfig.ts
+++ b/common/state/dateConfig.ts
@@ -7,9 +7,9 @@ import type {
   OverviewPresetParams,
   SystemSectionParams,
   TripsSectionParams,
-} from './types/dashboardConfigTypes';
+} from './types/dateConfigTypes';
 
-export interface DashboardConfig {
+export interface DateConfig {
   lineConfig: LineSectionParams;
   tripConfig: TripsSectionParams;
   systemConfig: SystemSectionParams;
@@ -21,7 +21,7 @@ export interface DashboardConfig {
   overviewPresetChange: (overviewConfig: OverviewPresetParams) => void;
 }
 
-export const useDashboardConfig = create<DashboardConfig>((set) => ({
+export const useDateConfig = create<DateConfig>((set) => ({
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: TODAY_STRING, queryType: 'single' },
   systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },

--- a/common/state/datePresetConfig.ts
+++ b/common/state/datePresetConfig.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { DatePresetKey } from '../constants/dates';
-import type { Section } from '../constants/pages';
+import type { DateConfigOptions } from '../constants/pages';
 import type { QueryParams } from '../types/router';
 import { PRESET_DEFAULTS } from './defaults/datePresetDefaults';
 import { checkForPreset } from './utils/datePresetUtils';
@@ -9,10 +9,10 @@ export interface DatePresetConfig {
   linePreset: DatePresetKey | undefined | 'custom';
   singleTripPreset: DatePresetKey | undefined | 'custom';
   rangeTripPreset: DatePresetKey | undefined | 'custom';
-  setDefaults: (section: Section | undefined, query: QueryParams) => void;
+  setDefaults: (section: DateConfigOptions | undefined, query: QueryParams) => void;
   setDatePreset: (
     newPreset: DatePresetKey | undefined | 'custom',
-    section: Section,
+    section: DateConfigOptions,
     range: boolean
   ) => void;
 }

--- a/common/state/defaults/dashboardDefaults.ts
+++ b/common/state/defaults/dashboardDefaults.ts
@@ -1,21 +1,21 @@
 import { BUS_MAX_DATE, OVERVIEW_OPTIONS, TODAY_STRING } from '../../constants/dates';
-import type { FullDashboardConfig } from '../types/dashboardConfigTypes';
+import type { FullDateConfig } from '../types/dateConfigTypes';
 
-export const SUBWAY_DEFAULTS: FullDashboardConfig = {
+export const SUBWAY_DEFAULTS: FullDateConfig = {
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: TODAY_STRING, queryType: 'single' },
   systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   overviewPreset: { view: 'year' },
 };
 
-export const BUS_DEFAULTS: FullDashboardConfig = {
+export const BUS_DEFAULTS: FullDateConfig = {
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: BUS_MAX_DATE, queryType: 'single' },
   systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   overviewPreset: undefined,
 };
 
-export const SYSTEM_DEFAULTS: FullDashboardConfig = {
+export const SYSTEM_DEFAULTS: FullDateConfig = {
   lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
   tripConfig: { startDate: BUS_MAX_DATE, queryType: 'single' },
   systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },

--- a/common/state/types/dateConfigTypes.ts
+++ b/common/state/types/dateConfigTypes.ts
@@ -10,8 +10,6 @@ export type TripsSectionParams = Partial<{
   startDate: string;
   endDate: string;
   queryType: QueryTypeOptions;
-  from: string;
-  to: string;
 }>;
 
 export type SystemSectionParams = Partial<{
@@ -23,7 +21,7 @@ export type OverviewPresetParams = {
   view: OverviewDatePresetKey;
 };
 
-export interface FullDashboardConfig {
+export interface FullDateConfig {
   lineConfig: LineSectionParams;
   tripConfig: TripsSectionParams;
   systemConfig: SystemSectionParams;

--- a/common/state/utils/dateConfigUtils.ts
+++ b/common/state/utils/dateConfigUtils.ts
@@ -1,31 +1,31 @@
 import dayjs from 'dayjs';
 import type { OverviewDatePresetKey } from '../../constants/dates';
 import { SMALL_DATE_FORMAT, RANGE_PRESETS } from '../../constants/dates';
-import type { Section } from '../../constants/pages';
+import type { DateConfigOptions } from '../../constants/pages';
 import type { QueryParams } from '../../types/router';
-import { getParams } from '../../utils/router';
-import type { DashboardConfig } from '../dashboardConfig';
+import { getDateParams } from '../../utils/router';
+import type { DateConfig } from '../dateConfig';
 
-export const saveDashboardConfig = (
-  section: Section,
+export const saveDateConfig = (
+  section: DateConfigOptions,
   query: QueryParams,
-  dashboardConfig: DashboardConfig
+  dateConfig: DateConfig
 ) => {
+  const params = getDateParams(query);
+
   if (section === 'trips') {
-    // TODO: filter out invalid keys.
-    const params = getParams(query);
-    if (params.startDate) dashboardConfig.setTripConfig(params);
+    if (params.startDate) dateConfig.setTripConfig(params);
   }
   if (section === 'line') {
-    dashboardConfig.setLineConfig({ startDate: query.startDate, endDate: query.endDate });
+    dateConfig.setLineConfig(params);
   }
 };
 
-export const getDashboardConfig = (section: Section, dashboardConfig: DashboardConfig) => {
-  if (section === 'trips') return dashboardConfig.tripConfig;
-  if (section === 'system') return dashboardConfig.systemConfig;
-  if (section === 'line') return dashboardConfig.lineConfig;
-  if (section === 'overview') return dashboardConfig.overviewPreset;
+export const getDateConfig = (section: DateConfigOptions, dateConfig: DateConfig) => {
+  if (section === 'trips') return dateConfig.tripConfig;
+  if (section === 'system') return dateConfig.systemConfig;
+  if (section === 'line') return dateConfig.lineConfig;
+  if (section === 'overview') return dateConfig.overviewPreset;
   return {};
 };
 

--- a/common/types/router.ts
+++ b/common/types/router.ts
@@ -24,3 +24,5 @@ export type QueryParams = {
 export type QueryTypeOptions = 'single' | 'range';
 
 export type Tab = 'Bus' | 'Subway' | 'System';
+
+export const DATE_PARAMS = ['startDate', 'endDate', 'date', 'queryType']; // TODO: Remove queryType from this array when stationConfig changes added.

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -5,12 +5,13 @@ import { useCallback } from 'react';
 import type { Line, LinePath, LineShort } from '../types/lines';
 import { RAIL_LINES } from '../types/lines';
 import type { QueryParams, Route, Tab } from '../types/router';
+import { DATE_PARAMS } from '../types/router';
 import type { PageMetadata, Page } from '../constants/pages';
 import { SYSTEM_PAGES_MAP, SUB_PAGES_MAP, ALL_PAGES } from '../constants/pages';
-import type { DashboardConfig } from '../state/dashboardConfig';
-import { useDashboardConfig } from '../state/dashboardConfig';
+import type { DateConfig } from '../state/dateConfig';
+import { useDateConfig } from '../state/dateConfig';
 import { LINE_OBJECTS } from '../constants/lines';
-import { getDashboardConfig, saveDashboardConfig } from '../state/utils/dashboardUtils';
+import { getDateConfig, saveDateConfig } from '../state/utils/dateConfigUtils';
 
 const linePathToKeyMap: Record<string, Line> = {
   red: 'line-red',
@@ -23,6 +24,12 @@ const linePathToKeyMap: Record<string, Line> = {
 export const getParams = (params: ParsedUrlQuery | QueryParams) => {
   return Object.fromEntries(
     Object.entries(params).filter(([key, value]) => key !== 'line' && value)
+  );
+};
+
+export const getDateParams = (params: ParsedUrlQuery | QueryParams) => {
+  return Object.fromEntries(
+    Object.entries(params).filter(([key, value]) => DATE_PARAMS.includes(key) && value)
   );
 };
 
@@ -160,7 +167,7 @@ export const getBusRouteSelectionItemHref = (newRoute: string, route: Route): st
 };
 
 export const getHref = (
-  dashboardConfig: DashboardConfig,
+  dateConfig: DateConfig,
   newPage: PageMetadata,
   currentPage: Page,
   query: QueryParams,
@@ -170,21 +177,21 @@ export const getHref = (
   if (pageObject?.section === newPage.section) {
     return navigateWithinSection(linePath, newPage, query);
   }
-  return navigateToNewSection(linePath, newPage, query, dashboardConfig);
+  return navigateToNewSection(linePath, newPage, query, dateConfig);
 };
 
 export const useHandlePageNavigation = () => {
   const { page, query } = useDelimitatedRoute();
   const pageObject = ALL_PAGES[page];
-  const dashboardConfig = useDashboardConfig();
+  const dateConfig = useDateConfig();
 
   const handlePageNavigation = useCallback(
     (page: PageMetadata) => {
       if (!(pageObject?.section === page.section)) {
-        saveDashboardConfig(pageObject.section, query, dashboardConfig);
+        saveDateConfig(pageObject.section, query, dateConfig);
       }
     },
-    [query, pageObject, dashboardConfig]
+    [query, pageObject, dateConfig]
   );
   return handlePageNavigation;
 };
@@ -197,9 +204,9 @@ const navigateToNewSection = (
   linePath: LinePath,
   page: PageMetadata,
   query: QueryParams,
-  dashboardConfig: DashboardConfig
+  dateConfig: DateConfig
 ) => {
-  const params = getDashboardConfig(page.section, dashboardConfig);
+  const params = getDateConfig(page.section, dateConfig);
   const busRouteOnly = query.busRoute ?? undefined;
   const newQuery = busRouteOnly ? { ...params, busRoute: busRouteOnly } : params;
   return {

--- a/modules/dashboard/HomescreenWidgetTitle.tsx
+++ b/modules/dashboard/HomescreenWidgetTitle.tsx
@@ -8,8 +8,8 @@ import { getHref, useDelimitatedRoute, useHandlePageNavigation } from '../../com
 import { LINE_COLORS } from '../../common/constants/colors';
 import type { Page } from '../../common/constants/pages';
 import { ALL_PAGES } from '../../common/constants/pages';
-import { useDashboardConfig } from '../../common/state/dashboardConfig';
-import { getSelectedDates } from '../../common/state/utils/dashboardUtils';
+import { useDateConfig } from '../../common/state/dateConfig';
+import { getSelectedDates } from '../../common/state/utils/dateConfigUtils';
 
 interface HomescreenWidgetTitle {
   title: string;
@@ -18,8 +18,8 @@ interface HomescreenWidgetTitle {
 export const HomescreenWidgetTitle: React.FC<HomescreenWidgetTitle> = ({ title, tab }) => {
   const { line, page, query, linePath } = useDelimitatedRoute();
   const handlePageNavigation = useHandlePageNavigation();
-  const dashboardConfig = useDashboardConfig();
-  const href = getHref(dashboardConfig, ALL_PAGES[tab], page, query, linePath);
+  const dateConfig = useDateConfig();
+  const href = getHref(dateConfig, ALL_PAGES[tab], page, query, linePath);
   const date = getSelectedDates({
     startDate: query.startDate,
     endDate: query.endDate,

--- a/modules/dashboard/WidgetTitle.tsx
+++ b/modules/dashboard/WidgetTitle.tsx
@@ -4,7 +4,7 @@ import type { Location } from '../../common/types/charts';
 import type { Line } from '../../common/types/lines';
 import { useBreakpoint } from '../../common/hooks/useBreakpoint';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import { getSelectedDates } from '../../common/state/utils/dashboardUtils';
+import { getSelectedDates } from '../../common/state/utils/dateConfigUtils';
 import { LocationTitle } from './LocationTitle';
 
 interface WidgetTitle {

--- a/modules/navigation/DashboardSelection.tsx
+++ b/modules/navigation/DashboardSelection.tsx
@@ -4,11 +4,11 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import { DASHBOARD_TABS } from '../../common/constants/dashboardTabs';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import { useDashboardConfig } from '../../common/state/dashboardConfig';
+import { useDateConfig } from '../../common/state/dateConfig';
 
 export const DashboardSelection: React.FC = () => {
   const { tab } = useDelimitatedRoute();
-  const swapDashboardTabs = useDashboardConfig((state) => state.swapDashboardTabs);
+  const swapDashboardTabs = useDateConfig((state) => state.swapDashboardTabs);
   const dashboardTabs = Object.values(DASHBOARD_TABS);
   return (
     <Tab.Group

--- a/modules/navigation/RangeTabs.tsx
+++ b/modules/navigation/RangeTabs.tsx
@@ -3,23 +3,23 @@ import React from 'react';
 import { Tab } from '@headlessui/react';
 import { useRouter } from 'next/router';
 import { useDelimitatedRoute } from '../../common/utils/router';
-import { useDashboardConfig } from '../../common/state/dashboardConfig';
+import { useDateConfig } from '../../common/state/dateConfig';
 import { switchToRange, switchToSingleDay } from './utils/rangeTabUtils';
 
 export const RangeTabs = () => {
   const route = useDelimitatedRoute();
   const { query, line } = route;
   const router = useRouter();
-  const dashboardConfig = useDashboardConfig();
+  const dateConfig = useDateConfig();
   const selected = query.queryType === 'single' ? 1 : 0;
   const rangeOptions = ['Multi Day', 'Single Day'];
 
   const handleChange = (index: number) => {
     if (index) {
-      switchToSingleDay(router, dashboardConfig);
+      switchToSingleDay(router, dateConfig);
       return;
     }
-    switchToRange(router, dashboardConfig);
+    switchToRange(router, dateConfig);
   };
 
   return (

--- a/modules/navigation/SidebarTabs.tsx
+++ b/modules/navigation/SidebarTabs.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Link from 'next/link';
 import { getHref, useDelimitatedRoute, useHandlePageNavigation } from '../../common/utils/router';
 import type { PageMetadata } from '../../common/constants/pages';
-import { useDashboardConfig } from '../../common/state/dashboardConfig';
+import { useDateConfig } from '../../common/state/dateConfig';
 
 interface SidebarTabs {
   tabs: PageMetadata[];
@@ -14,7 +14,7 @@ interface SidebarTabs {
 export const SidebarTabs: React.FC<SidebarTabs> = ({ tabs, setSidebarOpen }) => {
   const { line, page, query, linePath } = useDelimitatedRoute();
   const handlePageNavigation = useHandlePageNavigation();
-  const dashboardConfig = useDashboardConfig();
+  const dateConfig = useDateConfig();
 
   const handleChange = (enabled: boolean, tab: PageMetadata) => {
     if (!enabled) return null;
@@ -28,7 +28,7 @@ export const SidebarTabs: React.FC<SidebarTabs> = ({ tabs, setSidebarOpen }) => 
         {tabs.map((tab: PageMetadata) => {
           const enabled = line ? tab.lines.includes(line) : true;
           const selected = page === tab.key;
-          const href = getHref(dashboardConfig, tab, page, query, linePath);
+          const href = getHref(dateConfig, tab, page, query, linePath);
           return (
             <li key={tab.key}>
               <Link

--- a/modules/navigation/utils/rangeTabUtils.ts
+++ b/modules/navigation/utils/rangeTabUtils.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs';
 import type { NextRouter } from 'next/router';
 import { DATE_FORMAT, ONE_WEEK_AGO_STRING, TODAY_STRING } from '../../../common/constants/dates';
-import { saveDashboardConfig } from '../../../common/state/utils/dashboardUtils';
-import type { DashboardConfig } from '../../../common/state/dashboardConfig';
-import type { TripsSectionParams } from '../../../common/state/types/dashboardConfigTypes';
+import { saveDateConfig } from '../../../common/state/utils/dateConfigUtils';
+import type { DateConfig } from '../../../common/state/dateConfig';
+import type { TripsSectionParams } from '../../../common/state/types/dateConfigTypes';
 
-export const switchToSingleDay = (router: NextRouter, dashboardConfig: DashboardConfig) => {
-  saveDashboardConfig('trips', router.query, dashboardConfig);
+export const switchToSingleDay = (router: NextRouter, dateConfig: DateConfig) => {
+  saveDateConfig('trips', router.query, dateConfig);
   router.query.queryType = 'single';
   router.query.startDate = router.query.endDate;
   delete router.query.endDate;
@@ -14,9 +14,9 @@ export const switchToSingleDay = (router: NextRouter, dashboardConfig: Dashboard
   return;
 };
 
-export const switchToRange = (router: NextRouter, dashboardConfig: DashboardConfig) => {
+export const switchToRange = (router: NextRouter, dateConfig: DateConfig) => {
   router.query.queryType = 'range';
-  const { tripConfig } = dashboardConfig;
+  const { tripConfig } = dateConfig;
 
   if (tripConfig.endDate) {
     return returnToPreviousRange(router, tripConfig);


### PR DESCRIPTION
## Motivation

With the upcoming trips section changes, it became evident that storing both the `date` and `station` configuration as one object was an issue. Mainly because we want multi day and single day trips to share `station` configuration but not `date` configuration. It also will improve code quality and remove complicated logic.

This change renames `dashboardConfig` to `dateConfig`. It also removes `to` and `from` from the `tripConfig`, which means the dashboard no longer has state to track the station. This will be fixed in the upcoming PRs. If we want to avoid that we could keep this as a separate branch and merge followup changes to this branch.

## Changes

The only change should be that station selection should not persist between stations. This is a degradation that should be fixed soon.

## Testing Instructions

Test that date persists across sections with previous behavior.