### PR TITLE
Set API Gateway name to the backend hostname, for debugging ease

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,12 @@ while getopts "pc" opt; do
   esac
 done
 
+# Ensure required secrets are set
+if [[ -z "$MBTA_V2_API_KEY" || -z "$DD_API_KEY"  ]]; then
+    echo "Must provide MBTA_V2_API_KEY and DD_API_KEY in environment to deploy" 1>&2
+    exit 1
+fi
+
 # Setup environment stuff
 # By default deploy to beta, otherwise deploys to production
 

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -132,6 +132,15 @@
         "Stage": { "Ref": "RestAPI.Stage" }
       }
     },
+    "RestAPI": {
+      "Properties": {
+        "DefinitionBody": {
+          "info": {
+            "title": { "Ref": "TMFrontendHostname" }
+          }
+        }
+      }
+    },
     "FrontendCloudFront": {
       "Type": "AWS::CloudFront::Distribution",
       "Properties": {

--- a/server/frontend-cfn.json
+++ b/server/frontend-cfn.json
@@ -136,7 +136,7 @@
       "Properties": {
         "DefinitionBody": {
           "info": {
-            "title": { "Ref": "TMFrontendHostname" }
+            "title": { "Ref": "TMBackendHostname" }
           }
         }
       }


### PR DESCRIPTION
## Motivation
This morning we couldn't figure out which API Gateway entity belonged to which hostname when we were trying to figure out what was wrong with the stacks.

## Changes

This sets the API Gateway title to the backend hostname, which makes this suck less.

## Testing Instructions

These should be the hostname instead of `data-dashboard`: https://us-east-1.console.aws.amazon.com/apigateway/main/apis?region=us-east-1
