### PR TITLE
Exclude the Mattapan line from landing graphs

### DIFF
--- a/common/types/lines.ts
+++ b/common/types/lines.ts
@@ -136,6 +136,7 @@ export const LANDING_RAIL_LINES: Line[] = [
   'line-orange',
   'line-blue',
   'line-green',
+  'line-mattapan',
   'line-commuter-rail',
 ];
 

--- a/modules/landing/utils.ts
+++ b/modules/landing/utils.ts
@@ -31,6 +31,11 @@ const getDatasetOptions = (line: Line): Partial<ChartDataset<'line'>> => {
 
 export const convertToSpeedDataset = (data: { [key in Line]?: DeliveredTripMetrics[] }) => {
   return Object.keys(data).map((line: Line) => {
+    // We don't need to show the Mattapan line on the landing page
+    if (line === 'line-mattapan') {
+      return { data: [] };
+    }
+
     const datasetOptions = getDatasetOptions(line);
     return {
       ...datasetOptions,
@@ -97,6 +102,11 @@ export const convertToAggregateStationSpeedDataset = (
 
 export const convertToServiceDataset = (data: { [key in Line]?: DeliveredTripMetrics[] }) => {
   return Object.keys(data).map((line: Line) => {
+    // We don't need to show the Mattapan line on the landing page
+    if (line === 'line-mattapan') {
+      return { data: [] };
+    }
+
     const datasetOptions = getDatasetOptions(line);
     return {
       ...datasetOptions,
@@ -113,6 +123,11 @@ export const convertToServiceDataset = (data: { [key in Line]?: DeliveredTripMet
 export const convertToRidershipDataset = (data: { [key in Line]: RidershipCount[] }) => {
   return (
     Object.keys(data).map((line: Line) => {
+      // We don't need to show the Mattapan line on the landing page
+      if (line === 'line-mattapan') {
+        return { data: [] };
+      }
+
       const datasetOptions = getDatasetOptions(line);
       return {
         ...datasetOptions,


### PR DESCRIPTION
## Motivation

We don't need to display Mattapan on the landing charts, they can get confusing mixed in with the red line

## Changes

- Excludes Mattapan line from landing graphs

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
