### PR TITLE
Added Central Wharf to Charlestown Ferry

### DIFF
--- a/common/constants/ferry_constants/ferry_f4.json
+++ b/common/constants/ferry_constants/ferry_f4.json
@@ -22,6 +22,21 @@
                 "terminus": true
             },
             {
+                "stop_name": "Central Wharf (South)",
+                "station": "Boat-Aquarium",
+                "branches": null,
+                "order": 1,
+                "stops": {
+                    "0": [
+                        "Boat-Aquarium"
+                    ],
+                    "1": [
+                        "Boat-Aquarium"
+                    ]
+                },
+                "terminus": true
+            },
+            {
                 "stop_name": "Charlestown Navy Yard",
                 "station": "Boat-Charlestown",
                 "branches": null,


### PR DESCRIPTION
## Motivation

Added Central Wharf to Charlestown Ferry as a number of trips in 2025 used this stop. 

## Changes

Updates the Ferry manifest file. 

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
