### PR TITLE
fix: Render SZ segment labels properly in Safari

### DIFF
--- a/common/components/maps/LineMap.stories.tsx
+++ b/common/components/maps/LineMap.stories.tsx
@@ -26,7 +26,7 @@ const redLineSegments: SegmentRenderOptions[] = [
       {
         mapSide: '0',
         boundingSize: 40,
-        content: (
+        content: () => (
           <div style={{ fontSize: 4 }}>
             Greetings amigos thank you for inviting me into your SVG
           </div>
@@ -35,7 +35,7 @@ const redLineSegments: SegmentRenderOptions[] = [
       {
         mapSide: '1',
         boundingSize: 40,
-        content: (
+        content: () => (
           <div style={{ fontSize: 4 }}>And on this side too! I also like being on this side!</div>
         ),
       },

--- a/common/components/maps/LineMap.tsx
+++ b/common/components/maps/LineMap.tsx
@@ -24,7 +24,7 @@ export type SegmentLabel = {
   mapSide: MapSide;
   boundingSize?: number;
   offset?: { x: number; y: number };
-  content: React.ReactNode;
+  content: (size: { width: number; height: number }) => React.ReactNode;
 };
 
 export type SegmentRenderOptions = {
@@ -33,12 +33,12 @@ export type SegmentRenderOptions = {
   labels?: SegmentLabel[];
 };
 
-export type TooltipRenderer = (props: {
+type TooltipRenderer = (props: {
   segmentLocation: SegmentLocation<true>;
   isHorizontal: boolean;
 }) => React.ReactNode;
 
-export type TooltipOptions = {
+type TooltipOptions = {
   render: TooltipRenderer;
   snapToSegment?: boolean;
   maxDistance?: number;
@@ -64,7 +64,7 @@ const getPropsForStrokeOptions = (options: Partial<StrokeOptions>) => {
   };
 };
 
-const getLabelPositionProps = (
+const getSegmentLabelBounds = (
   segmentBounds: Rect,
   segmentLabel: SegmentLabel,
   isHorizontal: boolean
@@ -75,32 +75,19 @@ const getLabelPositionProps = (
   if (isHorizontal) {
     const moveAcross = mapSide === '0';
     return {
-      foreignObjectProps: {
-        x: top + offset.x,
-        y: 0 - left - (moveAcross ? boundingSize + width : 0) + offset.y,
-        width: height,
-        height: boundingSize,
-        style: { transform: 'rotate(90deg)' },
-      },
-      wrapperDivStyles: {
-        flexDirection: 'row',
-        alignItems: moveAcross ? 'flex-end' : 'flex-start',
-      },
+      x: top + offset.x,
+      y: 0 - left - (moveAcross ? boundingSize + width : 0) + offset.y,
+      width: height,
+      height: boundingSize,
     } as const;
   }
   const moveAcross = mapSide === '1';
   return {
-    foreignObjectProps: {
-      x: right - (moveAcross ? boundingSize + width : 0) + offset.x,
-      y: top + offset.y,
-      height,
-      width: boundingSize,
-    },
-    wrapperDivStyles: {
-      flexDirection: 'column',
-      alignItems: moveAcross ? 'flex-end' : 'flex-start',
-    },
-  } as const;
+    x: right - (moveAcross ? boundingSize + width : 0) + offset.x,
+    y: top + offset.y,
+    height,
+    width: boundingSize,
+  };
 };
 
 export const LineMap: React.FC<LineMapProps> = ({
@@ -173,27 +160,15 @@ export const LineMap: React.FC<LineMapProps> = ({
       });
 
       const computedLabels = labels.map((label, index) => {
-        const { foreignObjectProps, wrapperDivStyles } = getLabelPositionProps(
-          bounds,
-          label,
-          isHorizontal
-        );
+        const { x, y, width, height } = getSegmentLabelBounds(bounds, label, isHorizontal);
         return (
-          <foreignObject
+          <g
             key={`label-${fromStationId}-${toStationId}-${index}`}
-            {...foreignObjectProps}
+            transform={`translate(${x}, ${y})`}
           >
-            <div
-              style={{
-                width: '100%',
-                height: '100%',
-                display: 'flex',
-                ...wrapperDivStyles,
-              }}
-            >
-              {label.content}
-            </div>
-          </foreignObject>
+            <rect x={0} y={0} width={width} height={height} fill="transparent" />
+            {label.content({ width, height })}
+          </g>
         );
       });
 
@@ -263,7 +238,12 @@ export const LineMap: React.FC<LineMapProps> = ({
   };
 
   const renderComputedLabels = () => {
-    return computedSegmentExtras.map((segment) => segment.computedLabels).flat();
+    const transform = isHorizontal ? 'rotate(90)' : undefined;
+    return (
+      <g transform={transform}>
+        {computedSegmentExtras.map((segment) => segment.computedLabels).flat()}
+      </g>
+    );
   };
 
   const renderTooltip = () => {

--- a/common/components/maps/useDiagramCoordinates.ts
+++ b/common/components/maps/useDiagramCoordinates.ts
@@ -65,8 +65,8 @@ export const useDiagramCoordinates = (options: Options) => {
         const scaleBasis = getScaleBasis({ width: viewportWidth, height: viewportHeight });
         setSvgProps({
           viewBox: `${x} ${y} ${width} ${height}`,
-          width: width * scaleBasis,
-          height: height * scaleBasis,
+          width: Math.round(width * scaleBasis),
+          height: Math.round(height * scaleBasis),
         });
       }
     }

--- a/common/utils/time.tsx
+++ b/common/utils/time.tsx
@@ -61,3 +61,49 @@ export const getFormattedTimeString = (value: number, unit: 'minutes' | 'seconds
       return `${duration.format('H')}h ${duration.format('m').padStart(2, '0')}m`;
   }
 };
+
+interface GetClockFormattedTimeStringOptions {
+  truncateLeadingZeros?: boolean;
+  showSeconds?: boolean;
+  showHours?: boolean;
+  use12Hour?: boolean;
+}
+
+export const getClockFormattedTimeString = (
+  time: number,
+  options: GetClockFormattedTimeStringOptions = {}
+): string => {
+  time = Math.round(time);
+  const {
+    truncateLeadingZeros = true,
+    showSeconds = false,
+    showHours = true,
+    use12Hour = false,
+  } = options;
+  let seconds = time,
+    minutes = 0,
+    hours = 0;
+  const minutesToAdd = Math.floor(seconds / 60);
+  seconds = seconds % 60;
+  minutes = minutes += minutesToAdd;
+  const hoursToAdd = Math.floor(minutes / 60);
+  minutes = minutes % 60;
+  hours += hoursToAdd;
+  const isPM = hours >= 12 && hours < 24;
+  hours = (use12Hour && hours > 12 ? hours - 12 : hours) % 24;
+  // eslint-disable-next-line prefer-const
+  let [hoursString, minutesString, secondsString] = [hours, minutes, seconds].map((num) =>
+    num.toString().padStart(2, '0')
+  );
+  let timeString = [hoursString, minutesString, secondsString]
+    .slice(showHours ? 0 : 1)
+    .slice(0, showSeconds ? 3 : 2)
+    .join(':');
+  if (truncateLeadingZeros && timeString.startsWith('0')) {
+    timeString = timeString.slice(1);
+  }
+  if (use12Hour) {
+    return `${timeString} ${isPM ? 'PM' : 'AM'}`;
+  }
+  return timeString;
+};

--- a/modules/slowzones/map/DirectionIndicator.tsx
+++ b/modules/slowzones/map/DirectionIndicator.tsx
@@ -19,7 +19,7 @@ export const DirectionIndicator: React.FC<DirectionIndicatorProps> = ({
 }) => {
   const rotation = isHorizontal ? (direction === '1' ? 90 : 270) : direction === '1' ? 180 : 0;
   return (
-    <div
+    <span
       className={styles.directionIndicator}
       style={{
         borderTopColor: color,

--- a/modules/slowzones/map/SlowZonesMap.tsx
+++ b/modules/slowzones/map/SlowZonesMap.tsx
@@ -94,7 +94,14 @@ export const SlowZonesMap: React.FC<SlowZonesMapProps> = ({
             mapSide: '0' as const,
             boundingSize: isHorizontal ? 15 : 20,
             ...getSegmentLabelOverrides(segment.segmentLocation, isHorizontal),
-            content: <SlowSegmentLabel isHorizontal={isHorizontal} segment={segment} line={line} />,
+            content: (size) => (
+              <SlowSegmentLabel
+                isHorizontal={isHorizontal}
+                segment={segment}
+                line={line}
+                {...size}
+              />
+            ),
           },
         ],
         strokes: Object.entries(segment.slowZones).map(([direction, zones]) => {


### PR DESCRIPTION
## Motivation

The time labels for Slow Zones map segments were previously rendered with the `<foreignobject>` SVG element, which doesn't really work in Safari. This change renders them in pure SVG.

## Changes

SVG layout is pretty manual work and it was easiest to resort to Unicode characters for the directional arrows. I found that the ones that work best (i.e. have no weird subpixel glitches) are these chevron ones:

<img src="https://github.com/transitmatters/t-performance-dash/assets/2208769/4ed7a765-561d-496a-ad77-d7dd88f522bc" width="600"/>

On mobile, though, we'll get a slightly different arrow look:

<img src="https://github.com/transitmatters/t-performance-dash/assets/2208769/322fc125-141f-4900-825f-98d9afbd6664" height="500"/>


## Testing Instructions

Visit `/red/slowzones` in desktop/mobile Safari and check that these elements render properly.
