### PR TITLE
Fix 404 bugs

### DIFF
--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -174,7 +174,7 @@ export const getHref = (
   linePath: LinePath
 ) => {
   const pageObject = ALL_PAGES[currentPage];
-  if (pageObject && pageObject?.dateStoreSection === newPage.dateStoreSection) {
+  if (pageObject && pageObject.dateStoreSection === newPage.dateStoreSection) {
     return navigateWithinSection(linePath, newPage, query);
   }
   return navigateToNewSection(linePath, newPage, query, dateStore);

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -149,8 +149,7 @@ export const getLineSelectionItemHref = (newLine: Line, route: Route): string =>
 
 export const getBusRouteSelectionItemHref = (newRoute: string, route: Route): string => {
   const { query, page } = route;
-  if (!page) return ''; // TODO: remove this. Only needed bc this loads on root URL at the moment.
-  const currentPage = ALL_PAGES[page];
+  const currentPage = ALL_PAGES[page] ?? ALL_PAGES['trips'];
   const currentPath = currentPage.path;
   const validPage = currentPage.lines.includes('line-bus');
   if (newRoute === route.query.busRoute || !validPage) {

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -42,7 +42,7 @@ const getPage = (pathItems: string[], tab: Tab): string => {
   const pageArray = pathItems.slice(2);
   if (pageArray[0] === '') return 'overview';
   if (pageArray[1]) {
-    return SUB_PAGES_MAP[pageArray[0]][pageArray[1]];
+    return SUB_PAGES_MAP[pageArray[0]]?.[pageArray[1]];
   }
   return pageArray[0];
 };
@@ -128,6 +128,7 @@ export const getLineSelectionItemHref = (newLine: Line, route: Route): string =>
   const { page, line, query } = route;
   const { path, key } = LINE_OBJECTS[newLine];
   const currentPage = ALL_PAGES[page];
+  if (!currentPage) return `/${path}`;
   const currentPath = currentPage.path;
   let href = `/${path}`;
   // Go to homepage if current line is selected or the selected page is not valid for the given line.
@@ -174,7 +175,7 @@ export const getHref = (
   linePath: LinePath
 ) => {
   const pageObject = ALL_PAGES[currentPage];
-  if (pageObject?.dateStoreSection === newPage.dateStoreSection) {
+  if (pageObject && pageObject?.dateStoreSection === newPage.dateStoreSection) {
     return navigateWithinSection(linePath, newPage, query);
   }
   return navigateToNewSection(linePath, newPage, query, dateStore);
@@ -187,7 +188,7 @@ export const useHandlePageNavigation = () => {
 
   const handlePageNavigation = useCallback(
     (page: PageMetadata) => {
-      if (!(pageObject?.dateStoreSection === page.dateStoreSection)) {
+      if (pageObject && !(pageObject?.dateStoreSection === page.dateStoreSection)) {
         saveDateStoreSection(pageObject.dateStoreSection, query, dateStore);
       }
     },


### PR DESCRIPTION
## Motivation

Some pages that should be 404 were throwing errors. Mainly because the sidebar logic was trying to work with broken links. Updated sidebar logic to not throw errors when given incorrect pages.

For example, going to `/red/invalidPage` would show a client-side error message.

## Changes

for line/busRoute selection - send links to default page (overview for rail, trips for bus).

Make sure invalid pages are not trying to save state.

## Testing Instructions

Go to any invalid page. `/invalid`, `/<valid-line>/invalid`, `/system/invalid`, etc. and the sidebar _should_ show a reasonable value and all links still work.