### PR TITLE
Extend slowzone segment link to include 7 days of trailing data.

### DIFF
--- a/modules/slowzones/charts/LineSegments.tsx
+++ b/modules/slowzones/charts/LineSegments.tsx
@@ -1,13 +1,18 @@
 import 'chartjs-adapter-date-fns';
 import { Bar } from 'react-chartjs-2';
 import React, { useMemo, useRef } from 'react';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import minMax from 'dayjs/plugin/minMax';
 import ChartjsPluginWatermark from 'chartjs-plugin-watermark';
 
 import type { ChartDataset } from 'chart.js';
-import { DATE_FORMAT, YESTERDAY_MIDNIGHT, YESTERDAY_STRING, todayOrDate, TODAY } from '../../../common/constants/dates';
+import {
+  DATE_FORMAT,
+  YESTERDAY_MIDNIGHT,
+  YESTERDAY_STRING,
+  TODAY,
+} from '../../../common/constants/dates';
 import { COLORS } from '../../../common/constants/colors';
 import type { Direction, LineSegmentData, SlowZone } from '../../../common/types/dataPoints';
 import type { LinePath } from '../../../common/types/lines';
@@ -172,10 +177,12 @@ export const LineSegments: React.FC<LineSegmentsProps> = ({
                 if (!(start && end)) return 'Unknown dates';
                 const startUTC = dayjs.utc(start);
                 const endUTC = dayjs.utc(end);
-                return `${startUTC.format('MMM D, YYYY')} - ${dayjs.utc(endUTC).isSame(YESTERDAY_MIDNIGHT)
-                  ? 'Ongoing'
-                  : dayjs(endUTC).format('MMM D, YYYY')
-                  }`;
+                return `${startUTC.format('MMM D, YYYY')} -
+                 ${
+                   dayjs.utc(endUTC).isSame(YESTERDAY_MIDNIGHT)
+                     ? 'Ongoing'
+                     : dayjs(endUTC).format('MMM D, YYYY')
+                 }`;
               },
             },
           },

--- a/modules/slowzones/charts/LineSegments.tsx
+++ b/modules/slowzones/charts/LineSegments.tsx
@@ -1,12 +1,13 @@
 import 'chartjs-adapter-date-fns';
 import { Bar } from 'react-chartjs-2';
 import React, { useMemo, useRef } from 'react';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import minMax from 'dayjs/plugin/minMax';
 import ChartjsPluginWatermark from 'chartjs-plugin-watermark';
 
 import type { ChartDataset } from 'chart.js';
-import { DATE_FORMAT, YESTERDAY_MIDNIGHT, YESTERDAY_STRING } from '../../../common/constants/dates';
+import { DATE_FORMAT, YESTERDAY_MIDNIGHT, YESTERDAY_STRING, todayOrDate, TODAY } from '../../../common/constants/dates';
 import { COLORS } from '../../../common/constants/colors';
 import type { Direction, LineSegmentData, SlowZone } from '../../../common/types/dataPoints';
 import type { LinePath } from '../../../common/types/lines';
@@ -24,6 +25,7 @@ import { stopIdsForStations } from '../../../common/utils/stations';
 import { ALL_PAGES } from '../../../common/constants/pages';
 import type { QueryParams } from '../../../common/types/router';
 dayjs.extend(utc);
+dayjs.extend(minMax);
 
 interface LineSegmentsProps {
   data: SlowZone[];
@@ -128,7 +130,7 @@ export const LineSegments: React.FC<LineSegmentsProps> = ({
             const queryParams: QueryParams = {
               // Show 7 days before slowzone start for comparison
               startDate: dayjs(x[0]).subtract(7, 'days').format(DATE_FORMAT),
-              endDate: x[1],
+              endDate: dayjs.min(TODAY, dayjs(x[1]).add(7, 'days'))?.format(DATE_FORMAT),
               to: stations.toStopIds?.[0],
               from: stations.fromStopIds?.[0],
             };
@@ -170,11 +172,10 @@ export const LineSegments: React.FC<LineSegmentsProps> = ({
                 if (!(start && end)) return 'Unknown dates';
                 const startUTC = dayjs.utc(start);
                 const endUTC = dayjs.utc(end);
-                return `${startUTC.format('MMM D, YYYY')} - ${
-                  dayjs.utc(endUTC).isSame(YESTERDAY_MIDNIGHT)
-                    ? 'Ongoing'
-                    : dayjs(endUTC).format('MMM D, YYYY')
-                }`;
+                return `${startUTC.format('MMM D, YYYY')} - ${dayjs.utc(endUTC).isSame(YESTERDAY_MIDNIGHT)
+                  ? 'Ongoing'
+                  : dayjs(endUTC).format('MMM D, YYYY')
+                  }`;
               },
             },
           },


### PR DESCRIPTION
## Motivation

A link to a slowzone on the multi-day view should show trailing context to make the extent of the slowzone clear:

![image](https://github.com/transitmatters/t-performance-dash/assets/8498946/a6bda136-c987-4816-a504-b3bc43758a6b)


