### PR TITLE
hotfix: github action healthcheck

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - name: Run backend healthcheck
         run: |
-          curl --fail-with-body https://dashboard-api.labs.transitmatters.org/healthcheck
+          curl --fail-with-body https://dashboard-api.labs.transitmatters.org/api/healthcheck


### PR DESCRIPTION
## Motivation

healthcheck machine broke

## Changes

Updates the API endpoint

## Testing Instructions

```bash
curl --fail-with-body https://dashboard-api.labs.transitmatters.org/api/healthcheck
```
