### PR TITLE
Added vehicle_consist to backend API, and Frontend Tooltip on Travel …

### DIFF
--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -190,9 +190,27 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                     const { dataIndex } = tooltipItems[0];
                     const dataPoint = data[dataIndex];
                     if (dataPoint?.vehicle_consist) {
-                      result.push(
-                        `Vehicle Number(s): ${dataPoint.vehicle_consist.replaceAll('|', ', ')}`
-                      );
+                      const arrNums = dataPoint.vehicle_consist.split('|').map(Number);
+                      if (arrNums.length > 1) {
+                        result.push(
+                          `Vehicle Number(s): ${dataPoint.vehicle_consist.replaceAll('|', ', ')}`
+                        );
+                      } else {
+                        result.push(`Vehicle Number: ${dataPoint.vehicle_consist}`);
+                      }
+                    }
+                    if (dataPoint?.vehicle_label) {
+                      if (dataPoint?.vehicle_consist) {
+                        const arrNums = dataPoint.vehicle_consist.split('|').map(Number);
+                        const consistHead = arrNums[0];
+                        if (consistHead === parseInt(dataPoint.vehicle_label)) {
+                          //pass
+                        } else {
+                          result.push(`Vehicle Label: ${dataPoint.vehicle_label}`);
+                        }
+                      } else {
+                        result.push(`Vehicle Label: ${dataPoint.vehicle_label}`);
+                      }
                     }
 
                     return result;

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -167,18 +167,34 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                     ) {
                       return '';
                     }
-                    return `${tooltipItem.dataset.label}: ${
-                      units === 'Minutes'
+                    return `${tooltipItem.dataset.label}: ${units === 'Minutes'
                         ? getFormattedTimeString(tooltipItem.parsed.y, 'minutes')
                         : `${tooltipItem.parsed.y} ${units}`
-                    }`;
+                      }`;
                   },
                   afterBody: (tooltipItems) => {
-                    return departureFromNormalString(
+                    const result: string[] = [];
+
+                    // Add departure from normal information
+                    const departureInfo = departureFromNormalString(
                       tooltipItems[0].parsed.y,
                       tooltipItems[1]?.parsed.y,
                       showUnderRatio
                     );
+                    if (departureInfo) {
+                      result.push(departureInfo);
+                    }
+
+                    // Add vehicle consist information if available
+                    const { dataIndex } = tooltipItems[0];
+                    const dataPoint = data[dataIndex];
+                    if (dataPoint?.vehicle_consist) {
+                      result.push(
+                        `Vehicle Number(s): ${dataPoint.vehicle_consist.replaceAll('|', ', ')}`
+                      );
+                    }
+
+                    return result;
                   },
                 },
               },

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -193,7 +193,7 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                       const arrNums = dataPoint.vehicle_consist.split('|').map(Number);
                       if (arrNums.length > 1) {
                         result.push(
-                          `Vehicle Number(s): ${dataPoint.vehicle_consist.replaceAll('|', ', ')}`
+                          `Vehicle Numbers: ${dataPoint.vehicle_consist.replaceAll('|', ', ')}`
                         );
                       } else {
                         result.push(`Vehicle Number: ${dataPoint.vehicle_consist}`);

--- a/common/components/charts/SingleDayLineChart.tsx
+++ b/common/components/charts/SingleDayLineChart.tsx
@@ -167,10 +167,11 @@ export const SingleDayLineChart: React.FC<SingleDayLineProps> = ({
                     ) {
                       return '';
                     }
-                    return `${tooltipItem.dataset.label}: ${units === 'Minutes'
+                    return `${tooltipItem.dataset.label}: ${
+                      units === 'Minutes'
                         ? getFormattedTimeString(tooltipItem.parsed.y, 'minutes')
                         : `${tooltipItem.parsed.y} ${units}`
-                      }`;
+                    }`;
                   },
                   afterBody: (tooltipItems) => {
                     const result: string[] = [];

--- a/common/types/charts.ts
+++ b/common/types/charts.ts
@@ -15,6 +15,7 @@ export interface SingleDayDataPoint {
   threshold_flag_1?: string;
   speed_mph?: number;
   benchmark_speed_mph?: number;
+  vehicle_consist?: string;
 }
 
 export interface AggregateDataPoint {

--- a/common/types/charts.ts
+++ b/common/types/charts.ts
@@ -16,6 +16,7 @@ export interface SingleDayDataPoint {
   speed_mph?: number;
   benchmark_speed_mph?: number;
   vehicle_consist?: string;
+  vehicle_label?: string;
 }
 
 export interface AggregateDataPoint {

--- a/common/types/dataPoints.ts
+++ b/common/types/dataPoints.ts
@@ -14,6 +14,7 @@ export interface TravelTimePoint extends DataPoint {
   threshold_flag_1?: string;
   threshold_flag_2?: string;
   threshold_flag_3?: string;
+  vehicle_consist?: string;
 }
 
 export interface HeadwayPoint extends DataPoint {
@@ -25,12 +26,14 @@ export interface HeadwayPoint extends DataPoint {
   threshold_flag_1?: string;
   threshold_flag_2?: string;
   threshold_flag_3?: string;
+  vehicle_consist?: string;
 }
 
 export interface DwellPoint extends DataPoint {
   arr_dt: string;
   dep_dt: string;
   dwell_time_sec: number;
+  vehicle_consist?: string;
 }
 
 export interface DayDelayTotals {

--- a/common/types/dataPoints.ts
+++ b/common/types/dataPoints.ts
@@ -15,6 +15,7 @@ export interface TravelTimePoint extends DataPoint {
   threshold_flag_2?: string;
   threshold_flag_3?: string;
   vehicle_consist?: string;
+  vehicle_label?: string;
 }
 
 export interface HeadwayPoint extends DataPoint {
@@ -27,6 +28,7 @@ export interface HeadwayPoint extends DataPoint {
   threshold_flag_2?: string;
   threshold_flag_3?: string;
   vehicle_consist?: string;
+  vehicle_label?: string;
 }
 
 export interface DwellPoint extends DataPoint {
@@ -34,6 +36,7 @@ export interface DwellPoint extends DataPoint {
   dep_dt: string;
   dwell_time_sec: number;
   vehicle_consist?: string;
+  vehicle_label?: string;
 }
 
 export interface DayDelayTotals {

--- a/server/chalicelib/s3_historical.py
+++ b/server/chalicelib/s3_historical.py
@@ -58,6 +58,7 @@ def dwells(stop_ids: list, start_date: date, end_date: date):
                     "dep_dt": date_utils.return_formatted_date(dep_dt),
                     "dwell_time_sec": delta.total_seconds(),
                     "vehicle_consist": vehicle_consist,
+                    "vehicle_label": maybe_a_departure["vehicle_label"],
                 }
             )
 
@@ -100,6 +101,7 @@ def headways(stop_ids: list, start_date: date, end_date: date):
                 "headway_time_sec": headway_time_sec,
                 "benchmark_headway_time_sec": benchmark_headway,
                 "vehicle_consist": vehicle_consist,
+                "vehicle_label": this["vehicle_label"],
             }
         )
 
@@ -158,6 +160,7 @@ def travel_times(stops_a: list, stops_b: list, start_date: date, end_date: date)
                 "travel_time_sec": travel_time_sec,
                 "benchmark_travel_time_sec": benchmark,
                 "vehicle_consist": vehicle_consist,
+                "vehicle_label": departure["vehicle_label"],
             }
         )
 

--- a/server/chalicelib/s3_historical.py
+++ b/server/chalicelib/s3_historical.py
@@ -49,7 +49,7 @@ def dwells(stop_ids: list, start_date: date, end_date: date):
             delta = dep_dt - arr_dt
 
             # not every vehicle will have vehicle_consist
-            vehicle_consist = maybe_a_departure.get("vehicle_consist", "placeholder|value|for|now")
+            vehicle_consist = maybe_a_departure.get("vehicle_consist")
             dwells.append(
                 {
                     "route_id": maybe_a_departure["route_id"],
@@ -91,7 +91,7 @@ def headways(stop_ids: list, start_date: date, end_date: date):
             benchmark_headway = None
 
         # not every vehicle will have vehicle_consist
-        vehicle_consist = this.get("vehicle_consist", "placeholder|value|for|now")
+        vehicle_consist = this.get("vehicle_consist")
 
         headways.append(
             {
@@ -150,7 +150,7 @@ def travel_times(stops_a: list, stops_b: list, start_date: date, end_date: date)
             benchmark = None
 
         # not every vehicle will have vehicle_consist
-        vehicle_consist = departure.get("vehicle_consist", "placeholder|value|for|now")
+        vehicle_consist = departure.get("vehicle_consist")
         travel_times.append(
             {
                 "route_id": departure["route_id"],

--- a/server/chalicelib/s3_historical.py
+++ b/server/chalicelib/s3_historical.py
@@ -47,6 +47,9 @@ def dwells(stop_ids: list, start_date: date, end_date: date):
             dep_dt = date_utils.parse_event_date(maybe_a_departure["event_time"])
             arr_dt = date_utils.parse_event_date(maybe_an_arrival["event_time"])
             delta = dep_dt - arr_dt
+
+            # not every vehicle will have vehicle_consist
+            vehicle_consist = maybe_a_departure.get("vehicle_consist", "placeholder|value|for|now")
             dwells.append(
                 {
                     "route_id": maybe_a_departure["route_id"],
@@ -54,6 +57,7 @@ def dwells(stop_ids: list, start_date: date, end_date: date):
                     "arr_dt": date_utils.return_formatted_date(arr_dt),
                     "dep_dt": date_utils.return_formatted_date(dep_dt),
                     "dwell_time_sec": delta.total_seconds(),
+                    "vehicle_consist": vehicle_consist,
                 }
             )
 
@@ -85,6 +89,9 @@ def headways(stop_ids: list, start_date: date, end_date: date):
         if benchmark_headway == "":
             benchmark_headway = None
 
+        # not every vehicle will have vehicle_consist
+        vehicle_consist = this.get("vehicle_consist", "placeholder|value|for|now")
+
         headways.append(
             {
                 "route_id": this["route_id"],
@@ -92,6 +99,7 @@ def headways(stop_ids: list, start_date: date, end_date: date):
                 "current_dep_dt": date_utils.return_formatted_date(this_dt),
                 "headway_time_sec": headway_time_sec,
                 "benchmark_headway_time_sec": benchmark_headway,
+                "vehicle_consist": vehicle_consist,
             }
         )
 
@@ -139,6 +147,8 @@ def travel_times(stops_a: list, stops_b: list, start_date: date, end_date: date)
         except (TypeError, ValueError):
             benchmark = None
 
+        # not every vehicle will have vehicle_consist
+        vehicle_consist = departure.get("vehicle_consist", "placeholder|value|for|now")
         travel_times.append(
             {
                 "route_id": departure["route_id"],
@@ -147,6 +157,7 @@ def travel_times(stops_a: list, stops_b: list, start_date: date, end_date: date)
                 "arr_dt": date_utils.return_formatted_date(arr_dt),
                 "travel_time_sec": travel_time_sec,
                 "benchmark_travel_time_sec": benchmark,
+                "vehicle_consist": vehicle_consist,
             }
         )
 


### PR DESCRIPTION
…Times, Headways, and Dwells charts (#1071)

## Motivation

This PR tackles Issue 1071 to add the new field Vehicle_Consist to the API to pull from LAMP/Gobble. It adds the relevant vehicle numbers to the Trip chart tooltips to see if we can correlate problematic trips with specific vehicles. 

## Changes
Added vehicle_consist to the API which consists of a pipe delimited string of the vehicle numbers. For testing purposes a default value of "placeholder|value|for|now" was assigned to test the splitting of the string.
Example of the pipe string split out into human readable format:
<img width="966" height="477" alt="image" src="https://github.com/user-attachments/assets/1c827a84-743b-4929-b8db-910f45355405" />
Example of a vehicle number for the 1 Bus
<img width="962" height="437" alt="image" src="https://github.com/user-attachments/assets/3c28e45d-720f-4ecf-8b5e-e935e90e9db7" />

## Testing Instructions

Follow the directions to set up a test environment. Then for one of the lines navigate to trips/single and examine some data points in the charts. 