### PR TITLE
fix: Only add slow zones to map that existed at currently selected `endDate`

### DIFF
--- a/modules/slowzones/map/SlowZonesTooltip.tsx
+++ b/modules/slowzones/map/SlowZonesTooltip.tsx
@@ -84,7 +84,7 @@ export const SlowZonesTooltip: React.FC<SlowZonesTooltipProps> = (props) => {
               <i>Slowest:</i> {minimumSpeed} mph
             </div>
             <div>
-              <i>Oldest:</i> {oldestString}
+              <i>Since:</i> {oldestString}
             </div>
           </div>
         </div>

--- a/modules/slowzones/map/segment.ts
+++ b/modules/slowzones/map/segment.ts
@@ -52,14 +52,17 @@ const filterActiveElements = <T extends Record<string, unknown>>(
   records: T[],
   targetLine: LineShort,
   targetDate: Date,
-  getRecordDate: (t: T) => Date,
+  getRecordDateRange: (t: T) => [Date, Date],
   getRecordLine: (t: T) => LineShort
 ) => {
-  return records.filter(
-    (record) =>
-      getRecordDate(record).valueOf() >= targetDate.valueOf() &&
+  return records.filter((record) => {
+    const [startDate, endDate] = getRecordDateRange(record);
+    return (
+      startDate.valueOf() <= targetDate.valueOf() &&
+      endDate.valueOf() >= targetDate.valueOf() &&
       getRecordLine(record) === targetLine
-  );
+    );
+  });
 };
 
 const locateIntoSegments = <T extends Record<string, unknown>>(
@@ -131,7 +134,7 @@ export const segmentSlowZones = (options: SegmentSlowZonesOptions): Segmentation
       slowZones,
       lineName,
       effectiveDate,
-      (sz) => new Date(sz.end),
+      (sz) => [new Date(sz.start), new Date(sz.end)],
       (sz) => sz.color
     ),
     (sz) => getParentStationForStopId(sz.fr_id),
@@ -142,7 +145,7 @@ export const segmentSlowZones = (options: SegmentSlowZonesOptions): Segmentation
       speedRestrictions,
       lineName,
       effectiveDate,
-      (rs) => rs.validAsOf,
+      (rs) => [new Date(rs.reported), rs.validAsOf],
       (rs) => rs.lineId.replace('line-', '') as LineShort
     ),
     (rs) => getStationById(rs.fromStopId!),


### PR DESCRIPTION
Resolves #764 

Test plan:

- Visit `/red/slowzones/?startDate=2022-06-01&endDate=2022-09-05` and verify that only a few sz are shown on the map
- Return to today and verify that there are a lot more 😢