### PR TITLE
Fix landing chart data labels

### DIFF
--- a/common/constants/charts.ts
+++ b/common/constants/charts.ts
@@ -31,6 +31,12 @@ export const DATA_LABELS_LANDING: LabelOptions = {
   font: {
     size: 12,
   },
-  display: (context) => context.dataIndex === context.dataset.data.length - 1,
+  display: (context) => {
+    const lastNonNullIndex = context.dataset.data.reduce(
+      (lastIndex, item, index) => (item !== null ? index : lastIndex),
+      -1
+    );
+    return context.dataIndex === lastNonNullIndex;
+  },
   formatter: (value) => `${value}%`, // Format the label content
 };

--- a/modules/landing/charts/OverallRidershipChart.tsx
+++ b/modules/landing/charts/OverallRidershipChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { RidershipCount } from '../../../common/types/dataPoints';
 import { RidershipBaseline } from '../../../copy/landingCopy';
 import type { Line as LineType } from '../../../common/types/lines';
-import { convertToRidershipDataset } from '../utils';
+import { convertToRidershipDataset, LANDING_CHART_LABELS } from '../utils';
 import { LandingChartDiv } from '../LandingChartDiv';
 import { LandingPageChart } from './LandingPageChart';
 
@@ -10,8 +10,8 @@ interface OverallRidershipChartProps {
   ridershipData: { [key in LineType]: RidershipCount[] };
 }
 export const OverallRidershipChart: React.FC<OverallRidershipChartProps> = ({ ridershipData }) => {
-  const labels = Object.values(ridershipData)[0].map((point) => point.date);
-  const datasets = convertToRidershipDataset(ridershipData);
+  const labels = LANDING_CHART_LABELS;
+  const datasets = convertToRidershipDataset(ridershipData, labels);
 
   return (
     <LandingChartDiv>

--- a/modules/landing/charts/OverallServiceChart.tsx
+++ b/modules/landing/charts/OverallServiceChart.tsx
@@ -3,15 +3,15 @@ import type { DeliveredTripMetrics } from '../../../common/types/dataPoints';
 import type { Line } from '../../../common/types/lines';
 import { ServiceBaseline } from '../../../copy/landingCopy';
 import { LandingChartDiv } from '../LandingChartDiv';
-import { convertToServiceDataset } from '../utils';
+import { convertToServiceDataset, LANDING_CHART_LABELS } from '../utils';
 import { LandingPageChart } from './LandingPageChart';
 
 interface OverallServiceChartProps {
   serviceData: { [key in Line]?: DeliveredTripMetrics[] };
 }
 export const OverallServiceChart: React.FC<OverallServiceChartProps> = ({ serviceData }) => {
-  const labels = Object.values(serviceData)[0].map((point) => point.date);
-  const datasets = convertToServiceDataset(serviceData);
+  const labels = LANDING_CHART_LABELS;
+  const datasets = convertToServiceDataset(serviceData, labels);
 
   return (
     <LandingChartDiv>

--- a/modules/landing/charts/OverallSpeedChart.tsx
+++ b/modules/landing/charts/OverallSpeedChart.tsx
@@ -3,15 +3,15 @@ import type { DeliveredTripMetrics } from '../../../common/types/dataPoints';
 import { SpeedBaseline } from '../../../copy/landingCopy';
 import type { Line } from '../../../common/types/lines';
 import { LandingChartDiv } from '../LandingChartDiv';
-import { convertToSpeedDataset } from '../utils';
+import { convertToSpeedDataset, LANDING_CHART_LABELS } from '../utils';
 import { LandingPageChart } from './LandingPageChart';
 
 interface OverallSpeedChartProps {
   speedData: { [key in Line]?: DeliveredTripMetrics[] };
 }
 export const OverallSpeedChart: React.FC<OverallSpeedChartProps> = ({ speedData }) => {
-  const labels = Object.values(speedData)[0].map((point) => point.date);
-  const datasets = convertToSpeedDataset(speedData);
+  const labels = LANDING_CHART_LABELS;
+  const datasets = convertToSpeedDataset(speedData, labels);
   return (
     <LandingChartDiv>
       <LandingPageChart datasets={datasets} labels={labels} id="system-speed" />


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

I have been noticing missing data labels on the landing pages. See below:
<img width="1091" alt="Screenshot 2025-02-05 at 2 03 23 PM" src="https://github.com/user-attachments/assets/98809b53-e298-4432-bf80-b1855ebe55d1" />

**Expected: **
<img width="611" alt="Screenshot 2025-02-05 at 2 03 41 PM" src="https://github.com/user-attachments/assets/28847ac1-2cae-4dfd-a1dd-351243cff12c" />

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->


The issue is that the labels for the chart were naively generated under the assumption that all weeks would have data for every line (my fault, I wrote this code). So it only looks at red line data to generate the data labels. 

So it looks at the return trip_metrics json file and uses that to generate the labels. see here: https://dashboard.transitmatters.org/static/landing/trip_metrics.json


Currently, there was no data for the week 2024-11-18 in the dataset for the red line (another possible fix would be to generate empty data for weekly aggregates rather than exclude the data).


This caused the labels for the data to be misaligned and causes issues not only with the missing labels, but also all of the datasets were aligned on the dates present on the red line, and gaps weren't appearing in the proper locations.


**Upon further review I am pretty sure this issue stems from weekly red line data being missing. I see that for the green line, weeks with no data generate entries with values of `0` but not for the red line.** 

I tried to take a look at this but couldn't find my AWS credentials. Maybe another day.

Regardless, this change is probably good to have. 



## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->

Verify that the results on each of the landing page charts aligns with the expected data from this endpoint: https://dashboard.transitmatters.org/static/landing/trip_metrics.json

You can also compare the dataset to the existing landing page charts and see there are errors. For example, there _is_ data for 11/18/2024 for the green line in the dataset, but the production site does not show it.
