### PR TITLE
Bump monthly data to March 31st 2024

### DIFF
--- a/common/constants/dates.ts
+++ b/common/constants/dates.ts
@@ -35,7 +35,7 @@ export const THREE_MONTHS_AGO_STRING = TODAY.subtract(90, 'days').format(DATE_FO
 const OVERVIEW_TRAIN_MIN_DATE = '2016-02-01';
 const TRAIN_MIN_DATE = '2016-01-15';
 const BUS_MIN_DATE = '2018-08-01';
-export const BUS_MAX_DATE = '2024-02-29';
+export const BUS_MAX_DATE = '2024-03-31';
 export const BUS_MAX_DAY = dayjs(BUS_MAX_DATE);
 export const BUS_MAX_DATE_MINUS_ONE_WEEK = dayjs(BUS_MAX_DATE)
   .subtract(7, 'days')

--- a/server/chalicelib/date_utils.py
+++ b/server/chalicelib/date_utils.py
@@ -8,7 +8,7 @@ DATE_FORMAT_OUT = "%Y-%m-%dT%H:%M:%S"
 EASTERN_TIME = ZoneInfo("US/Eastern")
 
 # The most recent date for which we have monthly data
-MAX_MONTH_DATA_DATE = "2024-02-29"
+MAX_MONTH_DATA_DATE = "2024-03-31"
 
 
 def parse_event_date(date_str: str):


### PR DESCRIPTION
## Motivation

Monthly data for march is now available

## Changes

Bumps monthly bus and rapid data to March

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
