### PR TITLE
Landing page breakpoint for smaller screens

### DIFF
--- a/modules/landing/LineButton.tsx
+++ b/modules/landing/LineButton.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import type { Line } from '../../common/types/lines';
 import { lineColorBackground, lineColorBorder } from '../../common/styles/general';
 import { LINE_OBJECTS } from '../../common/constants/lines';
+import { useBreakpoint } from '../../common/hooks/useBreakpoint';
 interface LineButtonProps {
   children: React.ReactNode;
   line: Line;
@@ -11,6 +12,8 @@ interface LineButtonProps {
 
 export const LineButton: React.FC<LineButtonProps> = ({ children, line }) => {
   const lineObject = LINE_OBJECTS[line];
+  const lgBreakpoint = useBreakpoint('lg');
+
   return (
     <Link
       href={`/${lineObject.path}`}
@@ -20,7 +23,8 @@ export const LineButton: React.FC<LineButtonProps> = ({ children, line }) => {
         className={classNames(
           lineColorBorder[line],
           lineColorBackground[line],
-          'flex h-32 w-32 cursor-pointer items-center justify-center rounded-full border-2 bg-opacity-50 group-hover:bg-opacity-100'
+          lgBreakpoint ? 'h-32 w-32' : 'h-24 w-24',
+          'flex cursor-pointer items-center justify-center rounded-full border-2 bg-opacity-50 group-hover:bg-opacity-100'
         )}
       >
         {children}

--- a/modules/landing/LineSelectionLanding.tsx
+++ b/modules/landing/LineSelectionLanding.tsx
@@ -1,28 +1,46 @@
 import React from 'react';
 import { faBus, faTrainSubway, faTrainTram } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classNames from 'classnames';
+import { useBreakpoint } from '../../common/hooks/useBreakpoint';
 import { LineButton } from './LineButton';
 
 export const LineSelectionLanding: React.FC = () => {
+  const lgBreakpoint = useBreakpoint('lg');
   return (
     <div className="flex w-full flex-col items-start px-4 pt-20 text-stone-900 md:items-center md:pt-32">
       <h2 className="text-5xl font-thin xl:text-7xl">Ready to learn more?</h2>
       <h3 className="text-lg font-thin">Select a subway line or bus route to get started.</h3>
       <div className="flex w-full flex-col gap-y-8 pt-12 md:flex-row md:justify-around">
         <LineButton line="line-red">
-          <FontAwesomeIcon icon={faTrainSubway} className="h-20 w-20 text-white" />
+          <FontAwesomeIcon
+            icon={faTrainSubway}
+            className={classNames(lgBreakpoint ? 'h-20 w-20' : 'h-16 w-16', 'text-white')}
+          />
         </LineButton>
         <LineButton line="line-orange">
-          <FontAwesomeIcon icon={faTrainSubway} className="h-20 w-20 text-white" />
+          <FontAwesomeIcon
+            icon={faTrainSubway}
+            className={classNames(lgBreakpoint ? 'h-20 w-20' : 'h-16 w-16', 'text-white')}
+          />
         </LineButton>
         <LineButton line="line-blue">
-          <FontAwesomeIcon icon={faTrainSubway} className="h-20 w-20 text-white" />
+          <FontAwesomeIcon
+            icon={faTrainSubway}
+            className={classNames(lgBreakpoint ? 'h-20 w-20' : 'h-16 w-16', 'text-white')}
+          />
         </LineButton>
         <LineButton line="line-green">
-          <FontAwesomeIcon icon={faTrainTram} className="h-20 w-20 text-white" />
+          <FontAwesomeIcon
+            icon={faTrainTram}
+            className={classNames(lgBreakpoint ? 'h-20 w-20' : 'h-16 w-16', 'text-white')}
+          />
         </LineButton>
         <LineButton line="line-bus">
-          <FontAwesomeIcon icon={faBus} className="h-20 w-20 text-white" />
+          <FontAwesomeIcon
+            icon={faBus}
+            className={classNames(lgBreakpoint ? 'h-20 w-20' : 'h-16 w-16', 'text-white')}
+          />
         </LineButton>
       </div>
     </div>


### PR DESCRIPTION
## Motivation

Closes #691 

## Changes

<img width="837" alt="Screenshot 2023-07-10 at 11 56 57 AM" src="https://github.com/transitmatters/t-performance-dash/assets/9310513/a6bb6dc6-127a-4d83-b0aa-13ce39c2939b">

Shrinks icons on screens smaller than `lg`

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
