### PR TITLE
Sort stop ids so we have consistent updates

### DIFF
--- a/common/constants/cr_constants/cr-fairmount.json
+++ b/common/constants/cr_constants/cr-fairmount.json
@@ -33,7 +33,7 @@
         "branches": null,
         "order": 3,
         "stops": {
-          "0": ["CR-Fairmount_0_DB-2222-02", "CR-Fairmount_0_DB-2222-01"],
+          "0": ["CR-Fairmount_0_DB-2222-01", "CR-Fairmount_0_DB-2222-02"],
           "1": ["CR-Fairmount_1_DB-2222-02"]
         }
       },
@@ -83,7 +83,7 @@
         "branches": null,
         "order": 8,
         "stops": {
-          "0": ["CR-Fairmount_0_DB-2265-02", "CR-Fairmount_0_DB-2265-01"],
+          "0": ["CR-Fairmount_0_DB-2265-01", "CR-Fairmount_0_DB-2265-02"],
           "1": ["CR-Fairmount_1_DB-2265-02"]
         }
       },
@@ -94,15 +94,15 @@
         "order": 9,
         "stops": {
           "0": [
-            "CR-Fairmount_0_NEC-2287-07",
             "CR-Fairmount_0_NEC-2287",
-            "CR-Fairmount_0_NEC-2287-11",
-            "CR-Fairmount_0_NEC-2287-08",
-            "CR-Fairmount_0_NEC-2287-13",
-            "CR-Fairmount_0_NEC-2287-09",
             "CR-Fairmount_0_NEC-2287-01",
+            "CR-Fairmount_0_NEC-2287-07",
+            "CR-Fairmount_0_NEC-2287-08",
+            "CR-Fairmount_0_NEC-2287-09",
             "CR-Fairmount_0_NEC-2287-10",
-            "CR-Fairmount_0_NEC-2287-12"
+            "CR-Fairmount_0_NEC-2287-11",
+            "CR-Fairmount_0_NEC-2287-12",
+            "CR-Fairmount_0_NEC-2287-13"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-fitchburg.json
+++ b/common/constants/cr_constants/cr-fitchburg.json
@@ -63,7 +63,7 @@
         "branches": null,
         "order": 6,
         "stops": {
-          "0": ["CR-Fitchburg_0_FR-0301-02", "CR-Fitchburg_0_FR-0301-01"],
+          "0": ["CR-Fitchburg_0_FR-0301-01", "CR-Fitchburg_0_FR-0301-02"],
           "1": ["CR-Fitchburg_1_FR-0301-02"]
         }
       },
@@ -83,7 +83,7 @@
         "branches": null,
         "order": 8,
         "stops": {
-          "0": ["CR-Fitchburg_0_FR-0219-02", "CR-Fitchburg_0_FR-0219-01"],
+          "0": ["CR-Fitchburg_0_FR-0219-01", "CR-Fitchburg_0_FR-0219-02"],
           "1": ["CR-Fitchburg_1_FR-0219-02"]
         }
       },
@@ -93,7 +93,7 @@
         "branches": null,
         "order": 9,
         "stops": {
-          "0": ["CR-Fitchburg_0_FR-0201-02", "CR-Fitchburg_0_FR-0201-01"],
+          "0": ["CR-Fitchburg_0_FR-0201-01", "CR-Fitchburg_0_FR-0201-02"],
           "1": ["CR-Fitchburg_1_FR-0201-02"]
         }
       },
@@ -133,7 +133,7 @@
         "branches": null,
         "order": 13,
         "stops": {
-          "0": ["CR-Fitchburg_0_FR-0115-02", "CR-Fitchburg_0_FR-0115-01"],
+          "0": ["CR-Fitchburg_0_FR-0115-01", "CR-Fitchburg_0_FR-0115-02"],
           "1": ["CR-Fitchburg_1_FR-0115-02"]
         }
       },
@@ -143,7 +143,7 @@
         "branches": null,
         "order": 14,
         "stops": {
-          "0": ["CR-Fitchburg_0_FR-0098-S", "CR-Fitchburg_0_FR-0098-01"],
+          "0": ["CR-Fitchburg_0_FR-0098-01", "CR-Fitchburg_0_FR-0098-S"],
           "1": ["CR-Fitchburg_1_FR-0098-S"]
         }
       },
@@ -173,7 +173,7 @@
         "branches": null,
         "order": 17,
         "stops": {
-          "0": ["CR-Fitchburg_0_FR-0034-02", "CR-Fitchburg_0_FR-0034-01"],
+          "0": ["CR-Fitchburg_0_FR-0034-01", "CR-Fitchburg_0_FR-0034-02"],
           "1": ["CR-Fitchburg_1_FR-0034-02"]
         }
       },
@@ -184,16 +184,16 @@
         "order": 18,
         "stops": {
           "0": [
+            "CR-Fitchburg_0_BNT-0000",
+            "CR-Fitchburg_0_BNT-0000-01",
+            "CR-Fitchburg_0_BNT-0000-02",
+            "CR-Fitchburg_0_BNT-0000-04",
             "CR-Fitchburg_0_BNT-0000-05",
             "CR-Fitchburg_0_BNT-0000-06",
             "CR-Fitchburg_0_BNT-0000-07",
-            "CR-Fitchburg_0_BNT-0000-04",
-            "CR-Fitchburg_0_BNT-0000-01",
-            "CR-Fitchburg_0_BNT-0000-10",
-            "CR-Fitchburg_0_BNT-0000",
             "CR-Fitchburg_0_BNT-0000-08",
-            "CR-Fitchburg_0_BNT-0000-02",
-            "CR-Fitchburg_0_BNT-0000-09"
+            "CR-Fitchburg_0_BNT-0000-09",
+            "CR-Fitchburg_0_BNT-0000-10"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-franklin.json
+++ b/common/constants/cr_constants/cr-franklin.json
@@ -123,8 +123,8 @@
         "branches": null,
         "order": 12,
         "stops": {
-          "0": ["CR-Franklin_0_FB-0095-05", "CR-Franklin_0_FB-0095-04"],
-          "1": ["CR-Franklin_1_NEC-2192-02", "CR-Franklin_1_FB-0095-04", "CR-Franklin_1_FB-0095-05"]
+          "0": ["CR-Franklin_0_FB-0095-04", "CR-Franklin_0_FB-0095-05"],
+          "1": ["CR-Franklin_1_FB-0095-04", "CR-Franklin_1_FB-0095-05", "CR-Franklin_1_NEC-2192-02"]
         }
       },
       {
@@ -143,11 +143,11 @@
         "branches": null,
         "order": 14,
         "stops": {
-          "0": ["CR-Franklin_0_NEC-2265-03", "CR-Franklin_0_NEC-2265-01"],
+          "0": ["CR-Franklin_0_NEC-2265-01", "CR-Franklin_0_NEC-2265-03"],
           "1": [
+            "CR-Franklin_1_NEC-2265-01",
             "CR-Franklin_1_NEC-2265-02",
-            "CR-Franklin_1_NEC-2265-03",
-            "CR-Franklin_1_NEC-2265-01"
+            "CR-Franklin_1_NEC-2265-03"
           ]
         }
       },
@@ -158,14 +158,14 @@
         "order": 15,
         "stops": {
           "0": [
-            "CR-Franklin_0_WML-0012-07",
+            "CR-Franklin_0_NEC-2276-01",
             "CR-Franklin_0_NEC-2276-03",
-            "CR-Franklin_0_NEC-2276-01"
+            "CR-Franklin_0_WML-0012-07"
           ],
           "1": [
+            "CR-Franklin_1_NEC-2276-01",
             "CR-Franklin_1_NEC-2276-02",
-            "CR-Franklin_1_NEC-2276-03",
-            "CR-Franklin_1_NEC-2276-01"
+            "CR-Franklin_1_NEC-2276-03"
           ]
         }
       },
@@ -176,17 +176,17 @@
         "order": 16,
         "stops": {
           "0": [
-            "CR-Franklin_0_NEC-2287-10",
-            "CR-Franklin_0_NEC-2287-04",
-            "CR-Franklin_0_NEC-2287-08",
             "CR-Franklin_0_NEC-2287",
-            "CR-Franklin_0_NEC-2287-11",
-            "CR-Franklin_0_NEC-2287-03",
             "CR-Franklin_0_NEC-2287-02",
-            "CR-Franklin_0_NEC-2287-07",
+            "CR-Franklin_0_NEC-2287-03",
+            "CR-Franklin_0_NEC-2287-04",
             "CR-Franklin_0_NEC-2287-05",
             "CR-Franklin_0_NEC-2287-06",
-            "CR-Franklin_0_NEC-2287-09"
+            "CR-Franklin_0_NEC-2287-07",
+            "CR-Franklin_0_NEC-2287-08",
+            "CR-Franklin_0_NEC-2287-09",
+            "CR-Franklin_0_NEC-2287-10",
+            "CR-Franklin_0_NEC-2287-11"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-greenbush.json
+++ b/common/constants/cr_constants/cr-greenbush.json
@@ -104,10 +104,10 @@
         "order": 10,
         "stops": {
           "0": [
-            "CR-Greenbush_0_NEC-2287-10",
             "CR-Greenbush_0_NEC-2287",
-            "CR-Greenbush_0_NEC-2287-11",
             "CR-Greenbush_0_NEC-2287-09",
+            "CR-Greenbush_0_NEC-2287-10",
+            "CR-Greenbush_0_NEC-2287-11",
             "CR-Greenbush_0_NEC-2287-12",
             "CR-Greenbush_0_NEC-2287-13"
           ],

--- a/common/constants/cr_constants/cr-kingston.json
+++ b/common/constants/cr_constants/cr-kingston.json
@@ -104,14 +104,14 @@
         "order": 10,
         "stops": {
           "0": [
-            "CR-Kingston_0_NEC-2287-13",
-            "CR-Kingston_0_NEC-2287-12",
+            "CR-Kingston_0_NEC-2287",
             "CR-Kingston_0_NEC-2287-05",
-            "CR-Kingston_0_NEC-2287-09",
-            "CR-Kingston_0_NEC-2287-11",
             "CR-Kingston_0_NEC-2287-07",
+            "CR-Kingston_0_NEC-2287-09",
             "CR-Kingston_0_NEC-2287-10",
-            "CR-Kingston_0_NEC-2287"
+            "CR-Kingston_0_NEC-2287-11",
+            "CR-Kingston_0_NEC-2287-12",
+            "CR-Kingston_0_NEC-2287-13"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-middleborough.json
+++ b/common/constants/cr_constants/cr-middleborough.json
@@ -44,7 +44,7 @@
         "order": 4,
         "stops": {
           "0": ["CR-Middleborough_0_MM-0200-S"],
-          "1": ["CR-Middleborough_1_MM-0200-S", "CR-Middleborough_1_MM-0200-CS"]
+          "1": ["CR-Middleborough_1_MM-0200-CS", "CR-Middleborough_1_MM-0200-S"]
         }
       },
       {
@@ -104,13 +104,13 @@
         "order": 10,
         "stops": {
           "0": [
-            "CR-Middleborough_0_NEC-2287-13",
-            "CR-Middleborough_0_NEC-2287-12",
-            "CR-Middleborough_0_NEC-2287-11",
-            "CR-Middleborough_0_NEC-2287-10",
-            "CR-Middleborough_0_NEC-2287-08",
             "CR-Middleborough_0_NEC-2287",
-            "CR-Middleborough_0_NEC-2287-09"
+            "CR-Middleborough_0_NEC-2287-08",
+            "CR-Middleborough_0_NEC-2287-09",
+            "CR-Middleborough_0_NEC-2287-10",
+            "CR-Middleborough_0_NEC-2287-11",
+            "CR-Middleborough_0_NEC-2287-12",
+            "CR-Middleborough_0_NEC-2287-13"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-needham.json
+++ b/common/constants/cr_constants/cr-needham.json
@@ -103,7 +103,7 @@
         "branches": null,
         "order": 10,
         "stops": {
-          "0": ["CR-Needham_0_NEC-2265-03", "CR-Needham_0_NEC-2265-01"],
+          "0": ["CR-Needham_0_NEC-2265-01", "CR-Needham_0_NEC-2265-03"],
           "1": ["CR-Needham_1_NEC-2265-02", "CR-Needham_1_NEC-2265-03"]
         }
       },
@@ -113,7 +113,7 @@
         "branches": null,
         "order": 11,
         "stops": {
-          "0": ["CR-Needham_0_NEC-2276-03", "CR-Needham_0_NEC-2276-01"],
+          "0": ["CR-Needham_0_NEC-2276-01", "CR-Needham_0_NEC-2276-03"],
           "1": ["CR-Needham_1_NEC-2276-02", "CR-Needham_1_NEC-2276-03"]
         }
       },
@@ -124,18 +124,19 @@
         "order": 12,
         "stops": {
           "0": [
-            "CR-Needham_0_NEC-2287-10",
+            "CR-Needham_0_NEC-2287",
+            "CR-Needham_0_NEC-2287-01",
+            "CR-Needham_0_NEC-2287-02",
+            "CR-Needham_0_NEC-2287-03",
+            "CR-Needham_0_NEC-2287-04",
             "CR-Needham_0_NEC-2287-05",
             "CR-Needham_0_NEC-2287-06",
             "CR-Needham_0_NEC-2287-07",
             "CR-Needham_0_NEC-2287-08",
-            "CR-Needham_0_NEC-2287",
-            "CR-Needham_0_NEC-2287-01",
-            "CR-Needham_0_NEC-2287-04",
-            "CR-Needham_0_NEC-2287-02",
+            "CR-Needham_0_NEC-2287-09",
+            "CR-Needham_0_NEC-2287-10",
             "CR-Needham_0_NEC-2287-12",
-            "CR-Needham_0_NEC-2287-13",
-            "CR-Needham_0_NEC-2287-03"
+            "CR-Needham_0_NEC-2287-13"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-newburyport.json
+++ b/common/constants/cr_constants/cr-newburyport.json
@@ -63,7 +63,7 @@
         "branches": null,
         "order": 6,
         "stops": {
-          "0": ["CR-Newburyport_0_GB-0198-02", "CR-Newburyport_0_GB-0198-01"],
+          "0": ["CR-Newburyport_0_GB-0198-01", "CR-Newburyport_0_GB-0198-02"],
           "1": ["CR-Newburyport_1_GB-0198-02"]
         }
       },
@@ -113,7 +113,7 @@
         "branches": null,
         "order": 11,
         "stops": {
-          "0": ["CR-Newburyport_0_ER-0208-02", "CR-Newburyport_0_ER-0208-01"],
+          "0": ["CR-Newburyport_0_ER-0208-01", "CR-Newburyport_0_ER-0208-02"],
           "1": ["CR-Newburyport_1_ER-0208-02"]
         }
       },
@@ -123,7 +123,7 @@
         "branches": null,
         "order": 12,
         "stops": {
-          "0": ["CR-Newburyport_0_ER-0183-02", "CR-Newburyport_0_ER-0183-01"],
+          "0": ["CR-Newburyport_0_ER-0183-01", "CR-Newburyport_0_ER-0183-02"],
           "1": ["CR-Newburyport_1_ER-0183-02"]
         }
       },
@@ -289,7 +289,7 @@
         "branches": null,
         "order": 17,
         "stops": {
-          "0": ["CR-Newburyport_0_ER-0117-02", "CR-Newburyport_0_ER-0117-01"],
+          "0": ["CR-Newburyport_0_ER-0117-01", "CR-Newburyport_0_ER-0117-02"],
           "1": ["CR-Newburyport_1_ER-0117-02"]
         }
       },
@@ -299,7 +299,7 @@
         "branches": null,
         "order": 18,
         "stops": {
-          "0": ["CR-Newburyport_0_ER-0099-02", "CR-Newburyport_0_ER-0099-01"],
+          "0": ["CR-Newburyport_0_ER-0099-01", "CR-Newburyport_0_ER-0099-02"],
           "1": ["CR-Newburyport_1_ER-0099-02"]
         }
       },
@@ -320,17 +320,17 @@
         "order": 20,
         "stops": {
           "0": [
-            "CR-Newburyport_0_BNT-0000-04",
-            "CR-Newburyport_0_BNT-0000-06",
-            "CR-Newburyport_0_BNT-0000-02",
-            "CR-Newburyport_0_BNT-0000-07",
-            "CR-Newburyport_0_BNT-0000-09",
-            "CR-Newburyport_0_BNT-0000-01",
-            "CR-Newburyport_0_BNT-0000-08",
             "CR-Newburyport_0_BNT-0000",
-            "CR-Newburyport_0_BNT-0000-10",
+            "CR-Newburyport_0_BNT-0000-01",
+            "CR-Newburyport_0_BNT-0000-02",
             "CR-Newburyport_0_BNT-0000-03",
-            "CR-Newburyport_0_BNT-0000-05"
+            "CR-Newburyport_0_BNT-0000-04",
+            "CR-Newburyport_0_BNT-0000-05",
+            "CR-Newburyport_0_BNT-0000-06",
+            "CR-Newburyport_0_BNT-0000-07",
+            "CR-Newburyport_0_BNT-0000-08",
+            "CR-Newburyport_0_BNT-0000-09",
+            "CR-Newburyport_0_BNT-0000-10"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-providence.json
+++ b/common/constants/cr_constants/cr-providence.json
@@ -43,8 +43,8 @@
         "branches": null,
         "order": 4,
         "stops": {
-          "0": ["CR-Providence_0_NEC-1891-02", "CR-Providence_0_NEC-1891-01"],
-          "1": ["CR-Providence_1_NEC-1891-02", "CR-Providence_1_NEC-1891-01"]
+          "0": ["CR-Providence_0_NEC-1891-01", "CR-Providence_0_NEC-1891-02"],
+          "1": ["CR-Providence_1_NEC-1891-01", "CR-Providence_1_NEC-1891-02"]
         }
       },
       {
@@ -114,11 +114,11 @@
         "order": 11,
         "stops": {
           "0": [
-            "CR-Providence_0_NEC-2139-02",
             "CR-Providence_0_NEC-2139-01",
+            "CR-Providence_0_NEC-2139-02",
             "CR-Providence_0_SB-0150-04"
           ],
-          "1": ["CR-Providence_1_SB-0150-06", "CR-Providence_1_NEC-2139-02"]
+          "1": ["CR-Providence_1_NEC-2139-02", "CR-Providence_1_SB-0150-06"]
         }
       },
       {
@@ -138,7 +138,7 @@
         "order": 13,
         "stops": {
           "0": ["CR-Providence_0_NEC-2192-03"],
-          "1": ["CR-Providence_1_NEC-2192-03", "CR-Providence_1_NEC-2192-02"]
+          "1": ["CR-Providence_1_NEC-2192-02", "CR-Providence_1_NEC-2192-03"]
         }
       },
       {
@@ -168,7 +168,7 @@
         "order": 16,
         "stops": {
           "0": ["CR-Providence_0_NEC-2276-01", "CR-Providence_0_NEC-2276-03"],
-          "1": ["CR-Providence_1_NEC-2276-03", "CR-Providence_1_NEC-2276-02"]
+          "1": ["CR-Providence_1_NEC-2276-02", "CR-Providence_1_NEC-2276-03"]
         }
       },
       {
@@ -178,18 +178,18 @@
         "order": 17,
         "stops": {
           "0": [
+            "CR-Providence_0_NEC-2287",
+            "CR-Providence_0_NEC-2287-02",
             "CR-Providence_0_NEC-2287-03",
-            "CR-Providence_0_NEC-2287-08",
-            "CR-Providence_0_NEC-2287-07",
-            "CR-Providence_0_NEC-2287-06",
             "CR-Providence_0_NEC-2287-04",
             "CR-Providence_0_NEC-2287-05",
-            "CR-Providence_0_NEC-2287-11",
+            "CR-Providence_0_NEC-2287-06",
+            "CR-Providence_0_NEC-2287-07",
+            "CR-Providence_0_NEC-2287-08",
             "CR-Providence_0_NEC-2287-09",
-            "CR-Providence_0_NEC-2287-12",
-            "CR-Providence_0_NEC-2287-02",
-            "CR-Providence_0_NEC-2287",
-            "CR-Providence_0_NEC-2287-10"
+            "CR-Providence_0_NEC-2287-10",
+            "CR-Providence_0_NEC-2287-11",
+            "CR-Providence_0_NEC-2287-12"
           ],
           "1": []
         },

--- a/common/constants/cr_constants/cr-worcester.json
+++ b/common/constants/cr_constants/cr-worcester.json
@@ -43,7 +43,7 @@
         "branches": null,
         "order": 4,
         "stops": {
-          "0": ["CR-Worcester_0_WML-0274-02", "CR-Worcester_0_WML-0274-01"],
+          "0": ["CR-Worcester_0_WML-0274-01", "CR-Worcester_0_WML-0274-02"],
           "1": ["CR-Worcester_1_WML-0274-02"]
         }
       },
@@ -64,7 +64,7 @@
         "order": 6,
         "stops": {
           "0": ["CR-Worcester_0_WML-0214-01", "CR-Worcester_0_WML-0214-02"],
-          "1": ["CR-Worcester_1_WML-0214-02", "CR-Worcester_1_WML-0214-01"]
+          "1": ["CR-Worcester_1_WML-0214-01", "CR-Worcester_1_WML-0214-02"]
         }
       },
       {
@@ -73,8 +73,8 @@
         "branches": null,
         "order": 7,
         "stops": {
-          "0": ["CR-Worcester_0_WML-0199-02", "CR-Worcester_0_WML-0199-01"],
-          "1": ["CR-Worcester_1_WML-0199-02", "CR-Worcester_1_WML-0199-01"]
+          "0": ["CR-Worcester_0_WML-0199-01", "CR-Worcester_0_WML-0199-02"],
+          "1": ["CR-Worcester_1_WML-0199-01", "CR-Worcester_1_WML-0199-02"]
         }
       },
       {
@@ -93,7 +93,7 @@
         "branches": null,
         "order": 9,
         "stops": {
-          "0": ["CR-Worcester_0_WML-0147-02", "CR-Worcester_0_WML-0147-01"],
+          "0": ["CR-Worcester_0_WML-0147-01", "CR-Worcester_0_WML-0147-02"],
           "1": ["CR-Worcester_1_WML-0147-01", "CR-Worcester_1_WML-0147-02"]
         }
       },
@@ -103,7 +103,7 @@
         "branches": null,
         "order": 10,
         "stops": {
-          "0": ["CR-Worcester_0_WML-0135-02", "CR-Worcester_0_WML-0135-01"],
+          "0": ["CR-Worcester_0_WML-0135-01", "CR-Worcester_0_WML-0135-02"],
           "1": ["CR-Worcester_1_WML-0135-01", "CR-Worcester_1_WML-0135-02"]
         }
       },
@@ -153,8 +153,8 @@
         "branches": null,
         "order": 15,
         "stops": {
-          "0": ["CR-Worcester_0_WML-0035-02", "CR-Worcester_0_WML-0035-01"],
-          "1": ["CR-Worcester_1_WML-0035-02", "CR-Worcester_1_WML-0035-01"]
+          "0": ["CR-Worcester_0_WML-0035-01", "CR-Worcester_0_WML-0035-02"],
+          "1": ["CR-Worcester_1_WML-0035-01", "CR-Worcester_1_WML-0035-02"]
         }
       },
       {
@@ -173,7 +173,7 @@
         "branches": null,
         "order": 17,
         "stops": {
-          "0": ["CR-Worcester_0_WML-0012-07", "CR-Worcester_0_WML-0012-05"],
+          "0": ["CR-Worcester_0_WML-0012-05", "CR-Worcester_0_WML-0012-07"],
           "1": ["CR-Worcester_1_WML-0012-05", "CR-Worcester_1_WML-0012-07"]
         }
       },
@@ -184,18 +184,18 @@
         "order": 18,
         "stops": {
           "0": [
-            "CR-Worcester_0_NEC-2287-03",
-            "CR-Worcester_0_NEC-2287-12",
-            "CR-Worcester_0_NEC-2287-02",
             "CR-Worcester_0_NEC-2287",
-            "CR-Worcester_0_NEC-2287-11",
+            "CR-Worcester_0_NEC-2287-01",
+            "CR-Worcester_0_NEC-2287-02",
+            "CR-Worcester_0_NEC-2287-03",
+            "CR-Worcester_0_NEC-2287-04",
+            "CR-Worcester_0_NEC-2287-05",
             "CR-Worcester_0_NEC-2287-06",
             "CR-Worcester_0_NEC-2287-07",
-            "CR-Worcester_0_NEC-2287-05",
-            "CR-Worcester_0_NEC-2287-04",
-            "CR-Worcester_0_NEC-2287-01",
+            "CR-Worcester_0_NEC-2287-09",
             "CR-Worcester_0_NEC-2287-10",
-            "CR-Worcester_0_NEC-2287-09"
+            "CR-Worcester_0_NEC-2287-11",
+            "CR-Worcester_0_NEC-2287-12"
           ],
           "1": []
         },

--- a/server/scripts/generate_line_files.py
+++ b/server/scripts/generate_line_files.py
@@ -71,6 +71,10 @@ def get_line_stops():
         else:
             parent_children_map[parent_id][direction].append(stop["name"])
 
+    for parent_id in parent_children_map:
+        for direction in parent_children_map[parent_id]:
+            parent_children_map[parent_id][direction].sort()
+
     return parent_children_map
 
 


### PR DESCRIPTION
## Motivation

Ensure that when updating CR manifests, we have smaller diffs in the future

## Changes

- Adds a sort option to CR stop ids

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
