### PR TITLE
fix(slow_zones): make green line slow zones page unselectable

### DIFF
--- a/common/components/nav/SubwayDropdown.tsx
+++ b/common/components/nav/SubwayDropdown.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import { SidebarTabs } from '../../../modules/navigation/SidebarTabs';
-import { OVERVIEW_PAGE, LINE_PAGES, TRIP_PAGES } from '../../constants/pages';
+import { OVERVIEW_PAGE, LINE_PAGES, TRIP_PAGES, ALL_PAGES } from '../../constants/pages';
 import { lineColorBorder } from '../../styles/general';
 import type { Line } from '../../types/lines';
 
@@ -21,7 +21,14 @@ export const SubwayDropdown: React.FC<SubwayDropdownProps> = ({ line, close }) =
     >
       <SidebarTabs tabs={OVERVIEW_PAGE} close={close} />
       <hr className="h-[1px] w-3/4 self-center border-neutral-500" />
-      <SidebarTabs tabs={LINE_PAGES} close={close} />
+      <SidebarTabs
+        tabs={
+          line === 'line-green'
+            ? LINE_PAGES.filter((cur) => cur !== ALL_PAGES.slowzones)
+            : LINE_PAGES
+        }
+        close={close}
+      />
       <hr className="h-[1px] w-3/4 self-center border-neutral-500" />
       <SidebarTabs tabs={TRIP_PAGES} close={close} />
     </div>

--- a/common/types/lines.ts
+++ b/common/types/lines.ts
@@ -77,6 +77,7 @@ export const BUS_ROUTES: BusRoute[] = [
   '220/221/222',
 ];
 
+// potential TODO: make this a type or make the line names for routing constants
 export const ALL_LINE_PATHS = RAIL_LINES.map((line) => {
   return {
     params: {

--- a/pages/[line]/slowzones.tsx
+++ b/pages/[line]/slowzones.tsx
@@ -7,7 +7,7 @@ export async function getStaticProps() {
 
 export async function getStaticPaths() {
   return {
-    paths: ALL_LINE_PATHS,
+    paths: ALL_LINE_PATHS.filter((p) => p.params.line !== 'green'),
     fallback: false,
   };
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->
Closes https://github.com/transitmatters/t-performance-dash/issues/921

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->
I went with just removing the slow zones tab for the green line. This seems like a better temporary fix until we have stuff ready for that page 
![image](https://github.com/transitmatters/t-performance-dash/assets/46619169/65e0dc15-ba7e-4ba0-9a6b-c7e448dd1c2e)
![image](https://github.com/transitmatters/t-performance-dash/assets/46619169/b92e5e21-1892-4b9e-8c9b-2300ce34f28e)


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
Navigate to http://localhost:3000/green/slowzones/?startDate=2022-12-28&endDate=2023-12-28 and verify a 404. Verify that the slow zones tab for the green line is gone 
