### PR TITLE
Tag cloudfront with service name

### DIFF
--- a/server/cloudformation.json
+++ b/server/cloudformation.json
@@ -197,7 +197,13 @@
             "AcmCertificateArn": { "Ref": "TMFrontendCertArn" },
             "SslSupportMethod": "sni-only"
           }
-        }
+        },
+        "Tags": [
+          {
+            "Key": "service",
+            "Value": "t-performance-dash"
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
## Motivation

Make sure datadog knows which cloudfront distribution is for which service

## Changes

Just adds a tag to our cloudfront ids

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
