### PR TITLE
Live Bus Data Beta Release

### DIFF
--- a/common/components/charts/ChartPageDiv.tsx
+++ b/common/components/charts/ChartPageDiv.tsx
@@ -5,5 +5,5 @@ interface ChartPageDivProps {
 }
 
 export const ChartPageDiv: React.FC<ChartPageDivProps> = ({ children }) => {
-  return <div className="flex w-full max-w-7xl flex-col gap-4 md:gap-8">{children}</div>;
+  return <div className="flex w-full max-w-7xl flex-col gap-4 md:gap-6">{children}</div>;
 };

--- a/common/components/notices/BetaDataNotice.tsx
+++ b/common/components/notices/BetaDataNotice.tsx
@@ -40,14 +40,14 @@ export const BetaDataNotice: React.FC = () => {
                   target="_blank"
                   className={classNames(lineColorTextHover[line ?? 'DEFAULT'])}
                 >
-                  MBTA's streaming API
+                  MBTA's V3 API
                 </Link>
                 . Unlike other data sources we show, this data is not cleaned or filtered in any way
-                before display. Innacuracies may be present.
+                before display. Please expect reduced accuracy.
               </p>
               <p>
-                Official MBTA data will be shown when available. Technical details of our data
-                collection can be found{' '}
+                We favor official performance data from the MBTA when it's available. Technical
+                details of our data collection can be found{' '}
                 <Link
                   href="https://github.com/transitmatters/gobble"
                   rel="noopener noreferrer"

--- a/common/components/notices/BetaDataNotice.tsx
+++ b/common/components/notices/BetaDataNotice.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import Link from 'next/link';
+import classNames from 'classnames';
+import { ExclamationTriangleIcon } from '@heroicons/react/20/solid';
+import { useDelimitatedRoute } from '../../utils/router';
+import { BUS_MAX_DAY } from '../../constants/dates';
+import { lineColorTextHover } from '../../styles/general';
+
+export const BetaDataNotice: React.FC = () => {
+  const {
+    line,
+    linePath,
+    query: { date, startDate, endDate },
+  } = useDelimitatedRoute();
+
+  const isStartDateAfterBusMaxDay =
+    (startDate !== undefined && dayjs(startDate).isAfter(BUS_MAX_DAY)) ||
+    (date !== undefined && dayjs(date).isAfter(BUS_MAX_DAY));
+  const isEndDateAfterBusMaxDay = endDate !== undefined && dayjs(endDate).isAfter(BUS_MAX_DAY);
+
+  if (
+    (line === 'line-bus' || linePath === 'bus') &&
+    (isStartDateAfterBusMaxDay || isEndDateAfterBusMaxDay)
+  ) {
+    return (
+      <div className="rounded-md bg-yellow-50 p-4">
+        <div className="flex">
+          <div className="flex-shrink-0">
+            <ExclamationTriangleIcon className="h-5 w-5 text-yellow-400" aria-hidden="true" />
+          </div>
+          <div className="ml-3">
+            <h3 className="text-sm font-medium text-yellow-800">Real-time bus data is in beta</h3>
+            <div className="mt-2 text-sm text-yellow-700">
+              <p>
+                Data shown here is collected by TransitMatters using the{' '}
+                <Link
+                  href="https://www.mbta.com/developers/v3-api/streaming"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  className={classNames(lineColorTextHover[line ?? 'DEFAULT'])}
+                >
+                  MBTA's streaming API
+                </Link>
+                . Unlike other data sources we show, this data is not cleaned or filtered in any way
+                before display. Innacuracies may be present.
+              </p>
+              <p>
+                Official MBTA data will be shown when available. Technical details of our data
+                collection can be found{' '}
+                <Link
+                  href="https://github.com/transitmatters/gobble"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  className={classNames(lineColorTextHover[line ?? 'DEFAULT'])}
+                >
+                  here
+                </Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return null;
+};

--- a/common/components/notices/SameDayNotice.tsx
+++ b/common/components/notices/SameDayNotice.tsx
@@ -6,11 +6,12 @@ import { TODAY_STRING } from '../../constants/dates';
 
 export const SameDayNotice: React.FC = () => {
   const {
+    line,
     query: { date, endDate },
   } = useDelimitatedRoute();
   const isToday = date === TODAY_STRING || endDate === TODAY_STRING;
 
-  if (isToday) {
+  if (isToday && line !== 'line-bus') {
     return (
       <div className={'flex items-center'}>
         <FontAwesomeIcon icon={faCalendarDay} size={'lg'} />

--- a/common/constants/dates.ts
+++ b/common/constants/dates.ts
@@ -59,7 +59,7 @@ export const FLAT_PICKER_OPTIONS: {
   Bus: {
     enableTime: false,
     minDate: BUS_MIN_DATE,
-    maxDate: BUS_MAX_DATE,
+    maxDate: TODAY_STRING,
     altInput: true,
     altFormat: 'M j, Y',
     dateFormat: 'Y-m-d',
@@ -141,7 +141,7 @@ export const SINGLE_PRESETS: {
   [key in Tab]: { [key in DatePresetKey]?: DateSelectionDefaultOptions<SingleDateParams> };
 } = {
   Subway: SINGLE_RAPID_PRESETS,
-  Bus: SINGLE_BUS_PRESETS,
+  Bus: SINGLE_RAPID_PRESETS,
   System: SINGLE_RAPID_PRESETS,
 };
 
@@ -263,7 +263,7 @@ export const RANGE_PRESETS: {
   [key in Tab]: { [key in DatePresetKey]?: DateSelectionDefaultOptions<DateParams> };
 } = {
   Subway: RANGE_RAPID_PRESETS,
-  Bus: RANGE_BUS_PRESETS,
+  Bus: RANGE_RAPID_PRESETS,
   System: RANGE_RAPID_PRESETS,
 };
 

--- a/common/state/defaults/dateDefaults.ts
+++ b/common/state/defaults/dateDefaults.ts
@@ -2,8 +2,6 @@ import type { Tab } from '../../constants/dashboardTabs';
 import type { DateStoreSection } from '../../constants/pages';
 import type { DateStoreConfiguration } from '../types/dateStoreTypes';
 import {
-  BUS_MAX_DATE,
-  BUS_MAX_DATE_MINUS_ONE_WEEK,
   ONE_WEEK_AGO_STRING,
   OVERVIEW_OPTIONS,
   TODAY_STRING,
@@ -28,11 +26,11 @@ export const BUS_DEFAULTS: WithOptional<DateStoreConfiguration, 'systemConfig' |
   {
     lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
     multiTripConfig: {
-      startDate: BUS_MAX_DATE_MINUS_ONE_WEEK,
-      endDate: BUS_MAX_DATE,
+      startDate: ONE_WEEK_AGO_STRING,
+      endDate: TODAY_STRING,
     },
     singleTripConfig: {
-      date: BUS_MAX_DATE,
+      date: TODAY_SERVICE_STARTED ? TODAY_STRING : YESTERDAY_STRING,
     },
   };
 

--- a/modules/landing/LineButton.tsx
+++ b/modules/landing/LineButton.tsx
@@ -29,7 +29,7 @@ export const LineButton: React.FC<LineButtonProps> = ({ children, line }) => {
       </div>
       <div className="flex flex-row items-baseline gap-2 md:flex-col md:items-center">
         <h3 className="text-center text-3xl md:text-xl">{LINE_OBJECTS[line].name}</h3>
-        {line === 'line-bus' && <p className="text-center font-bold">(WIP)</p>}
+        {line === 'line-bus' && <p className="text-center font-bold">(Beta)</p>}
       </div>
     </Link>
   );

--- a/modules/tripexplorer/TripExplorer.tsx
+++ b/modules/tripexplorer/TripExplorer.tsx
@@ -11,6 +11,7 @@ import { useDelimitatedRoute } from '../../common/utils/router';
 import { getParentStationForStopId } from '../../common/utils/stations';
 import { BusDataNotice } from '../../common/components/notices/BusDataNotice';
 import { GobbleDataNotice } from '../../common/components/notices/GobbleDataNotice';
+import { BetaDataNotice } from '../../common/components/notices/BetaDataNotice';
 import { useAlertStore } from './AlertStore';
 import { TripGraphs } from './TripGraphs';
 
@@ -37,6 +38,7 @@ export const TripExplorer = () => {
   return (
     <PageWrapper pageTitle={'Trips'}>
       <ChartPageDiv>
+        <BetaDataNotice />
         {alertsForModal?.length ? <AlertNotice /> : null}
         <TripGraphs fromStation={fromStation} toStation={toStation} />
         <div>

--- a/server/chalicelib/s3.py
+++ b/server/chalicelib/s3.py
@@ -78,6 +78,7 @@ def download_one_event_file(date, stop_id: str, use_live_data=False):
 @parallel.make_parallel
 def parallel_download_events(datestop):
     (date, stop) = datestop
+    # TODO: Force gobble when date is past the max monthly data date
     return download_one_event_file(date, stop)
 
 


### PR DESCRIPTION
## Motivation

Release gobble bus data to the masses!

## Changes

Releases day of bus data and switches bus to use the same date presets as rapid transit

<img width="1512" alt="Screenshot 2024-03-28 at 7 25 48 PM" src="https://github.com/transitmatters/t-performance-dash/assets/9310513/4fd4b2b8-cb18-441d-b0eb-1114686e2616">


## Testing Instructions

Confirm that there is live data for all bus routes

Confirm that data before Feb 29th 2024 doesn't show the beta warning

Confirm that aggregates and single dates all still work for bus data