### PR TITLE
V4/header link

### DIFF
--- a/modules/navigation/DesktopSideNavBar.tsx
+++ b/modules/navigation/DesktopSideNavBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 
 import TmLogoSvg from '../../public/tm-logo-big.svg';
 import { DonateButton } from '../../common/components/buttons/DonateButton';
@@ -10,9 +11,9 @@ export const SideNavBar = () => {
     <>
       <div className="bg-tm-grey text-gray-300">
         <div className="fixed inset-y-0 flex w-64 flex-col overflow-y-hidden bg-tm-grey">
-          <div className="sticky flex flex-shrink-0 px-6 pb-2 pt-6">
+          <Link href="/" className="sticky flex flex-shrink-0 px-6 pb-2 pt-6">
             <TmLogoSvg alt="TransitMatters Logo" />
-          </div>
+          </Link>
           <div className="relative flex flex-grow flex-col overflow-y-auto pb-4">
             <div className="fixed h-5 w-64 bg-gradient-to-b from-tm-grey to-transparent"></div>
             <SideNavigation />

--- a/modules/navigation/MobileNavHeader.tsx
+++ b/modules/navigation/MobileNavHeader.tsx
@@ -18,7 +18,25 @@ export const MobileNavHeader = () => {
           <Dialog as="div" className="relative z-40 w-full" onClose={setSidebarOpen}>
             <div className="fixed bottom-0 right-0 top-0 bg-gray-600 bg-opacity-75" />
 
-            <Dialog.Panel className="fixed bottom-0 left-0 right-0 top-12 flex w-full flex-col bg-tm-grey">
+            <Dialog.Panel className="fixed bottom-0 left-0 right-0 top-0 flex w-full flex-col bg-tm-grey">
+              <div className="top-0 z-10 flex flex-row items-center justify-between bg-tm-grey p-2">
+                <Link
+                  href="/"
+                  className="h-5 w-auto focus:outline-none"
+                  onClick={() => setSidebarOpen(false)}
+                >
+                  <TmLogoSvg className="mr-4 h-5 w-auto text-black" alt="TransitMatters Logo" />
+                </Link>
+
+                <button
+                  type="button"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-400"
+                  onClick={() => setSidebarOpen(false)}
+                >
+                  <span className="sr-only">{'Close Sidebar'}</span>
+                  <XMarkIcon className="h-8 w-8 text-stone-100" aria-hidden="true" />
+                </button>
+              </div>
               <div className="h-0 flex-1 overflow-y-auto px-4 pt-5">
                 <div className="h-0 flex-1 text-white md:mt-5">
                   <SideNavigation setSidebarOpen={setSidebarOpen} />
@@ -42,14 +60,10 @@ export const MobileNavHeader = () => {
             <button
               type="button"
               className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-400"
-              onClick={() => setSidebarOpen(!sidebarOpen)}
+              onClick={() => setSidebarOpen(true)}
             >
-              <span className="sr-only">{sidebarOpen ? 'Open Sidebar' : 'Close Sidebar'}</span>
-              {sidebarOpen ? (
-                <XMarkIcon className="h-8 w-8 text-stone-100" aria-hidden="true" />
-              ) : (
-                <Bars3Icon className="h-8 w-8 text-stone-100" aria-hidden="true" />
-              )}
+              <span className="sr-only">{'Open Sidebar'}</span>
+              <Bars3Icon className="h-8 w-8 text-stone-100" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/modules/navigation/MobileNavHeader.tsx
+++ b/modules/navigation/MobileNavHeader.tsx
@@ -1,8 +1,9 @@
 import React, { Fragment, useState } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import TmLogoSvg from '../../public/tm-logo-big.svg';
+import Link from 'next/link';
 
+import TmLogoSvg from '../../public/tm-logo-big.svg';
 import { DonateButton } from '../../common/components/buttons/DonateButton';
 import { FeedbackButton } from '../../common/components/buttons/FeedbackButton';
 import { SideNavigation } from './SideNavigation';
@@ -34,7 +35,10 @@ export const MobileNavHeader = () => {
 
         <div className="flex flex-1 flex-col">
           <div className="top-0 z-10 flex flex-row items-center justify-between bg-tm-grey p-2">
-            <TmLogoSvg className="mr-4 h-5 w-auto text-black" alt="TransitMatters Logo" />
+            <Link href="/" className="h-5 w-auto">
+              <TmLogoSvg className="mr-4 h-5 w-auto text-black" alt="TransitMatters Logo" />
+            </Link>
+
             <button
               type="button"
               className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-400"


### PR DESCRIPTION
## Motivation
Header title should link to homepage.
Closes #646 
## Changes
Add <Link/> components to TM logo.

Also added the header component to the mobile nav dropdown. A bit hacky, but the alternative was rewriting the nav to not use a headless `<Dialog/>` because with the `<Dialog/>` component if you click anywhere outside it just closes the dialog. So you couldn't click on the existing header without having to double tap.
## Testing Instructions
Click on header to navigate to the root URL `/`