### PR TITLE
Add The RIDE ridership

### DIFF
--- a/common/components/graphics/styles/spinnerFillColor.ts
+++ b/common/components/graphics/styles/spinnerFillColor.ts
@@ -9,4 +9,5 @@ export const spinnerFillColor: StyleMap = {
   'line-bus': 'fill-mbta-bus',
   'line-commuter-rail': 'fill-mbta-commuterRail',
   'line-ferry': 'fill-mbta-ferry',
+  'line-RIDE': 'fill-mbta-bus',
 };

--- a/common/components/nav/MenuDropdown.tsx
+++ b/common/components/nav/MenuDropdown.tsx
@@ -29,6 +29,8 @@ export const MenuDropdown: React.FC<MenuDropdownProps> = ({ line, route, childre
     switch (line) {
       case 'line-bus':
         return faBus;
+      case 'line-RIDE':
+        return faBus;
       case 'line-green':
       case 'line-mattapan':
         return faTrainTram;

--- a/common/components/nav/TheRideDropdown.tsx
+++ b/common/components/nav/TheRideDropdown.tsx
@@ -1,0 +1,34 @@
+import classNames from 'classnames';
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { SidebarTabs } from '../../../modules/navigation/SidebarTabs';
+import { LINE_PAGES } from '../../constants/pages';
+import { lineColorBorder } from '../../styles/general';
+import type { Line } from '../../types/lines';
+
+interface TheRideDropdownProps {
+  line: Line;
+  close?: () => void;
+}
+
+export const TheRideDropdown: React.FC<TheRideDropdownProps> = ({ line, close }) => {
+  const router = useRouter();
+  // Only redirect if line is 'line-RIDE' and not already on ridership page
+  useEffect(() => {
+    if (line === 'line-RIDE' && !router.asPath.includes('/ridership')) {
+      router.replace('/the-ride/ridership');
+    }
+  }, [line, router]);
+
+  return (
+    <div
+      className={classNames(
+        'flex flex-col gap-[2px] rounded-b-md border border-opacity-50 bg-neutral-800 px-1 py-[4px]',
+        lineColorBorder[line ?? 'DEFAULT']
+      )}
+      role={'navigation'}
+    >
+      <SidebarTabs tabs={LINE_PAGES.filter((cur) => cur.lines.includes(line))} close={close} />
+    </div>
+  );
+};

--- a/common/components/nav/TheRideSection.tsx
+++ b/common/components/nav/TheRideSection.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useDelimitatedRoute } from '../../utils/router';
+import { MenuDropdown } from './MenuDropdown';
+import { TheRideDropdown } from './TheRideDropdown';
+
+interface TheRideSectionProps {
+  close?: () => void;
+}
+
+export const TheRideSection: React.FC<TheRideSectionProps> = ({ close }) => {
+  const route = useDelimitatedRoute();
+
+  return (
+    <div className="flex w-full flex-col gap-y-1">
+      <MenuDropdown line="line-RIDE" route={route}>
+        <TheRideDropdown line="line-RIDE" close={close} />
+      </MenuDropdown>
+    </div>
+  );
+};

--- a/common/constants/baselines.ts
+++ b/common/constants/baselines.ts
@@ -11,6 +11,7 @@ export const PEAK_SCHEDULED_SERVICE: { [key in Line | 'DEFAULT']: number } = {
   'line-commuter-rail': 0,
   'line-bus': 0,
   'line-ferry': 0,
+  'line-RIDE': 0,
   DEFAULT: 0,
 };
 
@@ -23,6 +24,7 @@ export const PEAK_SPEED: { [key in Line | 'DEFAULT']: number } = {
   'line-commuter-rail': 0,
   'line-bus': 0,
   'line-ferry': 0,
+  'line-RIDE': 0,
   DEFAULT: 0,
 };
 
@@ -165,6 +167,7 @@ export const PEAK_RIDERSHIP: {
   'CR-Providence': 25728,
   'line-commuter-rail': 126755,
   'line-ferry': 0,
+  'line-RIDE': 34102,
   DEFAULT: 520580,
 };
 

--- a/common/constants/colors.ts
+++ b/common/constants/colors.ts
@@ -11,6 +11,7 @@ export const COLORS = {
     bus: '#FFC72C',
     commuterRail: '#80276c',
     ferry: '#008EAA',
+    theRide: '#FFC72C',
   },
   charts: {
     fillBackgroundColor: '#bfc8d680',
@@ -56,6 +57,7 @@ export const LINE_COLORS: { [key in Line | 'default']: string } = {
   'line-mattapan': COLORS.mbta.mattapan,
   'line-commuter-rail': COLORS.mbta.commuterRail,
   'line-ferry': COLORS.mbta.ferry,
+  'line-RIDE': COLORS.mbta.bus,
   default: '#303030',
 };
 
@@ -70,5 +72,6 @@ export const LINE_COLORS_LEVELS: {
   'line-bus': { 0: '#ffc72c', 1: '#ffce46', 2: '#ffd55f', 3: '#ffdb79' },
   'line-commuter-rail': { 0: '#80276c', 1: '#8f2f7e', 2: '#9e3790', 3: '#ad41a2' },
   'line-ferry': { 0: '#008EAA', 1: '#1a9bb5', 2: '#33a8c0', 3: '#4db5cb' },
+  'line-RIDE': { 0: '#ffc72c', 1: '#ffce46', 2: '#ffd55f', 3: '#ffdb79' },
   default: '#303030',
 };

--- a/common/constants/dashboardTabs.ts
+++ b/common/constants/dashboardTabs.ts
@@ -25,4 +25,8 @@ export const DASHBOARD_TABS: {
     path: '/ferry/trips/single',
     query: { ferryRoute: 'Boat-F1', date: FERRY_DEFAULTS.singleTripConfig.date },
   },
+  'The RIDE': {
+    name: 'The RIDE',
+    path: '/the-ride/ridership',
+  },
 };

--- a/common/constants/dates.ts
+++ b/common/constants/dates.ts
@@ -39,6 +39,7 @@ export const THREE_MONTHS_AGO_STRING = TODAY.subtract(90, 'days').format(DATE_FO
 export const OVERVIEW_TRAIN_MIN_DATE = '2016-02-01';
 const TRAIN_MIN_DATE = '2016-01-15';
 const BUS_MIN_DATE = '2018-08-01';
+const RIDE_MIN_DATE = '2017-02-16';
 export const BUS_MAX_DATE = '2025-08-31';
 export const BUS_MAX_DAY = dayjs(BUS_MAX_DATE);
 export const BUS_MAX_DATE_MINUS_ONE_WEEK = dayjs(BUS_MAX_DATE)
@@ -49,6 +50,8 @@ export const BUS_MAX_DATE_MINUS_ONE_WEEK = dayjs(BUS_MAX_DATE)
 export const COMMUTER_RAIL_RIDERSHIP_MIN_DATE = '2022-06-22';
 export const COMMUTER_RAIL_DATA_MIN_DATE = '2024-01-01';
 
+export const RIDE_MAX_DATE = '2025-08-31';
+export const RIDE_MAX_DAY = dayjs(RIDE_MAX_DATE);
 export const getESTDayjs = (date: string) => {
   return dayjs(date).tz(est);
 };
@@ -151,6 +154,14 @@ const FLAT_PICKER_OPTIONS: {
     altFormat: 'M j, Y',
     dateFormat: 'Y-m-d',
   },
+  'The RIDE': {
+    enableTime: false,
+    minDate: RIDE_MIN_DATE,
+    maxDate: RIDE_MAX_DATE,
+    altInput: true,
+    altFormat: 'M j, Y',
+    dateFormat: 'Y-m-d',
+  },
 };
 
 const SINGLE_RAPID_PRESETS: {
@@ -216,6 +227,37 @@ const SINGLE_BUS_PRESETS: {
   },
 };
 
+const SINGLE_RIDE_PRESETS: {
+  [key in DatePresetKey]?: DateSelectionDefaultOptions<SingleDateParams>;
+} = {
+  mostRecent: {
+    key: 'mostRecent',
+    name: `${RIDE_MAX_DAY.format(PRETTY_DATE_FORMAT)}`,
+    input: { date: BUS_MAX_DATE },
+  },
+  firstOfMonth: {
+    key: 'firstOfMonth',
+    name: `${RIDE_MAX_DAY.startOf('month').format(PRETTY_DATE_FORMAT)}`,
+    input: {
+      date: RIDE_MAX_DAY.startOf('month').format(DATE_FORMAT),
+    },
+  },
+  firstOfYear: {
+    key: 'firstOfYear',
+    name: `First of ${RIDE_MAX_DAY.startOf('year').format('YYYY')}`,
+    input: {
+      date: RIDE_MAX_DAY.startOf('month').format(DATE_FORMAT),
+    },
+  },
+  firstOfPrevYear: {
+    key: 'firstOfPrevYear',
+    name: `First of ${RIDE_MAX_DAY.subtract(1, 'year').startOf('year').format('YYYY')}`,
+    input: {
+      date: RIDE_MAX_DAY.subtract(1, 'year').startOf('year').format(DATE_FORMAT),
+    },
+  },
+};
+
 export const SINGLE_PRESETS: {
   [key in Tab]: { [key in DatePresetKey]?: DateSelectionDefaultOptions<SingleDateParams> };
 } = {
@@ -224,6 +266,7 @@ export const SINGLE_PRESETS: {
   System: SINGLE_RAPID_PRESETS,
   'Commuter Rail': SINGLE_RAPID_PRESETS,
   Ferry: SINGLE_RAPID_PRESETS,
+  'The RIDE': SINGLE_RIDE_PRESETS,
 };
 
 const RANGE_RAPID_PRESETS: {
@@ -334,8 +377,53 @@ const RANGE_BUS_PRESETS: {
     key: 'all',
     name: 'All time',
     input: {
-      startDate: dayjs(BUS_MIN_DATE).format(DATE_FORMAT),
+      startDate: dayjs(RIDE_MIN_DATE).format(DATE_FORMAT),
       endDate: BUS_MAX_DATE,
+    },
+  },
+};
+
+const RANGE_RIDE_PRESETS: {
+  [key in DatePresetKey]?: DateSelectionDefaultOptions<DateParams>;
+} = {
+  thisMonth: {
+    key: 'thisMonth',
+    name: RIDE_MAX_DAY.format('MMMM YYYY'),
+    input: {
+      startDate: RIDE_MAX_DAY.startOf('month').format(DATE_FORMAT),
+      endDate: RIDE_MAX_DATE,
+    },
+  },
+  lastMonth: {
+    key: 'lastMonth',
+    name: RIDE_MAX_DAY.subtract(1, 'month').format('MMMM YYYY'),
+    input: {
+      startDate: RIDE_MAX_DAY.subtract(1, 'month').startOf('month').format(DATE_FORMAT),
+      endDate: RIDE_MAX_DAY.subtract(1, 'month').endOf('month').format(DATE_FORMAT),
+    },
+  },
+  thisYear: {
+    key: 'thisYear',
+    name: RIDE_MAX_DAY.format('YYYY'),
+    input: {
+      startDate: RIDE_MAX_DAY.startOf('year').format(DATE_FORMAT),
+      endDate: RIDE_MAX_DATE,
+    },
+  },
+  lastYear: {
+    key: 'lastYear',
+    name: RIDE_MAX_DAY.subtract(1, 'year').format('YYYY'),
+    input: {
+      startDate: RIDE_MAX_DAY.startOf('year').subtract(1, 'year').format(DATE_FORMAT),
+      endDate: RIDE_MAX_DAY.endOf('year').subtract(1, 'year').format(DATE_FORMAT),
+    },
+  },
+  all: {
+    key: 'all',
+    name: 'All time',
+    input: {
+      startDate: dayjs(RIDE_MIN_DATE).format(DATE_FORMAT),
+      endDate: RIDE_MAX_DATE,
     },
   },
 };
@@ -348,6 +436,7 @@ export const RANGE_PRESETS: {
   System: RANGE_RAPID_PRESETS,
   'Commuter Rail': RANGE_RAPID_PRESETS,
   Ferry: RANGE_RAPID_PRESETS,
+  'The RIDE': RANGE_RIDE_PRESETS,
 };
 
 export type DatePresetKey =

--- a/common/constants/lines.ts
+++ b/common/constants/lines.ts
@@ -58,4 +58,11 @@ export const LINE_OBJECTS: LineObject = {
     key: 'line-ferry',
     color: COLORS.mbta.ferry,
   },
+  'line-RIDE': {
+    name: 'The RIDE',
+    short: 'The RIDE',
+    path: 'the-ride',
+    key: 'line-RIDE',
+    color: COLORS.mbta.ferry,
+  },
 };

--- a/common/constants/pages.ts
+++ b/common/constants/pages.ts
@@ -177,6 +177,7 @@ export const ALL_PAGES: PageMap = {
       'line-bus',
       'line-commuter-rail',
       'line-ferry',
+      'line-RIDE',
     ],
     icon: faUsers,
     dateStoreSection: 'line',
@@ -191,6 +192,8 @@ export const BUS_OVERVIEW = [ALL_PAGES.ridership];
 export const COMMUTER_RAIL_OVERVIEW = [ALL_PAGES.ridership];
 
 export const FERRY_OVERVIEW = [ALL_PAGES.ridership];
+
+export const RIDE_OVERVIEW = [ALL_PAGES.ridership];
 
 export const OVERVIEW_PAGE = [ALL_PAGES.overview];
 

--- a/common/constants/stations.ts
+++ b/common/constants/stations.ts
@@ -139,7 +139,7 @@ import ferry_eastboston from './ferry_constants/ferry_eastboston.json';
 import ferry_lynn from './ferry_constants/ferry_lynn.json';
 
 export const rtStations: {
-  [key in Exclude<LineShort, 'Bus' | 'Commuter Rail' | 'Ferry'>]: LineMap;
+  [key in Exclude<LineShort, 'Bus' | 'Commuter Rail' | 'Ferry' | 'The RIDE'>]: LineMap;
 } = stations_json;
 
 export const busStations: { [key in BusRoute]: LineMap } = {

--- a/common/state/defaults/dateDefaults.ts
+++ b/common/state/defaults/dateDefaults.ts
@@ -62,6 +62,20 @@ export const FERRY_DEFAULTS: WithOptional<
   },
 };
 
+export const RIDE_DEFAULTS: WithOptional<
+  DateStoreConfiguration,
+  'systemConfig' | 'overviewPreset'
+> = {
+  lineConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
+  multiTripConfig: {
+    startDate: ONE_WEEK_AGO_STRING,
+    endDate: TODAY_STRING,
+  },
+  singleTripConfig: {
+    date: TODAY_SERVICE_STARTED ? TODAY_STRING : YESTERDAY_STRING,
+  },
+};
+
 const SYSTEM_DEFAULTS: Partial<DateStoreConfiguration> = {
   systemConfig: { startDate: OVERVIEW_OPTIONS.year.startDate, endDate: TODAY_STRING },
 };
@@ -71,7 +85,8 @@ const TAB_DATE_MAP: { [key in Tab]: Partial<DateStoreConfiguration> } = {
   Bus: BUS_DEFAULTS,
   System: SYSTEM_DEFAULTS,
   'Commuter Rail': COMMUTER_RAIL_DEFAULTS,
-  Ferry: BUS_DEFAULTS,
+  Ferry: FERRY_DEFAULTS,
+  'The RIDE': RIDE_DEFAULTS,
 };
 
 export const getDefaultDates = (dateStoreSection: DateStoreSection, tab: Tab) => {

--- a/common/styles/general.ts
+++ b/common/styles/general.ts
@@ -9,6 +9,7 @@ export const lineColorBackground: DefaultStyleMap = {
   'line-bus': `bg-mbta-bus`,
   'line-commuter-rail': `bg-mbta-commuterRail`,
   'line-ferry': `bg-mbta-ferry`,
+  'line-RIDE': `bg-mbta-bus`,
   DEFAULT: `bg-stone-800`,
 };
 
@@ -21,6 +22,7 @@ export const lineColorLightBorder: DefaultStyleMap = {
   'line-bus': `border-mbta-lightBus`,
   'line-commuter-rail': `border-mbta-lightCommuterRail`,
   'line-ferry': `border-mbta-lightFerry`,
+  'line-RIDE': `border-mbta-lightBus`,
   DEFAULT: `border-stone-900`,
 };
 
@@ -33,6 +35,7 @@ export const mbtaTextConfig: DefaultStyleMap = {
   'line-bus': `text-mbta-bus`,
   'line-commuter-rail': `text-mbta-commuterRail`,
   'line-ferry': `text-mbta-ferry`,
+  'line-RIDE': `text-mbta-bus`,
   DEFAULT: `text-black`,
 };
 
@@ -45,6 +48,7 @@ export const lineColorLightBackground: DefaultStyleMap = {
   'line-bus': `bg-mbta-lightBus`,
   'line-commuter-rail': `bg-mbta-lightCommuterRail`,
   'line-ferry': `bg-mbta-lightFerry`,
+  'line-RIDE': `bg-mbta-lightBus`,
   DEFAULT: `bg-stone-900`,
 };
 
@@ -57,6 +61,7 @@ export const lineColorDarkBackground: DefaultStyleMap = {
   'line-bus': `bg-mbta-darkBus`,
   'line-commuter-rail': `bg-mbta-darkCommuterRail`,
   'line-ferry': `bg-mbta-darkFerry`,
+  'line-RIDE': `bg-mbta-darkBus`,
   DEFAULT: `bg-stone-900`,
 };
 
@@ -69,6 +74,7 @@ export const buttonHighlightFocus: DefaultStyleMap = {
   'line-bus': `focus:ring-mbta-bus`,
   'line-commuter-rail': `focus:ring-mbta-commuterRail`,
   'line-ferry': `focus:ring-mbta-ferry`,
+  'line-RIDE': `focus:ring-mbta-bus`,
   DEFAULT: `focus:ring-stone-800`,
 };
 
@@ -81,6 +87,7 @@ export const lineColorTextHover: DefaultStyleMap = {
   'line-bus': `hover:text-mbta-bus`,
   'line-commuter-rail': `hover:text-mbta-commuterRail`,
   'line-ferry': `hover:text-mbta-ferry`,
+  'line-RIDE': `hover:text-mbta-bus`,
   DEFAULT: `hover:text-stone-800`,
 };
 
@@ -93,6 +100,7 @@ export const lineColorDarkBorder: DefaultStyleMap = {
   'line-bus': `border-mbta-darkBus`,
   'line-commuter-rail': `border-mbta-darkCommuterRail`,
   'line-ferry': `border-mbta-darkFerry`,
+  'line-RIDE': `border-mbta-darkBus`,
   DEFAULT: `border-stone-900`,
 };
 
@@ -105,6 +113,7 @@ export const lineColorBorder: DefaultStyleMap = {
   'line-bus': `border-mbta-bus`,
   'line-commuter-rail': `border-mbta-commuterRail`,
   'line-ferry': `border-mbta-ferry`,
+  'line-RIDE': `border-mbta-bus`,
   DEFAULT: `border-stone-800`,
 };
 
@@ -117,6 +126,7 @@ export const lineColorText: DefaultStyleMap = {
   'line-bus': `text-mbta-bus`,
   'line-commuter-rail': `text-mbta-commuterRail`,
   'line-ferry': `text-mbta-ferry`,
+  'line-RIDE': `text-mbta-bus`,
   DEFAULT: `text-stone-800`,
 };
 
@@ -129,5 +139,6 @@ export const lineColorRing: DefaultStyleMap = {
   'line-bus': `ring-mbta-bus`,
   'line-commuter-rail': `ring-mbta-commuterRail`,
   'line-ferry': `ring-mbta-ferry`,
+  'line-RIDE': `ring-mbta-bus`,
   DEFAULT: `ring-stone-800`,
 };

--- a/common/types/lines.ts
+++ b/common/types/lines.ts
@@ -6,7 +6,8 @@ export type Line =
   | 'line-mattapan'
   | 'line-bus'
   | 'line-commuter-rail'
-  | 'line-ferry';
+  | 'line-ferry'
+  | 'line-RIDE';
 
 export type LineShort =
   | 'Red'
@@ -16,7 +17,8 @@ export type LineShort =
   | 'Mattapan'
   | 'Bus'
   | 'Commuter Rail'
-  | 'Ferry';
+  | 'Ferry'
+  | 'The RIDE';
 
 export type LinePath =
   | 'red'
@@ -26,7 +28,8 @@ export type LinePath =
   | 'mattapan'
   | 'bus'
   | 'commuter-rail'
-  | 'ferry';
+  | 'ferry'
+  | 'the-ride';
 
 export type FerryRoute =
   | 'Boat-F1'
@@ -272,6 +275,7 @@ export const RIDERSHIP_KEYS = {
   'line-blue': 'line-Blue',
   'line-green': 'line-Green',
   'line-mattapan': 'line-Mattapan',
+  'line-RIDE': 'line-RIDE',
 };
 
 export const GTFS_COLOR_LINE_IDS = [
@@ -482,5 +486,11 @@ export const COMMUTER_RAIL_PATH = {
 export const FERRY_PATH = {
   params: {
     line: 'ferry',
+  },
+};
+
+export const THE_RIDE_PATH = {
+  params: {
+    line: 'the-ride',
   },
 };

--- a/common/types/ridership.ts
+++ b/common/types/ridership.ts
@@ -15,7 +15,12 @@ export type LineKind =
 export type ServiceDay = 'weekday' | 'saturday' | 'sunday';
 export type ServiceRegime = 'peak' | 'current';
 
-export type RidershipKey = Exclude<Line, 'line-bus'> | BusRouteId | CommuterRailRoute | 'DEFAULT';
+export type RidershipKey =
+  | Exclude<Line, 'line-bus'>
+  | BusRouteId
+  | CommuterRailRoute
+  | 'line-RIDE'
+  | 'DEFAULT';
 
 export type TripsPerHour = readonly number[] & { length: 24 };
 

--- a/common/types/router.ts
+++ b/common/types/router.ts
@@ -29,4 +29,4 @@ export type QueryParams = {
 
 export type QueryTypeOptions = 'single' | 'range';
 
-export type Tab = 'Bus' | 'Subway' | 'Commuter Rail' | 'System' | 'Ferry';
+export type Tab = 'Bus' | 'Subway' | 'Commuter Rail' | 'System' | 'Ferry' | 'The RIDE';

--- a/common/types/stations.ts
+++ b/common/types/stations.ts
@@ -35,7 +35,7 @@ export interface LineMap {
 }
 
 export type StationMap = {
-  [key in LineShort]:
+  [key in Exclude<LineShort, 'The RIDE'>]:
     | LineMap
     | { [key in CommuterRailRoute]: LineMap }
     | { [key in BusRoute]: LineMap }

--- a/common/utils/router.tsx
+++ b/common/utils/router.tsx
@@ -25,6 +25,7 @@ const linePathToKeyMap: Record<LinePath, Line> = {
   bus: 'line-bus',
   'commuter-rail': 'line-commuter-rail',
   ferry: 'line-ferry',
+  'the-ride': 'line-RIDE',
 };
 
 const getParams = (params: ParsedUrlQuery | QueryParams) => {
@@ -65,6 +66,8 @@ const getTab = (path: LinePath) => {
     return 'Bus';
   } else if (path === 'commuter-rail') {
     return 'Commuter Rail';
+  } else if (path === 'the-ride') {
+    return 'The RIDE';
   } else {
     return 'System';
   }

--- a/modules/navigation/SideNavigation.tsx
+++ b/modules/navigation/SideNavigation.tsx
@@ -5,6 +5,7 @@ import { faHouse, faUsers, faWarning } from '@fortawesome/free-solid-svg-icons';
 import classNames from 'classnames';
 import { SubwaySection } from '../../common/components/nav/SubwaySection';
 import { BusSection } from '../../common/components/nav/BusSection';
+import { TheRideSection } from '../../common/components/nav/TheRideSection';
 import { useDelimitatedRoute } from '../../common/utils/router';
 import { CommuterRailSection } from '../../common/components/nav/CommuterRailSection';
 
@@ -60,6 +61,7 @@ export const SideNavigation: React.FC<SideNavigationProps> = ({ close }) => {
         <SubwaySection close={close} />
         <BusSection close={close} />
         <CommuterRailSection close={close} />
+        <TheRideSection close={close} />
       </ul>
     </nav>
   );

--- a/pages/[line]/ridership.tsx
+++ b/pages/[line]/ridership.tsx
@@ -1,4 +1,9 @@
-import { ALL_LINE_PATHS, BUS_PATH, COMMUTER_RAIL_PATH } from '../../common/types/lines';
+import {
+  ALL_LINE_PATHS,
+  BUS_PATH,
+  COMMUTER_RAIL_PATH,
+  THE_RIDE_PATH,
+} from '../../common/types/lines';
 import { RidershipDetails } from '../../modules/ridership/RidershipDetails';
 
 export async function getStaticProps() {
@@ -7,7 +12,7 @@ export async function getStaticProps() {
 
 export async function getStaticPaths() {
   return {
-    paths: [...ALL_LINE_PATHS, BUS_PATH, COMMUTER_RAIL_PATH],
+    paths: [...ALL_LINE_PATHS, BUS_PATH, COMMUTER_RAIL_PATH, THE_RIDE_PATH],
     fallback: false,
   };
 }


### PR DESCRIPTION
## Motivation

Adds ridership data for The RIDE since the MBTA provides daily information for this. 

## Changes

<img width="240" height="106" alt="image" src="https://github.com/user-attachments/assets/899717ee-9bc9-4697-9aac-e1525da7f737" />


<img width="2289" height="560" alt="image" src="https://github.com/user-attachments/assets/9eda5b40-4ad4-4f77-ae73-ec785e9624ef" />

## Testing Instructions

Only the Ridership data is shown, currently it navigates to /the-ride then /the-ride/ridership so right now users can briefly see a 404. Ideally we'd navigate directly to /the-ride/ridership or find some other datasets to make a landing/overview page fit in better. 