### PR TITLE
Hide beta warning on slow zones other than GL

### DIFF
--- a/common/components/notices/BetaSlowZoneDataNotice.tsx
+++ b/common/components/notices/BetaSlowZoneDataNotice.tsx
@@ -1,7 +1,14 @@
 import { ExclamationTriangleIcon } from '@heroicons/react/20/solid';
 import React from 'react';
+import { useDelimitatedRoute } from '../../utils/router';
 
 export const BetaSlowZoneDataNotice: React.FC = () => {
+  const { line } = useDelimitatedRoute();
+
+  if (line !== 'line-green') {
+    return null;
+  }
+
   return (
     <div className="rounded-md bg-yellow-50 p-4">
       <div className="flex">


### PR DESCRIPTION
## Motivation

We only need the beta warning on Green line data

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
