### PR TITLE
Swapped position of Line Map and Segment Chart for systemwide Slow Zone view

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -29,6 +29,9 @@ done
 if [[ -z "$MBTA_V2_API_KEY" || -z "$DD_API_KEY"  ]]; then
     echo "Must provide MBTA_V2_API_KEY and DD_API_KEY in environment to deploy" 1>&2
     exit 1
+elif [ -z "$TM_FRONTEND_CERT_ARN" ] && [ -z "$TM_LABS_WILDCARD_CERT_ARN" ]; then
+    echo "Must provide TM_FRONTEND_CERT_ARN or TM_LABS_WILDCARD_CERT_ARN in environment to deploy" 1>&2
+    exit 1
 fi
 
 # Setup environment stuff
@@ -43,7 +46,7 @@ $PRODUCTION && FRONTEND_DOMAIN_PREFIX=""                        || FRONTEND_DOMA
 
 BACKEND_ZONE="labs.transitmatters.org"
 BACKEND_CERT_ARN="$TM_LABS_WILDCARD_CERT_ARN"
-$PRODUCTION && BACKEND_DOMAIN_PREFIX="dashboard-api."            || BACKEND_DOMAIN_PREFIX="dashboard-api-beta."
+$PRODUCTION && BACKEND_DOMAIN_PREFIX="dashboard-api."           || BACKEND_DOMAIN_PREFIX="dashboard-api-beta."
 
 # Fetch repository tags
 # Run unshallow if deploying in CI

--- a/modules/slowzones/SystemSlowZonesDetails.tsx
+++ b/modules/slowzones/SystemSlowZonesDetails.tsx
@@ -78,6 +78,33 @@ export function SystemSlowZonesDetails({ showTitle = false }: SystemSlowZonesDet
             )}
           </div>
         </WidgetDiv>
+        <WidgetDiv>
+          <SlowZonesWidgetTitle />
+          <div className="relative flex flex-col">
+            {allData.data && speedRestrictions.data && canShowSlowZonesMap ? (
+              <SlowZonesMap
+                key={lineShort}
+                slowZones={allData.data}
+                speedRestrictions={speedRestrictions.data}
+                lineName={lineShort}
+                direction="horizontal-on-desktop"
+              />
+            ) : (
+              <div className="relative flex h-full">
+                <ChartPlaceHolder query={delayTotals} />
+              </div>
+            )}
+          </div>
+          <ButtonGroup
+            line={line}
+            pressFunction={setLineShort}
+            options={Object.entries({
+              Red: 'Red',
+              Orange: 'Orange',
+              Blue: 'Blue',
+            })}
+          />
+        </WidgetDiv>
         <div className="h-full rounded-lg bg-white p-4 shadow-dataBox">
           <div className="flex flex-col p-4 sm:p-0 lg:flex-row">
             <WidgetTitle title={`${DirectionObject[direction]} segments`} />
@@ -114,33 +141,6 @@ export function SystemSlowZonesDetails({ showTitle = false }: SystemSlowZonesDet
             </div>
           </div>
         </div>
-        <WidgetDiv>
-          <SlowZonesWidgetTitle />
-          <div className="relative flex flex-col">
-            {allData.data && speedRestrictions.data && canShowSlowZonesMap ? (
-              <SlowZonesMap
-                key={lineShort}
-                slowZones={allData.data}
-                speedRestrictions={speedRestrictions.data}
-                lineName={lineShort}
-                direction="horizontal-on-desktop"
-              />
-            ) : (
-              <div className="relative flex h-full">
-                <ChartPlaceHolder query={delayTotals} />
-              </div>
-            )}
-          </div>
-          <ButtonGroup
-            line={line}
-            pressFunction={setLineShort}
-            options={Object.entries({
-              Red: 'Red',
-              Orange: 'Orange',
-              Blue: 'Blue',
-            })}
-          />
-        </WidgetDiv>
       </ChartPageDiv>
     </PageWrapper>
   );


### PR DESCRIPTION
## Motivation
Systemwide page should match those of the individual lines, and I want @akh4rf's hard work to not be buried under all the T's slow zone segments :smile: 

## Changes
Just a position swap

## Testing Instructions
Build the dashboard locally with this branch
