### PR TITLE
Update Cloudformation config for 404 pages.

### DIFF
--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -97,7 +97,7 @@
         "AccessControl": "PublicRead",
         "WebsiteConfiguration": {
           "IndexDocument": "index.html",
-          "ErrorDocument": "index.html"
+          "ErrorDocument": "404.html"
         }
       }
     },
@@ -153,7 +153,7 @@
           "CustomErrorResponses": [
             {
               "ErrorCode": "404",
-              "ResponsePagePath": "/index.html",
+              "ResponsePagePath": "/404.html",
               "ResponseCode": "200",
               "ErrorCachingMinTTL": "86400"
             }


### PR DESCRIPTION
## Motivation
We didn't have 404 routing set up correctly. There is still an issue where if you go to a valid `/<line-name>/<invalid-page>` page a client-side error is thrown. Probably a nextJS config issue.

## Changes
Update cloudformation config to redirect to 404 page.

## Testing Instructions
I manually deployed to beta stack, and it seems to be working fine: 
https://dashboard-v4-beta.labs.transitmatters.org/invalidLine/otherinvalidpage
