### PR TITLE
fix scrolling issue in dropdown menu

### DIFF
--- a/common/components/inputs/StationSelector.tsx
+++ b/common/components/inputs/StationSelector.tsx
@@ -69,7 +69,7 @@ export const StationSelector: React.FC<StationSelector> = ({
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Listbox.Options className="md:max-w-screen fixed bottom-8 left-0 right-0 top-auto m-auto max-h-[60vh] max-w-xs overflow-auto rounded-md  border border-stone-200 bg-white  shadow-lg  ring-1 ring-black ring-opacity-5 focus:outline-none md:bottom-auto md:left-auto md:right-auto md:top-auto md:mt-1 md:max-h-[66vh] md:-translate-x-1/2 md:border-none">
+            <Listbox.Options className="md:max-w-screen absolute bottom-8 left-0 right-0 top-auto m-auto max-h-[60vh] max-w-xs overflow-auto rounded-md  border border-stone-200 bg-white  shadow-lg  ring-1 ring-black ring-opacity-5 focus:outline-none md:bottom-auto md:left-auto md:right-auto md:top-auto md:mt-1 md:max-h-[66vh] md:-translate-x-1/2 md:border-none">
               <div className="py-1">
                 {stationOptions?.map((station, stationIndex) => (
                   <Listbox.Option


### PR DESCRIPTION
## Motivation
https://github.com/transitmatters/t-performance-dash/issues/861

The previous `position: fixed` caused unexpected behavior during scrolling due to a `transform` applied to its containing element as part of the animation that happens when you open the dropdown menu. This is due to an interesting quirk of CSS that you can read about [here](https://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/)

## Changes

Changed `position: fixed` to `position: absolute` for the dropdown menu container to address scrolling issues. By switching to `position: absolute`, the element is now fixed with respect to its nearest positioned ancestor's context without being affected by `transform`s.

## Testing Instructions

Tested the change across different browsers and mobile views to validate the fix's effectiveness in resolving the scrolling issue.