### PR TITLE
feat: add dates to single day trips page

### DIFF
--- a/modules/dashboard/WidgetTitle.tsx
+++ b/modules/dashboard/WidgetTitle.tsx
@@ -25,7 +25,7 @@ export const WidgetTitle: React.FC<WidgetTitle> = ({
   const isMobile = !useBreakpoint('md');
   const { query } = useDelimitatedRoute();
   const date = getSelectedDates({
-    startDate: query.startDate,
+    startDate: query.startDate ? query.startDate : query.date,
     endDate: query.endDate,
     view: query.view,
   });


### PR DESCRIPTION
## Motivation
Closes #694 
<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes
- For single day trips, we don't have a `startDate`, so we need to check `date` as well.
![Screen Shot 2023-06-24 at 11 34 45 AM](https://github.com/transitmatters/t-performance-dash/assets/1361408/43bcd869-c4c7-4495-801c-3a23bf2cbcca)

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
