### PR TITLE
Fix: Align scheduled/delivered trip counts

### DIFF
--- a/common/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/common/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
@@ -150,6 +150,8 @@ export const TimeSeriesChart = <Data extends Dataset[]>(props: Props<Data>) => {
       },
     };
 
+    console.log({ unit, time });
+
     return {
       x: {
         min: timeAxis.from,

--- a/common/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/common/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
@@ -150,8 +150,6 @@ export const TimeSeriesChart = <Data extends Dataset[]>(props: Props<Data>) => {
       },
     };
 
-    console.log({ unit, time });
-
     return {
       x: {
         min: timeAxis.from,

--- a/common/utils/array.ts
+++ b/common/utils/array.ts
@@ -1,0 +1,10 @@
+export const indexByProperty = <T extends { [key: string]: any }>(
+    array: T[],
+    property: keyof T
+) => {
+    const res: Record<string, T> = {};
+    array.forEach((el) => {
+        res[el[property]] = el;
+    });
+    return res;
+};

--- a/common/utils/array.ts
+++ b/common/utils/array.ts
@@ -1,10 +1,10 @@
 export const indexByProperty = <T extends { [key: string]: any }>(
-    array: T[],
-    property: keyof T
+  array: T[],
+  property: keyof T
 ) => {
-    const res: Record<string, T> = {};
-    array.forEach((el) => {
-        res[el[property]] = el;
-    });
-    return res;
+  const res: Record<string, T> = {};
+  array.forEach((el) => {
+    res[el[property]] = el;
+  });
+  return res;
 };

--- a/modules/service/ServiceGraph.tsx
+++ b/modules/service/ServiceGraph.tsx
@@ -47,8 +47,6 @@ export const ServiceGraph: React.FC<ServiceGraphProps> = (props: ServiceGraphPro
   const scheduledDataByDate = indexByProperty(predictedData.counts, 'date');
   const deliveredDataByDate = indexByProperty(data, 'date');
 
-  console.log(allDates);
-
   const scheduled = useMemo(() => {
     return {
       label: 'Scheduled round trips',


### PR DESCRIPTION
## Motivation

I've noticed that the scheduled/delivered trip counts graph is getting out of sync. It turns out that we are missing a few data points for each line in the `DeliveredTripMetricsWeekly` table, which is causing the `delivered` array for a given date range to be a little shorter than the `scheduled` one. We should backfill these values, but in the meantime, I've added some code to make sure that the data points on those graphs are always aligned by day. This results in some "holes" in the graph. Maybe there was shuttling that should appear here?

Long term I there should be a single API that returns both scheduled and delivered trip counts in one shot, like `/api/service_hours` does.

## Changes

Before:

![Screenshot 2024-06-17 at 21-59-55 Service Data Dashboard](https://github.com/transitmatters/t-performance-dash/assets/2208769/3f4a8216-05c6-4d61-99a1-cf2b01bc4ac2)

After:

![Screenshot 2024-06-17 at 22-00-05 Service Data Dashboard](https://github.com/transitmatters/t-performance-dash/assets/2208769/3a36d3c3-61ce-45d8-87f1-e9419dfa646c)


## Testing Instructions

With "Past Year" time range selected, click through the Overview pages for each rapid transit line and verify that they load correctly and appear synchronized.
