### PR TITLE
feat: add travel time copy

### DIFF
--- a/modules/dashboard/WidgetTitle.tsx
+++ b/modules/dashboard/WidgetTitle.tsx
@@ -43,7 +43,7 @@ export const WidgetTitle: React.FC<WidgetTitle> = ({
           </h2>
           {isMobile && <p className="text-xs italic text-stone-700">{date}</p>}
         </div>
-        {subtitle && !isMobile && (
+        {subtitle && (
           <h2
             className={classNames('whitespace-nowrap text-sm italic leading-tight text-stone-600')}
           >

--- a/modules/dashboard/WidgetTitle.tsx
+++ b/modules/dashboard/WidgetTitle.tsx
@@ -43,7 +43,7 @@ export const WidgetTitle: React.FC<WidgetTitle> = ({
           </h2>
           {isMobile && <p className="text-xs italic text-stone-700">{date}</p>}
         </div>
-        {subtitle && (
+        {subtitle && !isMobile && (
           <h2
             className={classNames('whitespace-nowrap text-sm italic leading-tight text-stone-600')}
           >

--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -48,7 +48,13 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
       {aggregate ? (
         <>
           <WidgetDiv>
-            <WidgetTitle title="Travel times" location={location} line={line} both />
+            <WidgetTitle
+              title="Travel times"
+              subtitle="Time between stops"
+              location={location}
+              line={line}
+              both
+            />
             <TravelTimesAggregateWrapper
               query={traveltimes}
               fromStation={fromStation}
@@ -108,7 +114,13 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
       ) : (
         <>
           <WidgetDiv>
-            <WidgetTitle title="Travel times" location={location} line={line} both />
+            <WidgetTitle
+              title="Travel times"
+              subtitle="Time between stops"
+              location={location}
+              line={line}
+              both
+            />
             <TravelTimesSingleWrapper
               query={traveltimes}
               toStation={toStation}


### PR DESCRIPTION
## Motivation
- Noticed the travel time widget didn't have a subtitle and it looked a little off next to the other widgets that do.

## Changes
- Adds travel time subtitle

| Before | After|
| ------------- | ------------- |
| ![Screen Shot 2023-07-09 at 3 29 25 PM](https://github.com/transitmatters/t-performance-dash/assets/1361408/96a51bd1-7855-4e2e-beeb-c74d965b5565) | ![Screen Shot 2023-07-09 at 3 28 08 PM](https://github.com/transitmatters/t-performance-dash/assets/1361408/7d111449-382a-4a29-b6b1-2e3c4f64e4ed) |



<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
