### PR TITLE
Add bus date presets

### DIFF
--- a/common/components/inputs/DateSelection/DateSelection.tsx
+++ b/common/components/inputs/DateSelection/DateSelection.tsx
@@ -23,13 +23,13 @@ interface DateSelectionProps {
 }
 
 export const DateSelection: React.FC<DateSelectionProps> = ({ type = 'combo' }) => {
-  const { line, page } = useDelimitatedRoute();
+  const { line, page, tab } = useDelimitatedRoute();
   const [range, setRange] = useState<boolean>(false);
   const { dateStoreSection } = ALL_PAGES[page];
   const setDatePreset = useDatePresetStore((state) => state.setDatePreset);
   const datePreset = useSelectedPreset();
   const updateQueryParams = useUpdateQuery();
-  const presets = range ? RANGE_PRESETS : SINGLE_PRESETS;
+  const presets = range ? RANGE_PRESETS[tab] : SINGLE_PRESETS[tab];
   const presetDateArray = Object.values(presets);
 
   const handleSelection = (datePresetKey: DatePresetKey) => {

--- a/common/constants/dates.ts
+++ b/common/constants/dates.ts
@@ -35,6 +35,7 @@ const OVERVIEW_TRAIN_MIN_DATE = '2016-02-01';
 const TRAIN_MIN_DATE = '2016-01-15';
 const BUS_MIN_DATE = '2018-08-01';
 export const BUS_MAX_DATE = '2023-01-31';
+const BUS_MAX_DAY = dayjs(BUS_MAX_DATE);
 export const BUS_MAX_DATE_MINUS_ONE_WEEK = dayjs(BUS_MAX_DATE)
   .subtract(7, 'days')
   .format(DATE_FORMAT);
@@ -68,7 +69,7 @@ export const FLAT_PICKER_OPTIONS: {
   },
 };
 
-export const SINGLE_PRESETS: {
+const SINGLE_RAPID_PRESETS: {
   [key in DatePresetKey]?: DateSelectionDefaultOptions<SingleDateParams>;
 } = {
   today: { key: 'today', name: 'Today', input: { date: TODAY_STRING } },
@@ -100,8 +101,48 @@ export const SINGLE_PRESETS: {
   },
 };
 
-// TODO Different presets for buses
-export const RANGE_PRESETS: { [key in DatePresetKey]?: DateSelectionDefaultOptions<DateParams> } = {
+const SINGLE_BUS_PRESETS: {
+  [key in DatePresetKey]?: DateSelectionDefaultOptions<SingleDateParams>;
+} = {
+  mostRecent: {
+    key: 'mostRecent',
+    name: `${BUS_MAX_DAY.format(PRETTY_DATE_FORMAT)}`,
+    input: { date: BUS_MAX_DATE },
+  },
+  firstOfMonth: {
+    key: 'firstOfMonth',
+    name: `${BUS_MAX_DAY.startOf('month').format(PRETTY_DATE_FORMAT)}`,
+    input: {
+      date: BUS_MAX_DAY.startOf('month').format(DATE_FORMAT),
+    },
+  },
+  firstOfYear: {
+    key: 'firstOfYear',
+    name: `First of ${BUS_MAX_DAY.startOf('year').format('YYYY')}`,
+    input: {
+      date: BUS_MAX_DAY.startOf('month').format(DATE_FORMAT),
+    },
+  },
+  firstOfPrevYear: {
+    key: 'firstOfPrevYear',
+    name: `First of ${BUS_MAX_DAY.subtract(1, 'year').startOf('year').format('YYYY')}`,
+    input: {
+      date: BUS_MAX_DAY.subtract(1, 'year').startOf('year').format(DATE_FORMAT),
+    },
+  },
+};
+
+export const SINGLE_PRESETS: {
+  [key in Tab]: { [key in DatePresetKey]?: DateSelectionDefaultOptions<SingleDateParams> };
+} = {
+  Subway: SINGLE_RAPID_PRESETS,
+  Bus: SINGLE_BUS_PRESETS,
+  System: SINGLE_RAPID_PRESETS,
+};
+
+const RANGE_RAPID_PRESETS: {
+  [key in DatePresetKey]?: DateSelectionDefaultOptions<DateParams>;
+} = {
   week: {
     key: 'week',
     name: 'Past week',
@@ -112,7 +153,6 @@ export const RANGE_PRESETS: { [key in DatePresetKey]?: DateSelectionDefaultOptio
   },
   month: {
     key: 'month',
-
     name: 'Past month',
     input: {
       startDate: TODAY.subtract(31, 'days').format(DATE_FORMAT),
@@ -121,7 +161,6 @@ export const RANGE_PRESETS: { [key in DatePresetKey]?: DateSelectionDefaultOptio
   },
   thisMonth: {
     key: 'thisMonth',
-
     name: TODAY.format('MMMM YYYY'),
     input: {
       startDate: TODAY.startOf('month').format(DATE_FORMAT),
@@ -130,7 +169,6 @@ export const RANGE_PRESETS: { [key in DatePresetKey]?: DateSelectionDefaultOptio
   },
   lastMonth: {
     key: 'lastMonth',
-
     name: TODAY.subtract(1, 'month').format('MMMM YYYY'),
     input: {
       startDate: TODAY.subtract(1, 'month').startOf('month').format(DATE_FORMAT),
@@ -161,7 +199,6 @@ export const RANGE_PRESETS: { [key in DatePresetKey]?: DateSelectionDefaultOptio
       endDate: TODAY.endOf('year').subtract(1, 'year').format(DATE_FORMAT),
     },
   },
-
   all: {
     key: 'all',
     name: 'All time',
@@ -172,16 +209,73 @@ export const RANGE_PRESETS: { [key in DatePresetKey]?: DateSelectionDefaultOptio
   },
 };
 
+const RANGE_BUS_PRESETS: {
+  [key in DatePresetKey]?: DateSelectionDefaultOptions<DateParams>;
+} = {
+  thisMonth: {
+    key: 'thisMonth',
+    name: BUS_MAX_DAY.format('MMMM YYYY'),
+    input: {
+      startDate: BUS_MAX_DAY.startOf('month').format(DATE_FORMAT),
+      endDate: BUS_MAX_DATE,
+    },
+  },
+  lastMonth: {
+    key: 'lastMonth',
+    name: BUS_MAX_DAY.subtract(1, 'month').format('MMMM YYYY'),
+    input: {
+      startDate: BUS_MAX_DAY.subtract(1, 'month').startOf('month').format(DATE_FORMAT),
+      endDate: BUS_MAX_DAY.subtract(1, 'month').endOf('month').format(DATE_FORMAT),
+    },
+  },
+  thisYear: {
+    key: 'thisYear',
+    name: BUS_MAX_DAY.format('YYYY'),
+    input: {
+      startDate: BUS_MAX_DAY.startOf('year').format(DATE_FORMAT),
+      endDate: BUS_MAX_DATE,
+    },
+  },
+  lastYear: {
+    key: 'lastYear',
+    name: BUS_MAX_DAY.subtract(1, 'year').format('YYYY'),
+    input: {
+      startDate: BUS_MAX_DAY.startOf('year').subtract(1, 'year').format(DATE_FORMAT),
+      endDate: BUS_MAX_DAY.endOf('year').subtract(1, 'year').format(DATE_FORMAT),
+    },
+  },
+  all: {
+    key: 'all',
+    name: 'All time',
+    input: {
+      startDate: dayjs(BUS_MIN_DATE).format(DATE_FORMAT),
+      endDate: BUS_MAX_DATE,
+    },
+  },
+};
+
+export const RANGE_PRESETS: {
+  [key in Tab]: { [key in DatePresetKey]?: DateSelectionDefaultOptions<DateParams> };
+} = {
+  Subway: RANGE_RAPID_PRESETS,
+  Bus: RANGE_BUS_PRESETS,
+  System: RANGE_RAPID_PRESETS,
+};
+
 export type DatePresetKey =
   | OverviewDatePresetKey
   | 'today'
+  | 'mostRecent'
   | 'lastYear'
   | 'thisYear'
   | 'lastMonth'
   | 'thisMonth'
+  | 'firstOfMonth'
+  | 'firstOfYear'
+  | 'firstOfPrevYear'
   | 'yesterday';
 
-export type AggregationTypes = 'daily' | 'weekly' | 'monthly';
+type AggregationTypes = 'daily' | 'weekly' | 'monthly';
 
 // TODO: can probably consolidate this with the RANGE_PRESETS object.
 export const OVERVIEW_OPTIONS: {
@@ -216,13 +310,14 @@ export enum OverviewRangeTypes {
 }
 
 export const RANGE_DATE_KEYS = Object.fromEntries(
-  Object.values(RANGE_PRESETS).map((rangePreset) => [
-    `${rangePreset.input.startDate}${rangePreset.input.endDate}`,
-    rangePreset.key,
-  ])
+  [...Object.values(RANGE_RAPID_PRESETS), ...Object.values(RANGE_BUS_PRESETS)].map(
+    (rangePreset) => [`${rangePreset.input.startDate}${rangePreset.input.endDate}`, rangePreset.key]
+  )
 );
 export const SINGLE_DATE_KEYS = Object.fromEntries(
-  Object.values(SINGLE_PRESETS).map((singlePreset) => [singlePreset.input.date, singlePreset.key])
+  [...Object.values(SINGLE_RAPID_PRESETS), ...Object.values(SINGLE_BUS_PRESETS)].map(
+    (singlePreset) => [singlePreset.input.date, singlePreset.key]
+  )
 );
 
 export const todayOrDate = (date: dayjs.Dayjs) => {


### PR DESCRIPTION
## Motivation

The rapid presets don't make sense for bus data #717 

I'm not 100% happy with these, but they're better than what we had before

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

<img width="287" alt="Screenshot 2023-07-06 at 9 06 16 PM" src="https://github.com/transitmatters/t-performance-dash/assets/9310513/8581c55a-05bf-4e50-aad3-cee8912a955a">
<img width="357" alt="Screenshot 2023-07-06 at 9 06 25 PM" src="https://github.com/transitmatters/t-performance-dash/assets/9310513/30aa01a7-ab75-40f1-ada4-581080b76920">


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
