### PR TITLE
rounding bug

### DIFF
--- a/common/utils/time.tsx
+++ b/common/utils/time.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import type { DurationUnitType } from 'dayjs/plugin/duration';
 import { WidgetText } from '../components/widgets/internal/WidgetText';
 import { UnitText } from '../components/widgets/internal/UnitText';
 
@@ -46,28 +45,16 @@ export const getFormattedTimeValue = (value: number) => {
   }
 };
 
-export const getFormattedTimeString = (value: number, unit: DurationUnitType = 'seconds') => {
-  if (unit === 'seconds') {
-    const absValue = Math.round(Math.abs(value));
-    const duration = dayjs.duration(absValue, unit);
-    switch (true) {
-      case absValue < 100:
-        return `${absValue}s`;
-      case absValue < 3600:
-        return `${duration.format('m')}m ${duration.format('s').padStart(2, '0')}s`;
-      default:
-        return `${duration.format('H')}h ${duration.format('m').padStart(2, '0')}m`;
-    }
-  } else if (unit === 'minutes') {
-    const absValue = Math.abs(value);
-    const duration = dayjs.duration(absValue, unit);
-    switch (true) {
-      case absValue < 1:
-        return `${duration.format('s')}s`;
-      case absValue < 60:
-        return `${duration.format('m')}m ${duration.format('s').padStart(2, '0')}s`;
-      default:
-        return `${duration.format('H')}h ${duration.format('m').padStart(2, '0')}m`;
-    }
+export const getFormattedTimeString = (value: number, unit: 'minutes' | 'seconds') => {
+  const secondsValue = unit === 'seconds' ? value : value * 60;
+  const absValue = Math.round(Math.abs(secondsValue));
+  const duration = dayjs.duration(absValue, 'seconds');
+  switch (true) {
+    case absValue < 100:
+      return `${absValue}s`;
+    case absValue < 3600:
+      return `${duration.format('m')}m ${duration.format('s').padStart(2, '0')}s`;
+    default:
+      return `${duration.format('H')}h ${duration.format('m').padStart(2, '0')}m`;
   }
 };

--- a/common/utils/time.tsx
+++ b/common/utils/time.tsx
@@ -45,7 +45,7 @@ export const getFormattedTimeValue = (value: number) => {
   }
 };
 
-export const getFormattedTimeString = (value: number, unit: 'minutes' | 'seconds') => {
+export const getFormattedTimeString = (value: number, unit: 'minutes' | 'seconds' = 'seconds') => {
   const secondsValue = unit === 'seconds' ? value : value * 60;
   const absValue = Math.round(Math.abs(secondsValue));
   const duration = dayjs.duration(absValue, 'seconds');


### PR DESCRIPTION
## Motivation

There was a rounding bug with the widgets compared to the tooltips.  Caused by widgets receiving values in seconds, and tooltips receiving values in minutes, then converting to seconds.

![Screenshot 2023-07-06 at 9 46 37 AM](https://github.com/transitmatters/t-performance-dash/assets/46229349/095b1e30-fb57-487a-a106-4a79ef56bd2a)

This converts them back to seconds before creating the tooltip, so it will match the widgets. I think the core issue is that we want to round up seconds, and dayjs.duration() does not do that. So we need to round the seconds before creating a duration.

Since the tooltips are just values in seconds divided by 60, we can just multiply by 60.

The more complicated, but more accurate solution would probably be to convert all the charts to take seconds as the values. But this is good enough IMO.
