### PR TITLE
Improve ridership dashboard styling for very large viewports

### DIFF
--- a/modules/serviceAndRidership/LineCard/TphChart.tsx
+++ b/modules/serviceAndRidership/LineCard/TphChart.tsx
@@ -54,8 +54,9 @@ export const TphChart = (props: Props) => {
 
   const { datasets } = data;
 
-  const chartJsOptions = useMemo(() => {
+  const chartJsOptions: React.ComponentProps<typeof Line>['options'] = useMemo(() => {
     return {
+      maintainAspectRatio: false,
       plugins: {
         datalabels: {
           display: false,

--- a/modules/serviceAndRidership/LineGrid/LineGrid.tsx
+++ b/modules/serviceAndRidership/LineGrid/LineGrid.tsx
@@ -72,7 +72,7 @@ const isRidershipSort = (sort: '' | Sort) => {
 
 const getTailwindClassForDisplayOption = (display: DisplayOption) => {
   return display === 'grid'
-    ? 'w-full grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4'
+    ? 'w-full grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4'
     : 'w-full flex flex-col gap-4';
 };
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

Things were looking a little silly on my giant monitor:
<img width="3552" height="1521" alt="image" src="https://github.com/user-attachments/assets/469639a7-4941-4845-80ea-378f28ea8139" />

Much more manageable now:
<img width="3552" height="1521" alt="image" src="https://github.com/user-attachments/assets/98ab66a1-bfa3-4695-a4aa-177940b4387d" />

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

Visit `/system/ridership` and check that line cards look good at all viewport sizes
