### PR TITLE
fix(trip-explorer): disable speed between stations for green line

### DIFF
--- a/modules/tripexplorer/SubwayTripGraphs.tsx
+++ b/modules/tripexplorer/SubwayTripGraphs.tsx
@@ -85,18 +85,22 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
                 />
               </>
             )}
-            <div className={'flex w-full justify-center pt-2'}>
-              <ButtonGroup
-                line={line}
-                pressFunction={setTravelTimeDisplay}
-                options={[
-                  ['traveltimes', 'Travel times'],
-                  ['speeds', 'Speeds'],
-                ]}
-                additionalDivClass="md:w-auto"
-                additionalButtonClass="md:w-fit"
-              />
-            </div>
+            {line !== 'line-green' ? (
+              <div className={'flex w-full justify-center pt-2'}>
+                <ButtonGroup
+                  line={line}
+                  pressFunction={setTravelTimeDisplay}
+                  options={[
+                    ['traveltimes', 'Travel times'],
+                    ['speeds', 'Speeds'],
+                  ]}
+                  additionalDivClass="md:w-auto"
+                  additionalButtonClass="md:w-fit"
+                />
+              </div>
+            ) : (
+              <React.Fragment />
+            )}
           </WidgetDiv>
           <WidgetDiv>
             <WidgetTitle
@@ -183,18 +187,22 @@ export const SubwayTripGraphs: React.FC<SubwayTripGraphsProps> = ({
                 />
               </>
             )}
-            <div className={'flex w-full justify-center pt-2'}>
-              <ButtonGroup
-                line={line}
-                pressFunction={setTravelTimeDisplay}
-                options={[
-                  ['traveltimes', 'Travel times'],
-                  ['speeds', 'Speeds'],
-                ]}
-                additionalDivClass="md:w-auto"
-                additionalButtonClass="md:w-fit"
-              />
-            </div>
+            {line !== 'line-green' ? (
+              <div className={'flex w-full justify-center pt-2'}>
+                <ButtonGroup
+                  line={line}
+                  pressFunction={setTravelTimeDisplay}
+                  options={[
+                    ['traveltimes', 'Travel times'],
+                    ['speeds', 'Speeds'],
+                  ]}
+                  additionalDivClass="md:w-auto"
+                  additionalButtonClass="md:w-fit"
+                />
+              </div>
+            ) : (
+              <React.Fragment />
+            )}
           </WidgetDiv>
 
           <WidgetDiv>


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

After merging https://github.com/transitmatters/t-performance-dash/pull/909, I noticed that the distances from the GLX stations inbound weren't quite right 🤦 .  I missed this because they're fine in the outbound direction. Example below. It looks like I'll have to manually correct those. All of the other distances look good. For now, I think it's best to just disable this feature for the green line until then. 


![image](https://github.com/transitmatters/t-performance-dash/assets/46619169/0fb2f5d1-bde2-4e7b-af87-f19f2943ac4b)
![image](https://github.com/transitmatters/t-performance-dash/assets/46619169/d1184c6d-1375-4fad-973e-870645938ad5)

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->
Disable the speed between stations feature for GL trip explorer only until we can fix it 
![image](https://github.com/transitmatters/t-performance-dash/assets/46619169/3fb6e12e-49ed-4447-b0b4-d1b57a55c5f9)


## Testing Instructions
Verify there is no speed selector for the Green Line trip graphs 
<!-- How can the reviewer confirm these changes do what you say they do? -->
