### PR TITLE
Add Dwells to commuter rail

### DIFF
--- a/common/api/datadashboard.ts
+++ b/common/api/datadashboard.ts
@@ -146,6 +146,7 @@ export const useTripExplorerQueries: UseQueriesOverload = (
     return {
       [QueryNameKeys.traveltimes]: requests[0],
       [QueryNameKeys.headways]: requests[1],
+      [QueryNameKeys.dwells]: requests[2],
     };
   }
 

--- a/common/types/api.ts
+++ b/common/types/api.ts
@@ -14,7 +14,7 @@ export type RouteType = 'bus' | 'subway' | 'cr' | 'ferry';
 export const QUERIES: { [key in RouteType]: QueryNameOptions[] } = {
   subway: [QueryNameKeys.traveltimes, QueryNameKeys.headways, QueryNameKeys.dwells],
   bus: [QueryNameKeys.traveltimes, QueryNameKeys.headways],
-  cr: [QueryNameKeys.traveltimes, QueryNameKeys.headways],
+  cr: [QueryNameKeys.traveltimes, QueryNameKeys.headways, QueryNameKeys.dwells],
   ferry: [QueryNameKeys.traveltimes, QueryNameKeys.headways],
 };
 

--- a/modules/tripexplorer/CommuterRailTripGraphs.tsx
+++ b/modules/tripexplorer/CommuterRailTripGraphs.tsx
@@ -11,6 +11,8 @@ import { TravelTimesAggregateWrapper } from '../traveltimes/TravelTimesAggregate
 import { HeadwaysAggregateWrapper } from '../headways/HeadwaysAggregateWrapper';
 import { TravelTimesSingleWrapper } from '../traveltimes/TravelTimesSingleWrapper';
 import { HeadwaysSingleWrapper } from '../headways/HeadwaysSingleWrapper';
+import { DwellsAggregateWrapper } from '../dwells/DwellsAggregateWrapper';
+import { DwellsSingleWrapper } from '../dwells/DwellsSingleWrapper';
 import { WidgetTitle } from '../../common/components/widgets';
 
 interface CommuterRailTripGraphsProps {
@@ -32,7 +34,7 @@ export const CommuterRailTripGraphs: React.FC<CommuterRailTripGraphsProps> = ({
 }) => {
   const [peakTime, setPeakTime] = React.useState<'weekday' | 'weekend'>('weekday');
 
-  const { traveltimes, headways } = useTripExplorerQueries(
+  const { traveltimes, headways, dwells } = useTripExplorerQueries(
     'cr',
     parameters,
     // @ts-expect-error The overloading doesn't seem to handle this const
@@ -69,6 +71,19 @@ export const CommuterRailTripGraphs: React.FC<CommuterRailTripGraphsProps> = ({
 
             <HeadwaysAggregateWrapper
               query={headways}
+              fromStation={fromStation}
+              toStation={toStation}
+            />
+          </WidgetDiv>
+          <WidgetDiv>
+            <WidgetTitle
+              title="Dwells"
+              subtitle="Time spent at station"
+              location={location}
+              line={line}
+            />
+            <DwellsAggregateWrapper
+              query={dwells}
               fromStation={fromStation}
               toStation={toStation}
             />
@@ -126,6 +141,15 @@ export const CommuterRailTripGraphs: React.FC<CommuterRailTripGraphsProps> = ({
               toStation={toStation}
               fromStation={fromStation}
             />
+          </WidgetDiv>
+          <WidgetDiv>
+            <WidgetTitle
+              title="Dwells"
+              subtitle="Time spent at station"
+              location={location}
+              line={line}
+            />
+            <DwellsSingleWrapper query={dwells} toStation={toStation} fromStation={fromStation} />
           </WidgetDiv>
         </>
       )}


### PR DESCRIPTION
## Motivation

Commuter Rail dwells are known to be long, we should show them since we have the data

## Changes

- Show dwells for commuter rail stops

<img width="732" height="445" alt="Screenshot 2026-05-05 at 7 43 11 PM" src="https://github.com/user-attachments/assets/6164b2cb-d659-434d-ab03-172dfb009f37" />

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
