### PR TITLE
Widget fix

### DIFF
--- a/common/components/general/WidgetCarousel.tsx
+++ b/common/components/general/WidgetCarousel.tsx
@@ -2,7 +2,7 @@ import React, { Children, cloneElement, useCallback, useMemo, useState } from 'r
 import classNames from 'classnames';
 import type { ComponentProps, FC, ReactElement } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronCircleLeft, faChevronCircleRight } from '@fortawesome/free-solid-svg-icons';
+import { faChevronCircleLeft } from '@fortawesome/free-solid-svg-icons';
 
 interface WidgetCarouselProps {
   children: React.ReactNode;

--- a/common/components/general/WidgetCarousel.tsx
+++ b/common/components/general/WidgetCarousel.tsx
@@ -2,7 +2,7 @@ import React, { Children, cloneElement, useCallback, useMemo, useState } from 'r
 import classNames from 'classnames';
 import type { ComponentProps, FC, ReactElement } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronCircleDown } from '@fortawesome/free-solid-svg-icons';
+import { faChevronCircleLeft, faChevronCircleRight } from '@fortawesome/free-solid-svg-icons';
 
 interface WidgetCarouselProps {
   children: React.ReactNode;
@@ -39,7 +39,7 @@ export const WidgetCarousel: FC<WidgetCarouselProps> = ({ children, isSingleWidg
   const isBeforeActiveItem = (item: number) =>
     item !== activeItem && (activeItem === 0 ? item === items.length - 1 : item + 1 === activeItem);
   return (
-    <div className="relative flex flex-row gap-1">
+    <div className="relative flex flex-row gap-2">
       <div className="flex items-center">
         {!isSingleWidget && (
           <button
@@ -51,14 +51,14 @@ export const WidgetCarousel: FC<WidgetCarouselProps> = ({ children, isSingleWidg
             type="button"
           >
             <FontAwesomeIcon
-              icon={faChevronCircleDown}
+              icon={faChevronCircleLeft}
               size="lg"
               className="text-stone-300 hover:text-stone-600"
             />
           </button>
         )}
       </div>
-      <div className="relative h-8 w-full overflow-hidden lg:h-[3.25rem] ">
+      <div className="relative h-[3.25rem] w-full overflow-hidden ">
         {items?.map((item, index) => (
           <div
             key={index}
@@ -67,8 +67,8 @@ export const WidgetCarousel: FC<WidgetCarouselProps> = ({ children, isSingleWidg
               {
                 hidden:
                   index !== activeItem && !isBeforeActiveItem(index) && !isAfterActiveItem(index),
-                '-translate-y-full opacity-0': isBeforeActiveItem(index),
-                'translate-y-full opacity-0': isAfterActiveItem(index),
+                '-translate-x-1/3 opacity-0': isBeforeActiveItem(index),
+                'translate-x-1/3 opacity-0': isAfterActiveItem(index),
               }
             )}
           >

--- a/common/components/widgets/internal/WidgetForCarousel.tsx
+++ b/common/components/widgets/internal/WidgetForCarousel.tsx
@@ -21,7 +21,7 @@ export const WidgetForCarousel: React.FC<WidgetForCarouselProps> = ({
   layoutKind = 'total-and-delta',
   sentimentDirection = 'negativeOnIncrease',
 }) => {
-  const isHorizontal = !useBreakpoint('lg');
+  const isHorizontal = false;
 
   if (isHorizontal)
     return (

--- a/common/components/widgets/internal/WidgetForCarousel.tsx
+++ b/common/components/widgets/internal/WidgetForCarousel.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import type { WidgetValueInterface } from '../../../types/basicWidgets';
 import { LoadingSpinner } from '../../graphics/LoadingSpinner';
-import { useBreakpoint } from '../../../hooks/useBreakpoint';
 import { Delta } from './Delta';
 
 type LayoutKind = 'total-and-delta' | 'delta-and-percent-change' | 'no-delta';

--- a/common/components/widgets/internal/WidgetForCarousel.tsx
+++ b/common/components/widgets/internal/WidgetForCarousel.tsx
@@ -20,33 +20,6 @@ export const WidgetForCarousel: React.FC<WidgetForCarouselProps> = ({
   layoutKind = 'total-and-delta',
   sentimentDirection = 'negativeOnIncrease',
 }) => {
-  const isHorizontal = false;
-
-  if (isHorizontal)
-    return (
-      <div className={classNames('relative flex w-full')}>
-        {widgetValue.value === undefined && <LoadingSpinner isWidget />}
-        <div className={classNames('flex flex-row items-baseline justify-between rounded-lg px-2')}>
-          <div className="flex flex-row items-baseline justify-end gap-4">
-            <div className="flex flex-row items-baseline gap-x-1">
-              {widgetValue.getFormattedValue()}
-            </div>
-            <div className="mt-1 flex flex-row items-baseline gap-x-1">
-              {layoutKind !== 'no-delta' && (
-                <Delta
-                  widgetValue={widgetValue}
-                  sentimentDirection={sentimentDirection}
-                  usePercentChange={layoutKind === 'delta-and-percent-change'}
-                />
-              )}
-              <p className={classNames('truncate text-xs text-design-subtitleGrey sm:text-sm')}>
-                {analysis}
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
   return (
     <div className="">
       <div className={classNames('relative flex')}>


### PR DESCRIPTION
## Motivation

There were a few people mentioning the widget slider button looked like a dropdown.


## Changes
Make the widgets move right to left rather than down. Still looks kinda wack, and I have a longer term plan to improve, but I think this is better for short term.

https://github.com/transitmatters/t-performance-dash/assets/46229349/51489508-8a51-4301-9c9c-c3635c5162aa


Make the widgets vertical on mobile and desktop. The horizontal was just way too cramped.
<img width="473" alt="Screenshot 2023-07-14 at 12 12 54 PM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/1e66036e-c59a-4758-afdc-971f15004ac2">

## Testing Instructions

Scroll through widgets