### PR TITLE
Updated time format to 12hr (#1038)

### DIFF
--- a/modules/speed/charts/SpeedBetweenStationsAggregateChart.tsx
+++ b/modules/speed/charts/SpeedBetweenStationsAggregateChart.tsx
@@ -42,7 +42,7 @@ export const SpeedBetweenStationsAggregateChart: React.FC<
         pointField={timeUnitByDate ? PointFieldKeys.serviceDate : PointFieldKeys.depTimeFromEpoch}
         timeUnit={timeUnitByDate ? 'day' : 'hour'}
         byTime={!timeUnitByDate}
-        timeFormat={timeUnitByDate ? 'MMM d yyyy' : 'H:mm aaaa'}
+        timeFormat={timeUnitByDate ? 'MMM d yyyy' : 'h:mm aaaa'}
         seriesName={'Median Speed'}
         startDate={startDate}
         endDate={endDate}

--- a/modules/traveltimes/charts/TravelTimesAggregateChart.tsx
+++ b/modules/traveltimes/charts/TravelTimesAggregateChart.tsx
@@ -40,7 +40,7 @@ export const TravelTimesAggregateChart: React.FC<TravelTimesAggregateChartProps>
         pointField={timeUnitByDate ? PointFieldKeys.serviceDate : PointFieldKeys.depTimeFromEpoch}
         timeUnit={timeUnitByDate ? 'day' : 'hour'}
         byTime={!timeUnitByDate}
-        timeFormat={timeUnitByDate ? 'MMM d yyyy' : 'H:mm aaaa'}
+        timeFormat={timeUnitByDate ? 'MMM d yyyy' : 'h:mm aaaa'}
         seriesName={'Median travel time'}
         startDate={startDate}
         endDate={endDate}


### PR DESCRIPTION
## Motivation

Per #1038 Tooltip times are 24-hour formatted, but with an AM/PM indicator on the "travel times by hour" chart.
This PR fixes the time format so that the times are formatted as 12-hour instead of 24. 

## Changes
Changed H:mm aaaa to h:mm aaaa on TravelTimesAggregateChart which was the chart that prompted the issue. I also changed it on SpeedBetweenStationsAggregateChart however we don't seem to show the time on that tooltip. 

<img width="953" height="398" alt="image" src="https://github.com/user-attachments/assets/3b7475ab-9b8a-43d1-a857-de00537fa421" />

## Testing Instructions

Start local environment and navigate to one of the lines or bus, then select "multi-day trips". Under the Travel times by hour chart hover over a datapoint after 1pm or so. If there is no data available, modify to an earlier date from the default Today value to ensure data in the afternoon populates. 