### PR TITLE
small change

### DIFF
--- a/modules/slowzones/charts/TotalSlowTime.tsx
+++ b/modules/slowzones/charts/TotalSlowTime.tsx
@@ -43,45 +43,45 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({
   const isMobile = !useBreakpoint('md');
   const labels = data.map((item) => dayjs.utc(item.date).format('YYYY-MM-DD'));
   const unit = getTimeUnitSlowzones(startDateUTC, endDateUTC);
+  const isLinePage = line !== undefined && lineShort !== undefined;
 
-  const datasets =
-    line !== undefined && lineShort !== undefined
-      ? [
-          {
-            label: `${lineShort} Line`,
-            data: data?.map((d) => (d[lineShort] / 60).toFixed(2)),
-            borderColor: LINE_COLORS[line],
-            backgroundColor: LINE_COLORS[line],
-            pointRadius: 0,
-            tension: 0.1,
-          },
-        ]
-      : [
-          {
-            label: `Red Line`,
-            data: data?.map((d) => (d['Red'] / 60).toFixed(2)),
-            borderColor: LINE_COLORS['line-red'],
-            backgroundColor: LINE_COLORS['line-red'],
-            pointRadius: 0,
-            tension: 0.1,
-          },
-          {
-            label: `Orange Line`,
-            data: data?.map((d) => (d['Orange'] / 60).toFixed(2)),
-            borderColor: LINE_COLORS['line-orange'],
-            backgroundColor: LINE_COLORS['line-orange'],
-            pointRadius: 0,
-            tension: 0.1,
-          },
-          {
-            label: `Blue Line`,
-            data: data?.map((d) => (d['Blue'] / 60).toFixed(2)),
-            borderColor: LINE_COLORS['line-blue'],
-            backgroundColor: LINE_COLORS['line-blue'],
-            pointRadius: 0,
-            tension: 0.1,
-          },
-        ];
+  const datasets = isLinePage
+    ? [
+        {
+          label: `${lineShort} Line`,
+          data: data?.map((d) => (d[lineShort] / 60).toFixed(2)),
+          borderColor: LINE_COLORS[line],
+          backgroundColor: LINE_COLORS[line],
+          pointRadius: 0,
+          tension: 0.1,
+        },
+      ]
+    : [
+        {
+          label: `Red Line`,
+          data: data?.map((d) => (d['Red'] / 60).toFixed(2)),
+          borderColor: LINE_COLORS['line-red'],
+          backgroundColor: LINE_COLORS['line-red'],
+          pointRadius: 0,
+          tension: 0.1,
+        },
+        {
+          label: `Orange Line`,
+          data: data?.map((d) => (d['Orange'] / 60).toFixed(2)),
+          borderColor: LINE_COLORS['line-orange'],
+          backgroundColor: LINE_COLORS['line-orange'],
+          pointRadius: 0,
+          tension: 0.1,
+        },
+        {
+          label: `Blue Line`,
+          data: data?.map((d) => (d['Blue'] / 60).toFixed(2)),
+          borderColor: LINE_COLORS['line-blue'],
+          backgroundColor: LINE_COLORS['line-blue'],
+          pointRadius: 0,
+          tension: 0.1,
+        },
+      ];
   return (
     <ChartBorder>
       <ChartDiv isMobile={isMobile}>
@@ -154,10 +154,9 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({
                     return `${tooltipItems[0].label.split(',').slice(0, 2).join(',')}`;
                   },
                   label: (tooltipItem) => {
-                    return `${tooltipItem.dataset.label} Total Slow Time: ${getFormattedTimeString(
-                      tooltipItem.parsed.y,
-                      'minutes'
-                    )}`;
+                    return `${
+                      !isLinePage ? `${tooltipItem.dataset.label} slow time:` : 'Total slow time: '
+                    } ${getFormattedTimeString(tooltipItem.parsed.y, 'minutes')}`;
                   },
                 },
               },


### PR DESCRIPTION
## Motivation

Match the casing to chart title. (Total Slow Time -> Total slow time)
Remove line name when on line page.


## Changes


<img width="1118" alt="Screenshot 2023-07-07 at 4 11 43 PM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/49607e3e-7355-4691-b2ed-8ce2a7e1166d">

<img width="1076" alt="Screenshot 2023-07-07 at 4 11 08 PM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/49253065-3afd-476f-8b1d-22b0eaf70b84">

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
