### PR TITLE
Bus TT by hour

### DIFF
--- a/modules/tripexplorer/BusTripGraphs.tsx
+++ b/modules/tripexplorer/BusTripGraphs.tsx
@@ -6,6 +6,8 @@ import { WidgetDiv } from '../../common/components/widgets/WidgetDiv';
 import { WidgetTitle } from '../dashboard/WidgetTitle';
 import { getLocationDetails } from '../../common/utils/stations';
 import type { Line } from '../../common/types/lines';
+import { AggregateChartWrapper } from '../../common/components/charts/AggregateChartWrapper';
+import { ButtonGroup } from '../../common/components/general/ButtonGroup';
 import { TravelTimesAggregateWrapper } from '../traveltimes/TravelTimesAggregateWrapper';
 import { TravelTimesSingleWrapper } from '../traveltimes/TravelTimesSingleWrapper';
 import { HeadwaysSingleWrapper } from '../headways/HeadwaysSingleWrapper';
@@ -36,6 +38,7 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
     enabled
   );
   const location = getLocationDetails(fromStation, toStation);
+  const [peakTime, setPeakTime] = React.useState<'weekday' | 'weekend'>('weekday');
 
   return (
     <div className="flex flex-col gap-4">
@@ -61,6 +64,28 @@ export const BusTripGraphs: React.FC<BusTripGraphsProps> = ({
               toStation={toStation}
               fromStation={fromStation}
             />
+          </WidgetDiv>
+          <WidgetDiv className="flex flex-col justify-center">
+            <WidgetTitle title="Travel times by hour" location={location} line={line} both />
+            <AggregateChartWrapper
+              query={traveltimes}
+              toStation={toStation}
+              fromStation={fromStation}
+              type={'traveltimes'}
+              timeUnit={'by_time'}
+              peakTime={peakTime === 'weekday' ? true : false}
+            />
+            <div className={'flex w-full justify-center pt-2'}>
+              <ButtonGroup
+                pressFunction={setPeakTime}
+                options={[
+                  ['weekday', 'Weekday'],
+                  ['weekend', 'Weekend/holiday'],
+                ]}
+                additionalDivClass="md:w-auto"
+                additionalButtonClass="md:w-fit"
+              />
+            </div>
           </WidgetDiv>
         </>
       ) : (


### PR DESCRIPTION
## Motivation
Bus Travel times by hour was missing in new dashboards.

## Changes

Add it back
<img width="1440" alt="Screenshot 2023-08-18 at 12 57 46 PM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/1ce3b5bd-a223-4c74-84ff-9c83889ddf4f">

## Testing Instructions
Check out various routes and date configurations