### PR TITLE
[v3] hide secrets in healthcheck output

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -49,7 +49,10 @@ def healthcheck():
             if not check_bool:
                 failed_checks[check] = "Check failed :("
         except Exception as e:
-            failed_checks[check] = f"Check threw an exception: {e}"
+            e_str = str(e)
+            for secret in secrets.HEALTHCHECK_HIDE_SECRETS:
+                e_str.replace(secret, "HIDDEN")
+            failed_checks[check] = f"Check threw an exception: {e_str}"
 
     if len(failed_checks) == 0:
         return Response(body={

--- a/server/chalicelib/secrets.py
+++ b/server/chalicelib/secrets.py
@@ -2,3 +2,8 @@ import os
 
 MBTA_V2_API_KEY = os.environ.get("MBTA_V2_API_KEY", "")
 MBTA_V3_API_KEY = os.environ.get("MBTA_V3_API_KEY", "")
+
+HEALTHCHECK_HIDE_SECRETS = [
+    MBTA_V2_API_KEY,
+    MBTA_V3_API_KEY
+]


### PR DESCRIPTION
## Motivation

Exceptions can contain outbound http request URLs, which can expose API keys.

## Changes

- Hide keys from public healthcheck output

## Testing Instructions

1. Change the API key environment variable to an invalid value, causing the healthcheck to fail
2. The healthcheck output should contain the string `HIDDEN`.
