### PR TITLE
feat: headways historgram improvements

### DIFF
--- a/common/types/charts.ts
+++ b/common/types/charts.ts
@@ -117,3 +117,8 @@ export interface HeadwaysChartProps {
   toStation: Station;
   showLegend?: boolean;
 }
+
+// additional data for rendering headway tooltip
+export interface HeadwayTooltipData {
+  pct_trains: number;
+}

--- a/common/types/dataPoints.ts
+++ b/common/types/dataPoints.ts
@@ -27,12 +27,6 @@ export interface HeadwayPoint extends DataPoint {
   threshold_flag_3?: string;
 }
 
-// data for rendering headway in a chart
-export interface HeadwayData {
-  number_of_trains: number;
-  pct_of_trains: number;
-}
-
 export interface DwellPoint extends DataPoint {
   arr_dt: string;
   dep_dt: string;

--- a/common/types/dataPoints.ts
+++ b/common/types/dataPoints.ts
@@ -27,6 +27,12 @@ export interface HeadwayPoint extends DataPoint {
   threshold_flag_3?: string;
 }
 
+// data for rendering headway in a chart
+export interface HeadwayData {
+  number_of_trains: number;
+  pct_of_trains: number;
+}
+
 export interface DwellPoint extends DataPoint {
   arr_dt: string;
   dep_dt: string;


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->
Closes https://github.com/transitmatters/t-performance-dash/issues/800

I experimented with showing difference from the benchmark instead, but it ended up being a little bit confusing in my opinion. As an alternative, I made the tooltip display the benchmark time for more context. Let me know what you think.

## Changes
![image](https://github.com/transitmatters/t-performance-dash/assets/46619169/645d179d-db85-48bb-9b9b-3c32222e5f06)

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
Navigate to trip explorer page for all lines and ensure that the headways distribution chart displays correctly