### PR TITLE
fix: Bad property access crashes service chart

### DIFF
--- a/modules/service/utils/utils.ts
+++ b/modules/service/utils/utils.ts
@@ -8,10 +8,11 @@ export const getServiceWidgetValues = (
 ) => {
   const totals = deliveredTripMetrics.reduce(
     (totals, datapoint, index) => {
-      if (datapoint.count && predictedData.counts[index].count) {
+      const predictedDatapoint = predictedData.counts[index];
+      if (datapoint.count && predictedDatapoint?.count) {
         return {
           actual: totals.actual + datapoint.count,
-          scheduled: totals.scheduled + predictedData.counts[index].count,
+          scheduled: totals.scheduled + predictedDatapoint.count,
         };
       }
       return { actual: totals.actual, scheduled: totals.scheduled };


### PR DESCRIPTION
## Motivation

Service chart is crashing

## Changes

Looks like there's sometimes a mismatch in the length of the predicted and actual service values. Don't assume they are the same length.

## Testing Instructions

Load the Red Line overview page
