### PR TITLE
Add additional explainer text around prediction data delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TransitMatters Data Dashboard
 
+![Release](https://img.shields.io/github/v/release/transitmatters/t-performance-dash)
 ![lint](https://github.com/transitmatters/t-performance-dash/workflows/lint/badge.svg?branch=main)
 ![build](https://github.com/transitmatters/t-performance-dash/workflows/build/badge.svg?branch=main)
 ![deploy](https://github.com/transitmatters/t-performance-dash/workflows/deploy/badge.svg?branch=main)

--- a/modules/predictions/PredictionsDetails.tsx
+++ b/modules/predictions/PredictionsDetails.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { useDelimitatedRoute } from '../../common/utils/router';
@@ -118,6 +119,18 @@ export function PredictionsDetails() {
                       <li>6-12 min: 150 seconds early to 210 seconds late</li>
                       <li>12-30 min: 240 seconds early to 360 seconds late</li>
                     </ul>
+                    <br />
+                    <p>
+                      We receive this data in monthly batches from the{' '}
+                      <Link
+                        href="https://mbta-massdot.opendata.arcgis.com"
+                        target="_blank"
+                        className="hover:text-blue-500"
+                      >
+                        MassDOT Open Data Portal
+                      </Link>
+                      - if recent data is missing, it's likely because it's not yet available.
+                    </p>
                   </div>
                 ),
               },


### PR DESCRIPTION
## Motivation

Just some additional clarity for users, wrt both changes

## Changes

- Adds additional explainer text about where we get our data about predictions
- Adds release badge to README

## Testing Instructions
![image](https://github.com/transitmatters/t-performance-dash/assets/31703736/7888dc0e-7faa-4a2a-a68a-69ce25360604)
