### PR TITLE
Fix system tab controls and title bug on mobile

### DIFF
--- a/common/components/controls/ControlPanel.tsx
+++ b/common/components/controls/ControlPanel.tsx
@@ -9,9 +9,9 @@ import { DateControl } from './DateControl';
 
 interface ControlPanelProps {
   dateStoreSection: DateStoreSection;
-  line?: Line;
-  busRoute?: BusRoute;
-  queryType?: QueryTypeOptions;
+  busRoute: BusRoute | undefined;
+  line: Line | undefined;
+  queryType: QueryTypeOptions | undefined;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({

--- a/common/components/controls/MobileControlPanel.tsx
+++ b/common/components/controls/MobileControlPanel.tsx
@@ -7,8 +7,8 @@ import { DateControl } from './DateControl';
 
 interface MobileControlPanelProps {
   dateStoreSection: DateStoreSection;
-  line: Line;
-  busRoute: BusRoute | undefined;
+  line?: Line;
+  busRoute?: BusRoute;
   queryType?: QueryTypeOptions;
 }
 
@@ -19,7 +19,7 @@ export const MobileControlPanel: React.FC<MobileControlPanelProps> = ({
   queryType,
 }) => {
   const getControls = () => {
-    if (dateStoreSection === 'trips' && queryType) {
+    if (dateStoreSection === 'trips' && queryType && line) {
       return (
         <>
           <div className="p-1 pb-0">

--- a/common/components/controls/MobileControlPanel.tsx
+++ b/common/components/controls/MobileControlPanel.tsx
@@ -31,7 +31,11 @@ export const MobileControlPanel: React.FC<MobileControlPanelProps> = ({
         </>
       );
     }
-    if (dateStoreSection === 'line' || dateStoreSection === 'overview') {
+    if (
+      dateStoreSection === 'line' ||
+      dateStoreSection === 'overview' ||
+      dateStoreSection === 'system'
+    ) {
       return (
         <div className="p-1">
           <DateControl dateStoreSection={dateStoreSection} queryType={'range'} />

--- a/common/components/controls/MobileControlPanel.tsx
+++ b/common/components/controls/MobileControlPanel.tsx
@@ -7,9 +7,9 @@ import { DateControl } from './DateControl';
 
 interface MobileControlPanelProps {
   dateStoreSection: DateStoreSection;
-  line?: Line;
-  busRoute?: BusRoute;
-  queryType?: QueryTypeOptions;
+  busRoute: BusRoute | undefined;
+  line: Line | undefined;
+  queryType: QueryTypeOptions | undefined;
 }
 
 export const MobileControlPanel: React.FC<MobileControlPanelProps> = ({

--- a/common/layouts/DashboardLayout.tsx
+++ b/common/layouts/DashboardLayout.tsx
@@ -17,10 +17,11 @@ interface DashboardLayoutProps {
 
 export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   const isMobile = !useBreakpoint('md');
-  const { line, page, query } = useDelimitatedRoute();
+  const { line, page, query, tab } = useDelimitatedRoute();
   const { busRoute, queryType } = query;
   const dateStoreSection = page ? ALL_PAGES[page]?.dateStoreSection : undefined;
-  const showControlParams = dateStoreSection && line && dateStoreSection !== 'today';
+  const showControlParams =
+    dateStoreSection && (line || tab === 'System') && dateStoreSection !== 'today';
   usePresetsOnFirstLoad(dateStoreSection, query);
 
   return (

--- a/modules/dashboard/MobileHeader.tsx
+++ b/modules/dashboard/MobileHeader.tsx
@@ -12,10 +12,16 @@ export const MobileHeader: React.FC = () => {
   const {
     line,
     page,
+    tab,
     query: { busRoute, startDate, endDate, view },
   } = useDelimitatedRoute();
   const section = page ? ALL_PAGES[page]?.dateStoreSection : undefined;
 
+  const getLineName = () => {
+    if (busRoute) return `Route ${busRoute}`;
+    if (line) return LINE_OBJECTS[line]?.short;
+    if (tab === 'System') return 'System';
+  };
   return (
     <div
       className={classNames(
@@ -30,10 +36,8 @@ export const MobileHeader: React.FC = () => {
         )}
       >
         <div className="flex shrink-0 flex-row items-baseline pl-2">
-          <h3 className="text-lg font-semibold">
-            {busRoute ? `Route ${busRoute}` : line && LINE_OBJECTS[line]?.short}
-          </h3>
-          {ALL_PAGES[page]?.sectionTitle && (
+          <h3 className="text-lg font-semibold">{getLineName()}</h3>
+          {ALL_PAGES[page]?.sectionTitle && tab !== 'System' && (
             <>
               <span className="px-1 text-lg">•</span>
               <h2 className="select-none text-lg font-semibold">


### PR DESCRIPTION
## Motivation
Closes #639 

also there was an issue with the page title logic on mobile. Seems when we added the slow zones tab we only updated the desktop header title logic. 

Still needed: `DatePresetConfig` logic for systems page.

Ideally there would only be one source of truth for mobile and desktop.... but not worth it at the moment imo.
## Changes
**Before** (no controls and `•` before the title)
 ![Screen Shot 2023-06-10 at 3 41 08 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/3016ef9e-8020-4661-a5ed-3aaa9c2c55ee)
 
 **After**
 Controls and correct title.
![Screen Shot 2023-06-10 at 3 41 51 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/0d445360-2138-46cb-83a5-b292c2a4b40e)


<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions
Go to System > Slow zones page.