### PR TITLE
add histogram back

### DIFF
--- a/common/constants/baselines.ts
+++ b/common/constants/baselines.ts
@@ -9,7 +9,7 @@ export const PEAK_SCHEDULED_SERVICE = {
 };
 
 export const PEAK_SPEED = {
-  'line-red': 21.4,
+  'line-red': 21.2,
   'line-orange': 18,
   'line-blue': 20.5,
   'line-green': 12.6,

--- a/modules/headways/HeadwaysDetails.tsx
+++ b/modules/headways/HeadwaysDetails.tsx
@@ -108,7 +108,7 @@ export function HeadwaysDetails() {
           />
 
           <HeadwaysHistogramWrapper
-            headways={headways}
+            query={headways}
             fromStation={fromStation}
             toStation={toStation}
           />

--- a/modules/headways/charts/HeadwaysHistogramWrapper.tsx
+++ b/modules/headways/charts/HeadwaysHistogramWrapper.tsx
@@ -6,19 +6,19 @@ import { ChartPlaceHolder } from '../../../common/components/graphics/ChartPlace
 import { HeadwaysHistogram } from './HeadwaysHistogram';
 
 interface HeadwaysHistogramWrapperProps {
-  headways: UseQueryResult<SingleDayDataPoint[]>;
+  query: UseQueryResult<SingleDayDataPoint[]>;
   toStation: Station | undefined;
   fromStation: Station | undefined;
 }
 
 export const HeadwaysHistogramWrapper: React.FC<HeadwaysHistogramWrapperProps> = ({
-  headways,
+  query,
   toStation,
   fromStation,
 }) => {
-  const dataReady = headways.data && toStation && fromStation;
-  if (!dataReady) return <ChartPlaceHolder query={headways} />;
+  const dataReady = query.data && toStation && fromStation;
+  if (!dataReady) return <ChartPlaceHolder query={query} />;
   return (
-    <HeadwaysHistogram headways={headways.data} fromStation={fromStation} toStation={toStation} />
+    <HeadwaysHistogram headways={query.data} fromStation={fromStation} toStation={toStation} />
   );
 };

--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -154,7 +154,7 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
           <WidgetDiv>
             <WidgetTitle
               title="Headway histogram"
-              subtitle="Time spent at station"
+              subtitle="Time between trains"
               location={location}
               line={line}
             />

--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -14,6 +14,7 @@ import { DwellsAggregateWrapper } from '../dwells/DwellsAggregateWrapper';
 import { TravelTimesSingleWrapper } from '../traveltimes/TravelTimesSingleWrapper';
 import { HeadwaysSingleWrapper } from '../headways/HeadwaysSingleWrapper';
 import { DwellsSingleWrapper } from '../dwells/DwellsSingleWrapper';
+import { HeadwaysHistogramWrapper } from '../headways/charts/HeadwaysHistogramWrapper';
 
 interface SubwayTripGraphsProps {
   fromStation: Station;
@@ -149,6 +150,19 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
               line={line}
             />
             <DwellsSingleWrapper query={dwells} toStation={toStation} fromStation={fromStation} />
+          </WidgetDiv>
+          <WidgetDiv>
+            <WidgetTitle
+              title="Headway histogram"
+              subtitle="Time spent at station"
+              location={location}
+              line={line}
+            />
+            <HeadwaysHistogramWrapper
+              query={headways}
+              toStation={toStation}
+              fromStation={fromStation}
+            />
           </WidgetDiv>
         </>
       )}

--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -153,7 +153,7 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
           </WidgetDiv>
           <WidgetDiv>
             <WidgetTitle
-              title="Headway histogram"
+              title="Headway distribution"
               subtitle="Time between trains"
               location={location}
               line={line}


### PR DESCRIPTION
## Motivation

Forgot to add the headways histogram back.


## Changes

Adds headways histogram back.
Removing the grid in #748 which makes the whitespace at the botom go away.
![Screenshot 2023-07-12 at 12 52 53 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/a6bc16b1-d3bf-43d3-9557-f5a699c0700e)

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
