### PR TITLE
Tweaks to chart format and colors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,8 +26,8 @@ Steps to reproduce the behavior:
 **Device Info (please complete the following information):**
  - Device: [e.g. iPhone 6, Laptop]
  - OS: [e.g. iOS, Windows]
- - Browser: [e.g. chrome, safari]
- - Version: [e.g. 22]
+ - Browser: [e.g. Chrome, Safari]
+ - Browser Version: [e.g. 22]
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,6 +1,7 @@
 name: healthcheck
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '15 23 * * *' # 7:15PM EST every day
 

--- a/common/types/basicWidgets.tsx
+++ b/common/types/basicWidgets.tsx
@@ -145,7 +145,7 @@ export class PercentageWidgetValue extends BaseWidgetValue implements WidgetValu
 
 export class TripsWidgetValue extends BaseWidgetValue implements WidgetValueInterface {
   getUnits() {
-    return 'Trips';
+    return 'Round Trips';
   }
 
   getFormattedValue(isLarge?: boolean) {
@@ -188,7 +188,7 @@ export class MPHWidgetValue extends BaseWidgetValue implements WidgetValueInterf
 
 export class RidersWidgetValue extends BaseWidgetValue implements WidgetValueInterface {
   getUnits() {
-    return 'Riders';
+    return 'Fare Validations';
   }
 
   getFormattedValue(isLarge?: boolean) {

--- a/common/types/basicWidgets.tsx
+++ b/common/types/basicWidgets.tsx
@@ -145,7 +145,7 @@ export class PercentageWidgetValue extends BaseWidgetValue implements WidgetValu
 
 export class TripsWidgetValue extends BaseWidgetValue implements WidgetValueInterface {
   getUnits() {
-    return 'Round Trips';
+    return 'Round trips';
   }
 
   getFormattedValue(isLarge?: boolean) {
@@ -188,7 +188,7 @@ export class MPHWidgetValue extends BaseWidgetValue implements WidgetValueInterf
 
 export class RidersWidgetValue extends BaseWidgetValue implements WidgetValueInterface {
   getUnits() {
-    return 'Fare Validations';
+    return 'Fare validations';
   }
 
   getFormattedValue(isLarge?: boolean) {

--- a/modules/ridership/RidershipGraph.tsx
+++ b/modules/ridership/RidershipGraph.tsx
@@ -71,7 +71,9 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
 
                 {
                   // This null dataset produces the entry in the legend for the peak annotation.
-                  label: `Historical Maximum (${PEAK_RIDERSHIP[routeIndex ?? 'DEFAULT'].toLocaleString("en-us")} riders)`,
+                  label: `Historical Maximum (${PEAK_RIDERSHIP[
+                    routeIndex ?? 'DEFAULT'
+                  ].toLocaleString('en-us')} riders)`,
                   backgroundColor: CHART_COLORS.ANNOTATIONS,
                   data: null,
                 },

--- a/modules/ridership/RidershipGraph.tsx
+++ b/modules/ridership/RidershipGraph.tsx
@@ -58,7 +58,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
               labels,
               datasets: [
                 {
-                  label: `Fare Validations`,
+                  label: `Fare validations`,
                   borderColor: lineColor,
                   backgroundColor: hexWithAlpha(lineColor, 0.8),
                   pointRadius: 0,
@@ -141,7 +141,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
                   },
                   title: {
                     display: true,
-                    text: 'Fare Validations',
+                    text: 'Fare validations',
                     color: COLORS.design.subtitleGrey,
                   },
                 },

--- a/modules/ridership/RidershipGraph.tsx
+++ b/modules/ridership/RidershipGraph.tsx
@@ -58,7 +58,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
               labels,
               datasets: [
                 {
-                  label: `Riders`,
+                  label: `Fare Validations`,
                   borderColor: lineColor,
                   backgroundColor: hexWithAlpha(lineColor, 0.8),
                   pointRadius: 0,
@@ -73,7 +73,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
                   // This null dataset produces the entry in the legend for the peak annotation.
                   label: `Historical Maximum (${PEAK_RIDERSHIP[
                     routeIndex ?? 'DEFAULT'
-                  ].toLocaleString('en-us')} riders)`,
+                  ].toLocaleString('en-us')} fare validations)`,
                   backgroundColor: CHART_COLORS.ANNOTATIONS,
                   data: null,
                 },
@@ -99,7 +99,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
                   callbacks: {
                     ...callbacks,
                     label: (context) => {
-                      return `${context.parsed.y} (${(
+                      return `${context.parsed.y.toLocaleString('en-us')} (${(
                         (100 * context.parsed.y) /
                         PEAK_RIDERSHIP[routeIndex ?? 'DEFAULT']
                       ).toFixed(1)}% of historical maximum)`;
@@ -141,7 +141,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
                   },
                   title: {
                     display: true,
-                    text: 'Riders',
+                    text: 'Fare Validations',
                     color: COLORS.design.subtitleGrey,
                   },
                 },

--- a/modules/ridership/RidershipGraph.tsx
+++ b/modules/ridership/RidershipGraph.tsx
@@ -71,7 +71,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
 
                 {
                   // This null dataset produces the entry in the legend for the peak annotation.
-                  label: `Historical Maximum (${PEAK_RIDERSHIP[routeIndex ?? 'DEFAULT']})`,
+                  label: `Historical Maximum (${PEAK_RIDERSHIP[routeIndex ?? 'DEFAULT'].toLocaleString("en-us")} riders)`,
                   backgroundColor: CHART_COLORS.ANNOTATIONS,
                   data: null,
                 },
@@ -139,7 +139,7 @@ export const RidershipGraph: React.FC<RidershipGraphProps> = ({
                   },
                   title: {
                     display: true,
-                    text: 'Trips',
+                    text: 'Riders',
                     color: COLORS.design.subtitleGrey,
                   },
                 },

--- a/modules/service/ServiceGraph.tsx
+++ b/modules/service/ServiceGraph.tsx
@@ -73,7 +73,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                   ),
                 },
                 {
-                  label: `MBTA scheduled trips`,
+                  label: `Scheduled round trips`,
                   stepped: true,
                   fill: true,
                   pointBorderWidth: 0,
@@ -89,7 +89,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                 },
                 {
                   // This null dataset produces the entry in the legend for the baseline annotation.
-                  label: `Historical Maximum (${peak.toLocaleString('en-us')} trips)`,
+                  label: `Historical Maximum (${peak.toLocaleString('en-us')} round trips)`,
                   backgroundColor: CHART_COLORS.ANNOTATIONS,
                   data: null,
                 },
@@ -157,7 +157,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                   },
                   title: {
                     display: true,
-                    text: 'Trips',
+                    text: 'Round Trips',
                     color: COLORS.design.subtitleGrey,
                   },
                 },

--- a/modules/service/ServiceGraph.tsx
+++ b/modules/service/ServiceGraph.tsx
@@ -89,7 +89,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                 },
                 {
                   // This null dataset produces the entry in the legend for the baseline annotation.
-                  label: `Historical Maximum (${peak})`,
+                  label: `Historical Maximum (${peak.toLocaleString("en-us")} trips)`,
                   backgroundColor: CHART_COLORS.ANNOTATIONS,
                   data: null,
                 },
@@ -115,9 +115,8 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                   callbacks: {
                     ...callbacks,
                     label: (context) => {
-                      return `${context.datasetIndex === 0 ? 'Actual:' : 'Scheduled:'} ${
-                        context.parsed.y
-                      } (${((100 * context.parsed.y) / peak).toFixed(1)}% of historical maximum)`;
+                      return `${context.datasetIndex === 0 ? 'Actual:' : 'Scheduled:'} ${context.parsed.y
+                        } (${((100 * context.parsed.y) / peak).toFixed(1)}% of historical maximum)`;
                     },
                   },
                 },
@@ -157,7 +156,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                   },
                   title: {
                     display: true,
-                    text: 'trips',
+                    text: 'Trips',
                     color: COLORS.design.subtitleGrey,
                   },
                 },

--- a/modules/service/ServiceGraph.tsx
+++ b/modules/service/ServiceGraph.tsx
@@ -89,7 +89,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                 },
                 {
                   // This null dataset produces the entry in the legend for the baseline annotation.
-                  label: `Historical Maximum (${peak.toLocaleString("en-us")} trips)`,
+                  label: `Historical Maximum (${peak.toLocaleString('en-us')} trips)`,
                   backgroundColor: CHART_COLORS.ANNOTATIONS,
                   data: null,
                 },
@@ -115,8 +115,9 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                   callbacks: {
                     ...callbacks,
                     label: (context) => {
-                      return `${context.datasetIndex === 0 ? 'Actual:' : 'Scheduled:'} ${context.parsed.y
-                        } (${((100 * context.parsed.y) / peak).toFixed(1)}% of historical maximum)`;
+                      return `${context.datasetIndex === 0 ? 'Actual:' : 'Scheduled:'} ${
+                        context.parsed.y
+                      } (${((100 * context.parsed.y) / peak).toFixed(1)}% of historical maximum)`;
                     },
                   },
                 },

--- a/modules/service/ServiceGraph.tsx
+++ b/modules/service/ServiceGraph.tsx
@@ -157,7 +157,7 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = ({
                   },
                   title: {
                     display: true,
-                    text: 'Round Trips',
+                    text: 'Round trips',
                     color: COLORS.design.subtitleGrey,
                   },
                 },

--- a/modules/speed/SpeedGraph.tsx
+++ b/modules/speed/SpeedGraph.tsx
@@ -53,6 +53,7 @@ export const SpeedGraph: React.FC<SpeedGraphProps> = ({
             datasets: [
               {
                 label: `MPH`,
+                backgroundColor: COLORS.design.background,
                 borderColor: LINE_COLORS[line ?? 'default'],
                 pointRadius: 0,
                 pointBorderWidth: 0,
@@ -67,7 +68,7 @@ export const SpeedGraph: React.FC<SpeedGraphProps> = ({
               },
               {
                 // This null dataset produces the entry in the legend for the baseline annotation.
-                label: `Historical Maximum (${peak})`,
+                label: `Historical Maximum (${peak} mph)`,
                 backgroundColor: CHART_COLORS.ANNOTATIONS,
                 data: null,
               },


### PR DESCRIPTION
## Motivation

This PR makes some stylistic suggestions to the chart formatting and coloring as well as some minor tweaks to the Bug Template and Healthcheck action

## Changes
![image](https://github.com/transitmatters/t-performance-dash/assets/31703736/165bc32a-48dc-48bb-a812-e062f5b0cf40)

- Clarified that `Version` in Bug Template referred to `Browser Version`
- Users can now trigger `healthcheck` action on demand
- Updated Historic Maximums to include commas to match labels on vertical axis
- Changed `trips` to `Trips` in Service graph to match other graphs' vertical axis
- Changed `Trips` in Ridership graph to `Riders`
- Added descriptor of Historic Maximum to all graphs for readability and consistency with the horizontal axis
- Made `MPH` box background more white than gray to match the graph background

## Testing Instructions

Deploy this PR locally
