### PR TITLE
Added Mattapan slow zone support

### DIFF
--- a/common/constants/pages.ts
+++ b/common/constants/pages.ts
@@ -143,7 +143,7 @@ export const ALL_PAGES: PageMap = {
     key: 'slowzones',
     path: '/slowzones',
     name: 'Slow zones',
-    lines: ['line-red', 'line-blue', 'line-orange', 'line-green'],
+    lines: ['line-red', 'line-blue', 'line-orange', 'line-green', 'line-mattapan'],
     icon: faWarning,
     dateStoreSection: 'line',
   },

--- a/modules/slowzones/SlowZonesDetails.tsx
+++ b/modules/slowzones/SlowZonesDetails.tsx
@@ -50,7 +50,11 @@ export function SlowZonesDetails() {
     !delayTotals.isError && delayTotals.data && startDateUTC && endDateUTC && lineShort && line;
   const segmentsReady = !allSlow.isError && allSlow.data && startDateUTC && lineShort;
   const canShowSlowZonesMap =
-    lineShort === 'Red' || lineShort === 'Blue' || lineShort === 'Orange' || lineShort === 'Green';
+    lineShort === 'Red' ||
+    lineShort === 'Blue' ||
+    lineShort === 'Orange' ||
+    lineShort === 'Green' ||
+    lineShort === 'Mattapan';
   const isDesktop = useBreakpoint('lg');
 
   if (!endDateUTC || !startDateUTC) {

--- a/modules/slowzones/SystemSlowZonesDetails.tsx
+++ b/modules/slowzones/SystemSlowZonesDetails.tsx
@@ -39,7 +39,11 @@ export function SystemSlowZonesDetails({ showTitle = false }: SystemSlowZonesDet
   const [lineShort, setLineShort] = useState<LineShort>('Red');
   const line = `line-${lineShort.toLowerCase()}` as Line;
   const canShowSlowZonesMap =
-    lineShort === 'Red' || lineShort === 'Blue' || lineShort === 'Orange' || lineShort === 'Green';
+    lineShort === 'Red' ||
+    lineShort === 'Blue' ||
+    lineShort === 'Orange' ||
+    lineShort === 'Green' ||
+    lineShort === 'Mattapan';
   const isDesktop = useBreakpoint('lg');
 
   const {
@@ -118,6 +122,7 @@ export function SystemSlowZonesDetails({ showTitle = false }: SystemSlowZonesDet
               Orange: 'Orange',
               Blue: 'Blue',
               Green: 'Green',
+              Mattapan: 'Mattapan',
             })}
           />
         </WidgetDiv>

--- a/modules/slowzones/charts/TotalSlowTime.tsx
+++ b/modules/slowzones/charts/TotalSlowTime.tsx
@@ -89,6 +89,14 @@ export const TotalSlowTime: React.FC<TotalSlowTimeProps> = ({
           pointRadius: 0,
           tension: 0.1,
         },
+        {
+          label: `Mattapan Line`,
+          data: data?.map((d) => (d['Mattapan'] / 60).toFixed(2)),
+          borderColor: LINE_COLORS['line-mattapan'],
+          backgroundColor: LINE_COLORS['line-mattapan'],
+          pointRadius: 0,
+          tension: 0.1,
+        },
       ];
   return (
     <ChartBorder>

--- a/modules/slowzones/map/SlowZonesMap.stories.tsx
+++ b/modules/slowzones/map/SlowZonesMap.stories.tsx
@@ -68,6 +68,12 @@ export const Primary = () => {
         direction="horizontal"
         speedRestrictions={[]}
       />
+      <SlowZonesMap
+        lineName="Mattapan"
+        slowZones={slowZonesResponses}
+        direction="horizontal"
+        speedRestrictions={[]}
+      />
     </>
   );
 };

--- a/modules/slowzones/types.ts
+++ b/modules/slowzones/types.ts
@@ -1,3 +1,3 @@
-const SLOW_ZONES_LINES = ['Red', 'Blue', 'Orange', 'Green'] as const;
+const SLOW_ZONES_LINES = ['Red', 'Blue', 'Orange', 'Green', 'Mattapan'] as const;
 
 export type SlowZonesLineName = (typeof SLOW_ZONES_LINES)[number];


### PR DESCRIPTION
## Motivation
Added support for Mattapan line slow zones per April, 3rd 2025 TM Labs meeting. 

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->
Added "Mattapan" to a bunch of Arrays, so that Mattapan line will have visualization for slow zone data. 

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
