### PR TITLE
Using replace instead of push to fix back nav

### DIFF
--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -120,7 +120,7 @@ export const useUpdateQuery = () => {
 
       if (!isEqual(router.query, newQuery)) {
         const query = pickBy(newQuery, (attr) => attr !== undefined);
-        router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+        router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
       }
     },
     [router]


### PR DESCRIPTION
## Motivation

Fixes #681 

## Changes

Changes from a `push` to a `replace` to stop polluting the history allowing logical back/forward nav

## Testing Instructions

Click around links, and then use browser back nav one page at a time and make sure there isn't 2 entries per click, but at least 1