### PR TITLE
Change landing page widget title

### DIFF
--- a/modules/landing/charts/LandingPageChart.tsx
+++ b/modules/landing/charts/LandingPageChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { Line } from 'react-chartjs-2';
 import type { ChartDataset } from 'chart.js';
+import dayjs from 'dayjs';
 
 import 'chartjs-adapter-date-fns';
 import ChartjsPluginWatermark from 'chartjs-plugin-watermark';
@@ -9,7 +10,11 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 import { enUS } from 'date-fns/locale';
 import { COLORS } from '../../../common/constants/colors';
-import { THREE_MONTHS_AGO_STRING, TODAY_STRING } from '../../../common/constants/dates';
+import {
+  PRETTY_DATE_FORMAT,
+  THREE_MONTHS_AGO_STRING,
+  TODAY_STRING,
+} from '../../../common/constants/dates';
 import { SPEED_RANGE_PARAM_MAP } from '../../speed/constants/speeds';
 import { LANDING_RAIL_LINES } from '../../../common/types/lines';
 import { LINE_OBJECTS } from '../../../common/constants/lines';
@@ -29,7 +34,7 @@ export const LandingPageChart: React.FC<LandingPageChartsProps> = ({ datasets, l
 
   const chart = useMemo(() => {
     const watermarkLayoutValues = watermarkLayout(isMobile);
-    const { tooltipFormat, unit, callbacks } = SPEED_RANGE_PARAM_MAP.week;
+    const { tooltipFormat, unit } = SPEED_RANGE_PARAM_MAP.week;
     return (
       <div className="chart-container relative h-[280px] w-full">
         <Line
@@ -60,7 +65,13 @@ export const LandingPageChart: React.FC<LandingPageChartsProps> = ({ datasets, l
                     `${value.formattedValue}% of historical maximum (${
                       LINE_OBJECTS[LANDING_RAIL_LINES[value.datasetIndex]].name
                     })`,
-                  ...callbacks,
+                  title: (value) => {
+                    const startDay = dayjs(value[0].label);
+                    const endDay = startDay.add(6, 'days');
+                    return `${startDay.format(PRETTY_DATE_FORMAT)} - ${endDay.format(
+                      PRETTY_DATE_FORMAT
+                    )}`;
+                  },
                 },
               },
               legend: {


### PR DESCRIPTION
## Motivation
The landing page chart tooltip titles were `week of <start date>`.

This made the data seem older than it was and like we weren't keeping it up to date.

## Changes
Change the title to `<start date> - <end date>`
**Before**
<img width="1075" alt="Screenshot 2023-08-12 at 10 58 36 AM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/51c92834-9579-4d4b-823b-2dc735b96a78">
**After**
<img width="968" alt="Screenshot 2023-08-12 at 10 58 41 AM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/4b05c346-bc11-4224-a7f0-6454e9753a8e">


## Testing Instructions

Look at chart tooltip titles.