### PR TITLE
Fixes back navigation to account for date changes

### DIFF
--- a/common/components/inputs/DateSelection/DatePickers.tsx
+++ b/common/components/inputs/DateSelection/DatePickers.tsx
@@ -40,12 +40,12 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
 
   const handleRangeToggle = () => {
     if (range) {
-      updateQueryParams({ startDate: startDate }, !range);
+      updateQueryParams({ startDate: startDate }, !range, false);
     } else if (startDate === TODAY_STRING) {
       // If start date is today -> set range to past week. This prevents bugs with startDate === endDate
-      updateQueryParams(RANGE_PRESETS[0].input, !range);
+      updateQueryParams(RANGE_PRESETS[0].input, !range, false);
     } else {
-      updateQueryParams({ startDate: startDate }, !range);
+      updateQueryParams({ startDate: startDate }, !range, false);
     }
     setRange(!range);
   };
@@ -58,9 +58,9 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
     }
     if (updatedDate.isBefore(startDateObject)) {
       // Swap start and end if new end < startDate
-      updateQueryParams({ startDate: newDate, endDate: startDate }, range);
+      updateQueryParams({ startDate: newDate, endDate: startDate }, range, false);
     } else {
-      updateQueryParams({ startDate: startDate, endDate: newDate }, range);
+      updateQueryParams({ startDate: startDate, endDate: newDate }, range, false);
     }
     clearPreset();
   };
@@ -73,15 +73,15 @@ export const DatePickers: React.FC<DatePickerProps> = ({ range, setRange, type, 
     }
     if (updatedDate.isAfter(endDateObject)) {
       // Swap start and end if new start > endDate
-      updateQueryParams({ startDate: endDate, endDate: newDate }, range);
+      updateQueryParams({ startDate: endDate, endDate: newDate }, range, false);
     } else {
-      updateQueryParams({ startDate: newDate, endDate: endDate }, range);
+      updateQueryParams({ startDate: newDate, endDate: endDate }, range, false);
     }
     clearPreset();
   };
 
   const handleDateChange = (newDate: string) => {
-    updateQueryParams({ date: newDate }, false);
+    updateQueryParams({ date: newDate }, false, false);
     clearPreset();
   };
 

--- a/common/components/inputs/DateSelection/DateSelection.tsx
+++ b/common/components/inputs/DateSelection/DateSelection.tsx
@@ -34,7 +34,7 @@ export const DateSelection: React.FC<DateSelectionProps> = ({ type = 'combo' }) 
 
   const handleSelection = (datePresetKey: DatePresetKey) => {
     const selectedPreset = presets[datePresetKey];
-    if (selectedPreset?.input) updateQueryParams(selectedPreset.input, range);
+    if (selectedPreset?.input) updateQueryParams(selectedPreset.input, range, false);
     setDatePreset(datePresetKey, dateStoreSection, range);
   };
 

--- a/common/components/inputs/DateSelection/DateSelection.tsx
+++ b/common/components/inputs/DateSelection/DateSelection.tsx
@@ -12,7 +12,7 @@ import { useDelimitatedRoute, useUpdateQuery } from '../../../utils/router';
 import type { DatePresetKey } from '../../../constants/dates';
 import { RANGE_PRESETS, SINGLE_PRESETS } from '../../../constants/dates';
 import { useDatePresetStore } from '../../../state/datePresetStore';
-import { useSelectedPreset } from '../../../state/utils/datePresetUtils';
+import { checkForPreset, useSelectedPreset } from '../../../state/utils/datePresetUtils';
 import { ALL_PAGES } from '../../../constants/pages';
 import { DatePickers } from './DatePickers';
 import { DatePickerPresets } from './DatePickerPresets';
@@ -23,7 +23,7 @@ interface DateSelectionProps {
 }
 
 export const DateSelection: React.FC<DateSelectionProps> = ({ type = 'combo' }) => {
-  const { line, page, tab } = useDelimitatedRoute();
+  const { line, page, tab, query } = useDelimitatedRoute();
   const [range, setRange] = useState<boolean>(false);
   const { dateStoreSection } = ALL_PAGES[page];
   const setDatePreset = useDatePresetStore((state) => state.setDatePreset);
@@ -45,6 +45,12 @@ export const DateSelection: React.FC<DateSelectionProps> = ({ type = 'combo' }) 
   const clearPreset = () => {
     setDatePreset('custom', dateStoreSection, range);
   };
+
+  useEffect(() => {
+    if (checkForPreset(query) !== datePreset) {
+      setDatePreset(checkForPreset(query), dateStoreSection, range);
+    }
+  }, [datePreset, dateStoreSection, query, range, setDatePreset]);
 
   return (
     <div

--- a/common/components/widgets/StationSelectorWidget.tsx
+++ b/common/components/widgets/StationSelectorWidget.tsx
@@ -37,18 +37,26 @@ export const StationSelectorWidget: React.FC<StationSelectorWidgetProps> = ({ li
   const updateStations = (action: 'to' | 'from' | 'swap', stationId?: Station) => {
     switch (action) {
       case 'to':
-        updateQueryParams({
-          to: stopIdsForStations(fromStation, stationId).toStopIds?.[0],
-        });
+        updateQueryParams(
+          {
+            to: stopIdsForStations(fromStation, stationId).toStopIds?.[0],
+          },
+          undefined,
+          false
+        );
         break;
       case 'from':
-        updateQueryParams({
-          from: stopIdsForStations(stationId, toStation).fromStopIds?.[0],
-        });
+        updateQueryParams(
+          {
+            from: stopIdsForStations(stationId, toStation).fromStopIds?.[0],
+          },
+          undefined,
+          false
+        );
         break;
       case 'swap': {
         const { fromStopIds, toStopIds } = stopIdsForStations(fromStation, toStation);
-        updateQueryParams({ from: toStopIds?.[0], to: fromStopIds?.[0] });
+        updateQueryParams({ from: toStopIds?.[0], to: fromStopIds?.[0] }, undefined, false);
         break;
       }
     }

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -87,7 +87,7 @@ export const useUpdateQuery = () => {
   const router = useRouter();
 
   const updateQueryParams = useCallback(
-    (newQueryParams: QueryParams, range?: boolean) => {
+    (newQueryParams: QueryParams, range?: boolean, replace = true) => {
       if (!newQueryParams) return;
       if (!router.isReady) return;
 
@@ -125,7 +125,11 @@ export const useUpdateQuery = () => {
 
       if (!isEqual(router.query, newQuery)) {
         const query = pickBy(newQuery, (attr) => attr !== undefined);
-        router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
+        if (replace) {
+          router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
+        } else {
+          router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+        }
       }
     },
     [router]


### PR DESCRIPTION
## Motivation

#712

## Changes

- Handles default loading values to not pollute history, but preserves date changes done by the user in the history

## Testing Instructions

Visit pages, hit back, make sure things feel natural and you can actually go back