### PR TITLE
Show better git tagging in deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,8 +49,8 @@ else
 fi
 
 # Identify the version and commit of the current deploy
-GIT_ID=`git describe --always`
-echo "Deploying git commit id $GIT_ID to beta site"
+GIT_VERSION=`git describe --tags`
+echo "Deploying version $GIT_VERSION"
 
 BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
 FRONTEND_HOSTNAME=$FRONTEND_DOMAIN_PREFIX$FRONTEND_ZONE # Must match in .chalice/config.json!
@@ -87,7 +87,7 @@ aws cloudformation deploy --template-file cfn/packaged.yaml --stack-name $CF_STA
     TMBackendZone=$BACKEND_ZONE \
     MbtaV2ApiKey=$MBTA_V2_API_KEY \
     DDApiKey=$DD_API_KEY \
-    GitId=$GIT_ID
+    GitVersion=$GIT_VERSION
 
 popd > /dev/null
 aws s3 sync out/ s3://$FRONTEND_HOSTNAME

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,10 +52,10 @@ fi
 # If beta, identify build with dirty hash
 
 if $PRODUCTION; then
-    GIT_ID=`git describe --tags --abbrev=0`
+    GIT_ID=`git describe --tags`
     echo "Deploying git tag $GIT_ID to production site"
 else
-    GIT_ID=`git describe --always --dirty --abbrev=10`
+    GIT_ID=`git describe --always`
     echo "Deploying git commit id $GIT_ID to beta site"
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,16 +48,9 @@ else
     git fetch --tags
 fi
 
-# If production, identify build with latest git tag
-# If beta, identify build with dirty hash
-
-if $PRODUCTION; then
-    GIT_ID=`git describe --tags`
-    echo "Deploying git tag $GIT_ID to production site"
-else
-    GIT_ID=`git describe --always`
-    echo "Deploying git commit id $GIT_ID to beta site"
-fi
+# Identify the version and commit of the current deploy
+GIT_ID=`git describe --always`
+echo "Deploying git commit id $GIT_ID to beta site"
 
 BACKEND_BUCKET=datadashboard-backend$ENV_SUFFIX
 FRONTEND_HOSTNAME=$FRONTEND_DOMAIN_PREFIX$FRONTEND_ZONE # Must match in .chalice/config.json!

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -40,7 +40,7 @@
       "Type": "String",
       "Description": "Datadog API key."
     },
-    "GitId": {
+    "GitVersion": {
       "Type": "String",
       "Description": "Current Git Id"
     }
@@ -88,7 +88,7 @@
           "Variables": {
             "MBTA_V2_API_KEY": { "Ref": "MbtaV2ApiKey" },
             "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitId" }
+            "DD_VERSION": { "Ref": "GitVersion" }
           }
         }
       }


### PR DESCRIPTION
## Motivation

Have deployment tracking show a more accurate deploy id

This value is only used by Datadog to track deployed version. In v4 we don't currently show this in the UI (we can change that, but for now this isn't useful)

## Changes

Show a version like: `4.0-2-gbab466b2` or `4.0` when deploying a tagged commit

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
