### PR TITLE
Add v3/v4 file trick to make it OK that V3 paths don't have trailing slashes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -106,6 +106,12 @@ aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STA
 popd > /dev/null
 aws s3 sync out/ s3://$FRONTEND_HOSTNAME
 
+# Band-aid the fact that v3 doesn't have trailing slashes on its path, but v4 does,
+#  so we need /THING to be a valid path in addition to the actual /THING/.
+aws s3 cp v3_to_v4_slash_trick/trick.html s3://$FRONTEND_HOSTNAME/rapidtransit --no-guess-mime-type --content-type="text/html"
+aws s3 cp v3_to_v4_slash_trick/trick.html s3://$FRONTEND_HOSTNAME/bus --no-guess-mime-type --content-type="text/html"
+aws s3 cp v3_to_v4_slash_trick/trick.html s3://$FRONTEND_HOSTNAME/slowzones --no-guess-mime-type --content-type="text/html"
+
 # Grab the cloudfront ID and invalidate its cache
 CLOUDFRONT_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items!=null] | [?contains(Aliases.Items, '$FRONTEND_HOSTNAME')].Id | [0]" --output text)
 aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/*"

--- a/v3_to_v4_slash_trick/trick.html
+++ b/v3_to_v4_slash_trick/trick.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <script>
+    window.location.pathname += "/";
+  </script>
+</head>
+
+</html>


### PR DESCRIPTION
## Motivation

Add v3/v4 file trick to make it OK that V3 paths don't have trailing slashes. Fixes #750 

## Changes
- Add HTML pages (with no extension, but they have a Content type set, so it's OK!) at /rapidtransit, /bus, and /slowzones that have the sole purpose of redirecting to the trailing slash equivalent.

## Testing Instructions

https://dashboard-beta.labs.transitmatters.org/rapidtransit?config=Red,70067,70071,2023-07-15,

should look the same as the v3 equiv:

https://dashboard.transitmatters.org/rapidtransit?config=Red,70067,70071,2023-07-15,
