### PR TITLE
[Release day] v3 hostname to dashboard-v3.labs.transitmatters.org

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -28,16 +28,16 @@ done
 # Setup environment stuff
 # By default deploy to beta, otherwise deploys to production
 
-$PRODUCTION && ENV_SUFFIX=""                                    || ENV_SUFFIX="-beta"
+$PRODUCTION && ENV_SUFFIX="-v3"                                 || ENV_SUFFIX="-v3-beta"
 $PRODUCTION && CHALICE_STAGE="production"                       || CHALICE_STAGE="beta"
 
-$PRODUCTION && FRONTEND_ZONE="dashboard.transitmatters.org"     || FRONTEND_ZONE="labs.transitmatters.org"
-$PRODUCTION && FRONTEND_CERT_ARN="$TM_FRONTEND_CERT_ARN"        || FRONTEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
-$PRODUCTION && FRONTEND_DOMAIN_PREFIX=""                        || FRONTEND_DOMAIN_PREFIX="dashboard-beta."
+$PRODUCTION && FRONTEND_ZONE="labs.transitmatters.org"          || FRONTEND_ZONE="labs.transitmatters.org"
+$PRODUCTION && FRONTEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"   || FRONTEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
+$PRODUCTION && FRONTEND_DOMAIN_PREFIX="dashboard-v3."           || FRONTEND_DOMAIN_PREFIX="dashboard-v3-beta."
 
-$PRODUCTION && BACKEND_ZONE="dashboard-api2.transitmatters.org" || BACKEND_ZONE="labs.transitmatters.org"
-$PRODUCTION && BACKEND_CERT_ARN="$TM_BACKEND_CERT_ARN"          || BACKEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
-$PRODUCTION && BACKEND_DOMAIN_PREFIX=""                         || BACKEND_DOMAIN_PREFIX="dashboard-api-beta."
+$PRODUCTION && BACKEND_ZONE="labs.transitmatters.org"           || BACKEND_ZONE="labs.transitmatters.org"
+$PRODUCTION && BACKEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"    || BACKEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
+$PRODUCTION && BACKEND_DOMAIN_PREFIX="dashboard-v3-api."        || BACKEND_DOMAIN_PREFIX="dashboard-v3-api-beta."
 
 
 # Fetch repository tags

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
   <meta name="twitter:title" content="TransitMatters Data Dashboard" />
   <meta name="twitter:description"
     content="Explore MBTA subway and bus performance data with the TransitMatters Data Dashboard." />
-  <meta name="twitter:image" content="https://dashboard.transitmatters.org/twitter-card.jpg" />
+  <meta name="twitter:image" content="https://dashboard-v3.labs.transitmatters.org/twitter-card.jpg" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <title>Data Dashboard</title>
   <script>

--- a/server/.chalice/config.json
+++ b/server/.chalice/config.json
@@ -11,10 +11,10 @@
       "autogen_policy": false,
       "iam_policy_file": "policy.json",
       "environment_variables": {
-        "TM_FRONTEND_HOST": "dashboard.transitmatters.org"
+        "TM_FRONTEND_HOST": "dashboard-v3.labs.transitmatters.org"
       },
       "api_gateway_custom_domain": {
-        "domain_name": "dashboard-api2.transitmatters.org",
+        "domain_name": "dashboard-v3-api.labs.transitmatters.org",
         "tls_version": "TLS_1_2",
         "certificate_arn": ""
       }
@@ -24,10 +24,10 @@
       "autogen_policy": false,
       "iam_policy_file": "policy.json",
       "environment_variables": {
-        "TM_FRONTEND_HOST": "dashboard-beta.labs.transitmatters.org"
+        "TM_FRONTEND_HOST": "dashboard-v3-beta.labs.transitmatters.org"
       },
       "api_gateway_custom_domain": {
-        "domain_name": "dashboard-api-beta.labs.transitmatters.org",
+        "domain_name": "dashboard-v3-api-beta.labs.transitmatters.org",
         "tls_version": "TLS_1_2",
         "certificate_arn": ""
       }

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -3,7 +3,7 @@
     "TMFrontendHostname": {
       "Type": "String",
       "Default": "dashboard-beta.labs.transitmatters.org",
-      "AllowedValues": ["dashboard-beta.labs.transitmatters.org", "dashboard.transitmatters.org"],
+      "AllowedValues": ["dashboard-beta.labs.transitmatters.org", "dashboard-v3.labs.transitmatters.org"],
       "Description": "The frontend hostname for the data dashboard."
     },
     "TMFrontendZone": {

--- a/src/App.js
+++ b/src/App.js
@@ -133,7 +133,7 @@ class App extends React.Component {
       this.state.error_message = this.checkForErrors(this.state.configuration);
     }
 
-    if (window.location.hostname !== 'dashboard.transitmatters.org') {
+    if (window.location.hostname !== 'dashboard-v3.labs.transitmatters.org') {
       showBetaTag();
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import { MbtaMajorEvent } from './slowzones/types';
 
 import stations_json from './stations.json';
 
-export const PRODUCTION = 'dashboard.transitmatters.org';
+export const PRODUCTION = 'dashboard-v3.labs.transitmatters.org';
 const FRONTEND_TO_BACKEND_MAP = new Map([
   [PRODUCTION, 'https://dashboard-api2.transitmatters.org'],
   ['dashboard-beta.labs.transitmatters.org', 'https://dashboard-api-beta.labs.transitmatters.org'],


### PR DESCRIPTION
Fixes https://github.com/transitmatters/t-performance-dash/issues/398

We'll still want v3 up at dashboard-v3.labs.transitmatters.org. Intent is for v3 to remain on this branch, "v3". This PR likely won't ever actually get merged