### PR TITLE
Ridership max widget + small fix.

### DIFF
--- a/modules/ridership/RidershipGraphWrapper.tsx
+++ b/modules/ridership/RidershipGraphWrapper.tsx
@@ -27,7 +27,7 @@ export const RidershipGraphWrapper: React.FC<RidershipGraphWrapperProps> = ({
   endDate,
 }) => {
   if (!data.some((datapoint) => datapoint.count !== null)) return <NoDataNotice isLineMetric />;
-  const { average, percentage } = getRidershipWidgetValues(data, line, busRoute);
+  const { average, percentage, peak } = getRidershipWidgetValues(data, line, busRoute);
 
   return (
     <CarouselGraphDiv>
@@ -43,6 +43,12 @@ export const RidershipGraphWrapper: React.FC<RidershipGraphWrapperProps> = ({
           sentimentDirection={'positiveOnIncrease'}
           layoutKind="no-delta"
           widgetValue={new PercentageWidgetValue(percentage)}
+        />
+        <WidgetForCarousel
+          layoutKind="no-delta"
+          sentimentDirection={'positiveOnIncrease'}
+          analysis={`Max - ${config.getWidgetTitle(peak.date)}`}
+          widgetValue={new RidersWidgetValue(peak ? peak.count : undefined)}
         />
       </WidgetCarousel>
       <RidershipGraph config={config} data={data} startDate={startDate} endDate={endDate} />

--- a/modules/ridership/utils/utils.ts
+++ b/modules/ridership/utils/utils.ts
@@ -9,8 +9,11 @@ export const getRidershipWidgetValues = (
 ) => {
   const routeIndex = busRoute ? busRoute.replaceAll('/', '') : line;
   const average = ridership.reduce((sum, current) => sum + current.count, 0) / ridership.length;
-
+  const peak = ridership.reduce(
+    (max, datapoint) => datapoint.count > max.count ? datapoint : max,
+    ridership[0]
+    );
   const percentage =
     ridership[ridership.length - 1]?.count / PEAK_RIDERSHIP[routeIndex ?? 'DEFAULT'];
-  return { average: average, percentage: percentage };
+  return { average: average, percentage: percentage, peak: peak, };
 };

--- a/modules/ridership/utils/utils.ts
+++ b/modules/ridership/utils/utils.ts
@@ -10,10 +10,10 @@ export const getRidershipWidgetValues = (
   const routeIndex = busRoute ? busRoute.replaceAll('/', '') : line;
   const average = ridership.reduce((sum, current) => sum + current.count, 0) / ridership.length;
   const peak = ridership.reduce(
-    (max, datapoint) => datapoint.count > max.count ? datapoint : max,
+    (max, datapoint) => (datapoint.count > max.count ? datapoint : max),
     ridership[0]
-    );
+  );
   const percentage =
     ridership[ridership.length - 1]?.count / PEAK_RIDERSHIP[routeIndex ?? 'DEFAULT'];
-  return { average: average, percentage: percentage, peak: peak, };
+  return { average: average, percentage: percentage, peak: peak };
 };

--- a/modules/service/ServiceGraphWrapper.tsx
+++ b/modules/service/ServiceGraphWrapper.tsx
@@ -38,7 +38,7 @@ export const ServiceGraphWrapper: React.FC<ServiceGraphWrapperProps> = ({
         <WidgetForCarousel
           layoutKind="no-delta"
           sentimentDirection={'positiveOnIncrease'}
-          analysis={`Historical Maximum - ${config.getWidgetTitle(peak.date)}`}
+          analysis={`Max - ${config.getWidgetTitle(peak.date)}`}
           widgetValue={new TripsWidgetValue(peak ? peak.count : undefined)}
         />
       </WidgetCarousel>

--- a/modules/speed/SpeedGraphWrapper.tsx
+++ b/modules/speed/SpeedGraphWrapper.tsx
@@ -42,7 +42,7 @@ export const SpeedGraphWrapper: React.FC<SpeedGraphWrapperProps> = ({
         />
         <WidgetForCarousel
           widgetValue={new MPHWidgetValue(peak.mph, undefined)}
-          analysis={`Historical Maximum - ${config.getWidgetTitle(peak.date)}`}
+          analysis={`Max - ${config.getWidgetTitle(peak.date)}`}
           sentimentDirection={'positiveOnIncrease'}
           layoutKind="no-delta"
         />


### PR DESCRIPTION
## Motivation

1. Fixing this #834 
2. Adding max to ridership widget carousel

## Changes

1)
**Before**
<img width="345" alt="Screenshot 2023-08-24 at 9 33 15 AM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/bbf8f330-0b70-42f4-b6f7-7fd4c60c870c">
**After**
<img width="377" alt="Screenshot 2023-08-24 at 9 33 36 AM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/08509638-212c-47f3-af69-40d93800488b">

2)
Added max to ridership widgets:
<img width="358" alt="Screenshot 2023-08-24 at 9 34 06 AM" src="https://github.com/transitmatters/t-performance-dash/assets/46229349/3e90a04e-6524-4261-9d6e-a09587d46220">

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
