### PR TITLE
Update README and GitHub action to clean up stale certificates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       TM_FRONTEND_CERT_ARN: ${{ secrets.TM_FRONTEND_CERT_ARN }}
-      TM_FRONTEND_CERT_ARN_BETA: ${{ secrets.TM_FRONTEND_CERT_ARN_BETA }}
       TM_LABS_WILDCARD_CERT_ARN: ${{ secrets.TM_LABS_WILDCARD_CERT_ARN }}
       MBTA_V2_API_KEY: ${{ secrets.MBTA_V2_API_KEY }}
     steps:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ This is the repository for the TransitMatters Data Dashboard. Client code is wri
 1. Configure AWS CLI 1.x or 2.x with your AWS access key ID and secret under the profile name `transitmatters`.
 2. Configure shell environment variables for AWS ACM domain certificates.
    - `TM_FRONTEND_CERT_ARN`
-   - `TM_FRONTEND_CERT_ARN_BETA`
-   - `TM_BACKEND_CERT_ARN`
-   - `TM_BACKEND_CERT_ARN_BETA`
+   - `TM_LABS_WILDCARD_CERT_ARN`
    - (You may also need to set `AWS_DEFAULT_REGION` in your shell to `us-east-1`. Maybe not! We're not sure.)
 3. Execute `$ ./deploy.sh` (for beta) or `$ ./deploy.sh -p` (for production). If deploying from a CI platform (such as GitHub Actions) you may also want to include the `-c` flag.
 


### PR DESCRIPTION
## Motivation

Readme is out of date with the update from https://transitmatters.slack.com/archives/GSJ6F35DW/p1687385820382579

## Changes

Update README and github action.

## Testing Instructions

Should be good if the deploy succeeds.
