### PR TITLE
Remove v3 relic of 404s being a lie because of react router

### DIFF
--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -161,7 +161,7 @@
             {
               "ErrorCode": "404",
               "ResponsePagePath": "/404.html",
-              "ResponseCode": "200",
+              "ResponseCode": "404",
               "ErrorCachingMinTTL": "86400"
             }
           ],


### PR DESCRIPTION
## Motivation

V3 relied on React Router to handle different URLs, and that worked because S3 returned the SPA for any request path. Next is more of a good citizen, in that it's generating actual files that are being served by S3/CloudFront. For that reason, we want the status code for 404s to ACTUALLY BE 404! :) Finally!

## Changes

We're changing the 404 ResponseCode from 200 to 404. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-customerrorresponse.html

## Testing Instructions

Previous behavior:
```
prestonmueller@Preston14 ~ $ curl -sI https://dashboard-beta.labs.transitmatters.org/this_doesnt_exist | head -n 1
HTTP/1.1 200 OK
```

Behavior after this is merged (anticipated);
```
prestonmueller@Preston14 ~ $ curl -sI https://dashboard-beta.labs.transitmatters.org/this_doesnt_exist | head -n 1
HTTP/1.1 404
```
