### PR TITLE
Adding bus data for Nov 2023

### DIFF
--- a/common/constants/dates.ts
+++ b/common/constants/dates.ts
@@ -35,7 +35,7 @@ export const THREE_MONTHS_AGO_STRING = TODAY.subtract(90, 'days').format(DATE_FO
 const OVERVIEW_TRAIN_MIN_DATE = '2016-02-01';
 const TRAIN_MIN_DATE = '2016-01-15';
 const BUS_MIN_DATE = '2018-08-01';
-export const BUS_MAX_DATE = '2023-10-31';
+export const BUS_MAX_DATE = '2023-11-30';
 const BUS_MAX_DAY = dayjs(BUS_MAX_DATE);
 export const BUS_MAX_DATE_MINUS_ONE_WEEK = dayjs(BUS_MAX_DATE)
   .subtract(7, 'days')

--- a/server/chalicelib/constants.py
+++ b/server/chalicelib/constants.py
@@ -7,7 +7,3 @@ LINE_TO_ROUTE_MAP = {
     "line-blue": ["line-blue"],
     "line-orange": ["line-orange"],
 }
-
-# Most recent date for which we have official MBTA data in S3
-# TODO: Fetch this date from S3 automatically
-BUS_MAX_DATE = "2023-10-31"


### PR DESCRIPTION
## Motivation

November 2023 Bus data

## Changes

- Bumps max bus date to Nov 2023
- Removed unused python variable

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
