### PR TITLE
Highlight unusually low headways in chart

### DIFF
--- a/common/components/charts/Legend.tsx
+++ b/common/components/charts/Legend.tsx
@@ -3,7 +3,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Disclosure } from '@headlessui/react';
 import React from 'react';
 
-export const LegendSingleDay: React.FC = () => {
+interface LegendProps {
+  showUnderRatio?: boolean;
+}
+
+export const LegendSingleDay: React.FC<LegendProps> = ({ showUnderRatio = false }) => {
   return (
     <Disclosure>
       {({ open }) => (
@@ -19,7 +23,7 @@ export const LegendSingleDay: React.FC = () => {
               'grid w-full grid-cols-2 items-baseline p-1 px-4 text-left text-xs lg:flex lg:flex-row lg:gap-4'
             }
           >
-            <LegendSingle />
+            <LegendSingle showUnderRatio={showUnderRatio} />
           </Disclosure.Panel>
         </div>
       )}
@@ -27,7 +31,7 @@ export const LegendSingleDay: React.FC = () => {
   );
 };
 
-const LegendSingle: React.FC = () => {
+const LegendSingle: React.FC<LegendProps> = ({ showUnderRatio = false }) => {
   return (
     <>
       <div className="col-span-2 flex flex-row items-baseline gap-2 pb-1 italic lg:pb-0">
@@ -37,6 +41,12 @@ const LegendSingle: React.FC = () => {
           MBTA benchmark:
         </p>
       </div>
+      {showUnderRatio && (
+        <p>
+          <span className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#0066ff] bg-[#0096FF]"></span>
+          {'50%+ early'}
+        </p>
+      )}
       <p>
         <span className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-[#57945B] bg-[#64b96a]"></span>
         {'On time'}

--- a/common/constants/colors.ts
+++ b/common/constants/colors.ts
@@ -31,6 +31,7 @@ export const COLORS = {
 // Colors for charts
 export const CHART_COLORS = {
   GREY: '#1c1c1c',
+  BLUE: '#0096FF',
   GREEN: '#64b96a',
   YELLOW: '#f5ed00',
   RED: '#c33149',

--- a/common/types/charts.ts
+++ b/common/types/charts.ts
@@ -80,6 +80,8 @@ export interface LineProps {
   includeBothStopsForLocation?: boolean;
   fname: DataName;
   showLegend?: boolean;
+  /** Show ratios under 1.00 differently in chart */
+  showUnderRatio?: boolean;
 }
 
 export interface AggregateLineProps extends LineProps {

--- a/modules/headways/charts/HeadwaysSingleChart.tsx
+++ b/modules/headways/charts/HeadwaysSingleChart.tsx
@@ -33,6 +33,7 @@ export const HeadwaysSingleChart: React.FC<HeadwaysChartProps> = ({
         fname={'headways'}
         units={'Minutes'}
         showLegend={showLegend && anyHeadwayBenchmarks}
+        showUnderRatio={true}
       />
     );
   }, [linePath, headways, date, fromStation, toStation, showLegend, anyHeadwayBenchmarks]);


### PR DESCRIPTION
## Motivation

Show headways which are 50% under the benchmark, often meaning that there's bunching

relates to #969 

## Changes

![Screenshot 2024-04-06 at 5 25 30 PM](https://github.com/transitmatters/t-performance-dash/assets/9310513/aa4ec5c8-ce08-4aee-b58c-1edc61161a2a)


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
