### PR TITLE
bug with sz system chart

### DIFF
--- a/modules/slowzones/SystemSlowZonesDetails.tsx
+++ b/modules/slowzones/SystemSlowZonesDetails.tsx
@@ -51,14 +51,12 @@ export function SystemSlowZonesDetails({ showTitle = false }: SystemSlowZonesDet
           <WidgetTitle title="Total slow time" />
           <div className="relative flex flex-col">
             {totalSlowTimeReady ? (
-              <div className="relative flex h-60">
-                <TotalSlowTime
-                  data={delayTotals.data}
-                  startDateUTC={startDateUTC}
-                  endDateUTC={endDateUTC}
-                  showTitle={showTitle}
-                />
-              </div>
+              <TotalSlowTime
+                data={delayTotals.data}
+                startDateUTC={startDateUTC}
+                endDateUTC={endDateUTC}
+                showTitle={showTitle}
+              />
             ) : (
               <div className="relative flex h-full">
                 <ChartPlaceHolder query={delayTotals} />


### PR DESCRIPTION

## Motivation
The x axis labels were overlapping the border of the chart.
![Screenshot 2023-07-12 at 12 53 58 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/bb737a8d-2f68-4a54-a934-e9e044d51b97)

## Changes
Fixes this.

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
