### PR TITLE
V4 home page title adjustment

### DIFF
--- a/modules/landing/Landing.tsx
+++ b/modules/landing/Landing.tsx
@@ -18,7 +18,7 @@ export function Landing() {
   }, []);
 
   return (
-    <PageWrapper pageTitle="TransitMatters Dashboard">
+    <PageWrapper pageTitle="Home">
       <div
         className={classNames(
           isMobile && 'pb-32',


### PR DESCRIPTION
<img width="225" alt="image" src="https://github.com/transitmatters/t-performance-dash/assets/193453/fc590cbe-57b4-433c-b35b-062fcf07311d">
instead of
<img width="236" alt="image" src="https://github.com/transitmatters/t-performance-dash/assets/193453/c4efa043-61ca-4507-8e25-87cce7dc596a">
