### PR TITLE
Only show full weeks on landing

### DIFF
--- a/common/api/hooks/ridership.ts
+++ b/common/api/hooks/ridership.ts
@@ -4,7 +4,7 @@ import { fetchRidership } from '../ridership';
 import { ONE_HOUR } from '../../constants/time';
 import type { Line } from '../../types/lines';
 import { RIDERSHIP_KEYS } from '../../types/lines';
-import { THREE_MONTHS_AGO_STRING, TODAY_STRING } from '../../constants/dates';
+import { ONE_WEEK_AGO_STRING, THREE_MONTHS_AGO_STRING } from '../../constants/dates';
 
 export const useRidershipData = (params: FetchRidershipOptions, enabled?: boolean) => {
   return useQuery(['trips', params], () => fetchRidership(params), {
@@ -19,7 +19,7 @@ export const useRidershipDataLanding = (lines: Line[]) => {
       const params: FetchRidershipOptions = {
         line_id: RIDERSHIP_KEYS[line],
         start_date: THREE_MONTHS_AGO_STRING,
-        end_date: TODAY_STRING,
+        end_date: ONE_WEEK_AGO_STRING,
       };
       return {
         queryKey: [`${line}-ridership`],

--- a/common/api/hooks/tripmetrics.ts
+++ b/common/api/hooks/tripmetrics.ts
@@ -1,7 +1,7 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
 import type { FetchDeliveredTripMetricsOptions } from '../../types/api';
 import { FIVE_MINUTES, ONE_HOUR } from '../../constants/time';
-import { THREE_MONTHS_AGO_STRING, TODAY_STRING } from '../../constants/dates';
+import { ONE_WEEK_AGO_STRING, THREE_MONTHS_AGO_STRING } from '../../constants/dates';
 import { LANDING_RAIL_LINES } from '../../types/lines';
 import { fetchActualTripsByLine } from '../tripmetrics';
 
@@ -21,7 +21,7 @@ export const useTripMetricsForLanding = () => {
       const params: FetchDeliveredTripMetricsOptions = {
         line: line,
         start_date: THREE_MONTHS_AGO_STRING,
-        end_date: TODAY_STRING,
+        end_date: ONE_WEEK_AGO_STRING,
         agg: 'weekly',
       };
       return {


### PR DESCRIPTION
## Motivation

#705 


## Changes
Onlly show values for weeks which are completed on landing.
![Screenshot 2023-07-12 at 3 35 27 PM](https://github.com/transitmatters/t-performance-dash/assets/46229349/ee3a9954-8335-4d60-99c9-92cd1c1228f9)
