### PR TITLE
Allow datadog to tell apart deploys

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -93,7 +93,8 @@ aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STA
     TMBackendHostname=$BACKEND_HOSTNAME \
     TMBackendZone=$BACKEND_ZONE \
     MbtaV2ApiKey=$MBTA_V2_API_KEY \
-    DDApiKey=$DD_API_KEY
+    DDApiKey=$DD_API_KEY \
+    GitId=$GIT_ID
 
 popd > /dev/null
 aws s3 sync out/ s3://$FRONTEND_HOSTNAME

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -39,6 +39,10 @@
     "DDApiKey": {
       "Type": "String",
       "Description": "Datadog API key."
+    },
+    "GitId": {
+      "Type": "String",
+      "Description": "Current Git Id"
     }
   },
   "Resources": {
@@ -83,7 +87,8 @@
         "Environment": {
           "Variables": {
             "MBTA_V2_API_KEY": { "Ref": "MbtaV2ApiKey" },
-            "DD_API_KEY": { "Ref": "DDApiKey" }
+            "DD_API_KEY": { "Ref": "DDApiKey" },
+            "DD_VERSION": { "Ref": "GitId" }
           }
         }
       }


### PR DESCRIPTION
## Motivation

Allow datadog to tell apart deploys
https://docs.datadoghq.com/tracing/services/deployment_tracking/

## Changes

- Adds git id to deployment env variables

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
