### PR TITLE
Route historical alerts through LAMP

### DIFF
--- a/server/chalicelib/data_funcs.py
+++ b/server/chalicelib/data_funcs.py
@@ -5,11 +5,16 @@ import pytz
 import traceback
 from datetime import date, timedelta
 from typing import Dict, Any, Callable, List, Union
+from botocore.exceptions import ClientError
 from chalicelib import s3_historical, s3_alerts, s3
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 WE_HAVE_V2_ALERTS_SINCE = datetime.date(2017, 11, 6)
-WE_HAVE_V3_ALERTS_SINCE = datetime.date(2024, 4, 12)
+# LAMP's alert coverage is dense from this date onward (sparser before it) -- see
+# mbta-performance's chalicelib/lamp/alerts.py module docstring. It supersedes the
+# v3 poller (previously the boundary here was WE_HAVE_V3_ALERTS_SINCE, 2024-04-12)
+# for every day at or after this date.
+WE_HAVE_LAMP_ALERTS_SINCE = datetime.date(2019, 9, 1)
 
 
 def bucket_by(
@@ -192,8 +197,10 @@ def dwells(start_date, stops, end_date: date | None = None):
 def alerts(day: date, params):
     """Retrieve and flatten alert data for a given date and route(s) from S3.
 
-    Fetches v2 alerts (2017-11-06 to 2024-04-12) or v3 alerts (after 2024-04-12),
-    then flattens alert versions into a list of {valid_from, valid_to, text} dicts.
+    Fetches v2 alerts (2017-11-06 to 2019-08-31), LAMP-derived alerts (2019-09-01
+    onward, falling back to the live v3 poller's file for a day LAMP hasn't
+    published yet), then flattens alert versions into a list of
+    {valid_from, valid_to, text} dicts.
 
     Args:
       day: date: The date to fetch alerts for.
@@ -203,14 +210,19 @@ def alerts(day: date, params):
       list[dict] | None: Flattened alert entries, or None if no data is available.
     """
     try:
-        # Use the API for today and yesterday's transit day, otherwise us.
         routes = params.get("route")
-        if day >= WE_HAVE_V2_ALERTS_SINCE and day <= WE_HAVE_V3_ALERTS_SINCE:
+        if day >= WE_HAVE_V2_ALERTS_SINCE and day < WE_HAVE_LAMP_ALERTS_SINCE:
             # This is stupid because we're emulating MBTA-performance ick
             alert_items = s3_alerts.get_v2_alerts(day, routes)
-        elif day >= WE_HAVE_V3_ALERTS_SINCE:
-            # fetch s3 v3 data
-            alert_items = s3_alerts.get_v3_alerts(day, routes)
+        elif day >= WE_HAVE_LAMP_ALERTS_SINCE:
+            try:
+                alert_items = s3_alerts.get_lamp_alerts(day, routes)
+            except ClientError as e:
+                if e.response["Error"]["Code"] != "NoSuchKey":
+                    raise
+                # LAMP hasn't published this day yet (e.g. today, before the daily
+                # rebuild has run) -- fall back to the live v3 poller's file.
+                alert_items = s3_alerts.get_v3_alerts(day, routes)
         else:
             return None
 

--- a/server/chalicelib/s3_alerts.py
+++ b/server/chalicelib/s3_alerts.py
@@ -53,6 +53,38 @@ def key(day, v3: bool = False):
     return f"Alerts/{str(day)}.json.gz"
 
 
+def lamp_key(day):
+    """Constructs the S3 object key for a given day's LAMP-derived alert data.
+
+    Args:
+        day: The date for which to retrieve alerts.
+
+    Returns:
+        str: The S3 key path for the alert file (e.g. ``Alerts/lamp/2024-01-01.json.gz``).
+    """
+    return f"Alerts/lamp/{str(day)}.json.gz"
+
+
+def _filter_by_route(alerts, routes):
+    """Filters an iterable of alert objects down to those touching any of ``routes``.
+
+    Args:
+        alerts: Iterable of alert objects (v2, v3, or LAMP -- routes_for_alert handles both shapes).
+        routes: Route IDs to filter by; no filtering is applied if falsy.
+
+    Returns:
+        list[dict]: Alerts that affect at least one route in ``routes``, or all of them if ``routes`` is falsy.
+    """
+
+    def matches_route(alert):
+        if not routes:
+            return True
+        targets = routes_for_alert(alert)
+        return any(r in targets for r in routes)
+
+    return list(filter(matches_route, alerts))
+
+
 def get_v2_alerts(day: date, routes):
     """Downloads and filters v2 alerts from S3 for a given day and set of routes.
 
@@ -65,23 +97,7 @@ def get_v2_alerts(day: date, routes):
     """
     alerts_str = s3.download(key(day), "utf8")
     alerts = json.loads(alerts_str)[0]["past_alerts"]
-
-    def matches_route(alert):
-        """Checks whether an alert applies to any of the target routes.
-
-        Args:
-            alert (dict): A single alert object.
-
-        Returns:
-            bool: True if the alert affects at least one route in ``routes``,
-            or True if ``routes`` is None (no filter applied).
-        """
-        if not routes:
-            return True
-        targets = routes_for_alert(alert)
-        return any(r in targets for r in routes)
-
-    return list(filter(matches_route, alerts))
+    return _filter_by_route(alerts, routes)
 
 
 def get_v3_alerts(day: date, routes: list[str]):
@@ -96,20 +112,23 @@ def get_v3_alerts(day: date, routes: list[str]):
     """
     alerts_str = s3.download(key(day, v3=True), "utf8")
     alerts = json.loads(alerts_str)
+    return _filter_by_route(alerts.values(), routes)
 
-    def matches_route(alert):
-        """Checks whether an alert applies to any of the target routes.
 
-        Args:
-            alert (dict): A single alert object.
+def get_lamp_alerts(day: date, routes: list[str]):
+    """Downloads and filters LAMP-derived alerts from S3 for a given day and set of routes.
 
-        Returns:
-            bool: True if the alert affects at least one route in ``routes``,
-            or True if ``routes`` is None (no filter applied).
-        """
-        if not routes:
-            return True
-        targets = routes_for_alert(alert)
-        return any(r in targets for r in routes)
+    The file is v3-JSON:API-shaped (a dict of alert id -> object with an
+    ``attributes`` key), identical to get_v3_alerts, so it shares the same
+    filtering logic and routes_for_alert branch.
 
-    return list(filter(matches_route, alerts.values()))
+    Args:
+        day (date): The date for which to retrieve alerts.
+        routes (list[str]): Route IDs to filter by.
+
+    Returns:
+        list[dict]: Alerts derived from LAMP that affect at least one of the given routes.
+    """
+    alerts_str = s3.download(lamp_key(day), "utf8")
+    alerts = json.loads(alerts_str)
+    return _filter_by_route(alerts.values(), routes)

--- a/server/tests/test_data_funcs_alerts.py
+++ b/server/tests/test_data_funcs_alerts.py
@@ -1,0 +1,96 @@
+"""Tests for data_funcs.alerts — v2/LAMP/v3 dispatch and flattening."""
+
+from datetime import date
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+from chalicelib import data_funcs
+
+
+def _no_such_key_error(operation="GetObject"):
+    return ClientError({"Error": {"Code": "NoSuchKey", "Message": "not found"}}, operation)
+
+
+class TestAlertsDispatch:
+    def test_before_v2_coverage_returns_none(self):
+        assert data_funcs.alerts(date(2016, 1, 1), {}) is None
+
+    def test_v2_range_uses_get_v2_alerts(self):
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_v2_alerts", return_value=[]) as mock_v2:
+            with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts") as mock_lamp:
+                data_funcs.alerts(date(2019, 8, 31), {})
+        mock_v2.assert_called_once()
+        mock_lamp.assert_not_called()
+
+    def test_lamp_range_uses_get_lamp_alerts(self):
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts", return_value=[]) as mock_lamp:
+            with mock.patch("chalicelib.data_funcs.s3_alerts.get_v2_alerts") as mock_v2:
+                data_funcs.alerts(date(2019, 9, 1), {})
+        mock_lamp.assert_called_once()
+        mock_v2.assert_not_called()
+
+    def test_lamp_range_falls_back_to_v3_when_lamp_key_missing(self):
+        # e.g. today, before the daily LAMP rebuild has run yet.
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts", side_effect=_no_such_key_error()):
+            with mock.patch("chalicelib.data_funcs.s3_alerts.get_v3_alerts", return_value=[]) as mock_v3:
+                result = data_funcs.alerts(date.today(), {})
+        mock_v3.assert_called_once()
+        assert result == []
+
+    def test_lamp_range_reraises_non_missing_key_errors(self):
+        other_error = ClientError({"Error": {"Code": "AccessDenied", "Message": "nope"}}, "GetObject")
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts", side_effect=other_error):
+            # alerts() wraps everything in a bare except and returns None -- so the
+            # important thing is that it does NOT silently fall back to v3.
+            with mock.patch("chalicelib.data_funcs.s3_alerts.get_v3_alerts") as mock_v3:
+                result = data_funcs.alerts(date.today(), {})
+        mock_v3.assert_not_called()
+        assert result is None
+
+    def test_v2_lamp_boundary_is_half_open(self):
+        # 2019-08-31 is v2's last day; 2019-09-01 is LAMP's first. Neither source
+        # should be asked to cover the other's day.
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_v2_alerts", return_value=[]) as mock_v2:
+            with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts") as mock_lamp:
+                data_funcs.alerts(date(2019, 9, 1), {})
+        mock_v2.assert_not_called()
+        mock_lamp.assert_called()
+
+
+class TestAlertsFlattening:
+    def test_lamp_shaped_alert_flattens_like_v3(self):
+        # LAMP-derived alerts are v3-JSON:API-shaped, so they should hit the same
+        # "attributes" branch and produce the same {valid_from, valid_to, text} shape.
+        alert = {
+            "id": "1",
+            "attributes": {
+                "effect": "DELAY",
+                "header": "Red Line delays",
+                "short_header": None,
+                "active_period": [{"start": "2026-01-01T00:00:00-05:00", "end": "2026-01-01T01:00:00-05:00"}],
+            },
+        }
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts", return_value=[alert]):
+            result = data_funcs.alerts(date(2026, 1, 1), {})
+        assert result == [
+            {
+                "valid_from": "2026-01-01T00:00:00-05:00",
+                "valid_to": "2026-01-01T01:00:00-05:00",
+                "text": "Red Line delays",
+            }
+        ]
+
+    def test_non_delay_effect_is_excluded(self):
+        alert = {
+            "id": "1",
+            "attributes": {
+                "effect": "ELEVATOR_CLOSURE",
+                "header": "Elevator unavailable",
+                "short_header": None,
+                "active_period": [{"start": "2026-01-01T00:00:00-05:00", "end": None}],
+            },
+        }
+        with mock.patch("chalicelib.data_funcs.s3_alerts.get_lamp_alerts", return_value=[alert]):
+            result = data_funcs.alerts(date(2026, 1, 1), {})
+        assert result == []

--- a/server/tests/test_s3_alerts.py
+++ b/server/tests/test_s3_alerts.py
@@ -1,0 +1,54 @@
+"""Tests for s3_alerts.py — key construction and route filtering."""
+
+from datetime import date
+from unittest import mock
+
+from chalicelib import s3_alerts
+
+
+class TestKeys:
+    def test_v2_key(self):
+        assert s3_alerts.key(date(2020, 1, 1)) == "Alerts/2020-01-01.json.gz"
+
+    def test_v3_key(self):
+        assert s3_alerts.key(date(2020, 1, 1), v3=True) == "Alerts/v3/2020-01-01.json.gz"
+
+    def test_lamp_key(self):
+        assert s3_alerts.lamp_key(date(2020, 1, 1)) == "Alerts/lamp/2020-01-01.json.gz"
+
+
+class TestRoutesForAlert:
+    def test_v3_shaped_alert(self):
+        alert = {"attributes": {"informed_entity": [{"route": "Red"}, {"stop": "place-pktrm"}]}}
+        assert s3_alerts.routes_for_alert(alert) == {"Red"}
+
+    def test_v2_shaped_alert(self):
+        alert = {"alert_versions": [{"informed_entity": [{"route_id": "Orange"}]}]}
+        assert s3_alerts.routes_for_alert(alert) == {"Orange"}
+
+    def test_entity_with_no_route_key_is_ignored(self):
+        # A LAMP-derived alert with no known route (e.g. a facility-only alert)
+        # omits the "route" key entirely rather than setting it null -- confirm
+        # that doesn't add a bare None into the route set.
+        alert = {"attributes": {"informed_entity": [{"stop": "70023"}]}}
+        assert s3_alerts.routes_for_alert(alert) == set()
+
+
+class TestGetLampAlerts:
+    def test_filters_by_route_and_shares_v3_shape(self):
+        payload = (
+            '{"1": {"id": "1", "type": "alert", "attributes": '
+            '{"informed_entity": [{"route": "Red"}]}}, '
+            '"2": {"id": "2", "type": "alert", "attributes": '
+            '{"informed_entity": [{"route": "Orange"}]}}}'
+        )
+        with mock.patch("chalicelib.s3_alerts.s3.download", return_value=payload) as mock_download:
+            result = s3_alerts.get_lamp_alerts(date(2020, 1, 1), ["Red"])
+        mock_download.assert_called_once_with("Alerts/lamp/2020-01-01.json.gz", "utf8")
+        assert [a["id"] for a in result] == ["1"]
+
+    def test_no_route_filter_returns_everything(self):
+        payload = '{"1": {"id": "1", "type": "alert", "attributes": {"informed_entity": []}}}'
+        with mock.patch("chalicelib.s3_alerts.s3.download", return_value=payload):
+            result = s3_alerts.get_lamp_alerts(date(2020, 1, 1), None)
+        assert [a["id"] for a in result] == ["1"]


### PR DESCRIPTION
## Summary

Companion to [transitmatters/mbta-performance#90](https://github.com/transitmatters/mbta-performance/pull/90). Routes historical alert lookups (`GET /api/alerts/{date}`) to mbta-performance's new `Alerts/lamp/{date}.json.gz` files, which are derived from MBTA's LAMP real-time alerts archive rather than a live 15-minute poller — see [transitmatters/data-ingestion#101](https://github.com/transitmatters/data-ingestion/issues/101).

## Changes

- `s3_alerts.py`: adds `lamp_key(day)` and `get_lamp_alerts(day, routes)`. LAMP-derived alerts are v3-JSON:API-shaped (same as the existing `Alerts/v3/` files), so `get_lamp_alerts` shares the route-filtering logic with `get_v3_alerts` via a new `_filter_by_route` helper (extracted from the duplicated closures in `get_v2_alerts`/`get_v3_alerts`).
- `data_funcs.py`: `alerts()` now dispatches to LAMP for any date from **2019-09-01** onward (LAMP's dense-coverage start), falling back to `Alerts/v3/` on a missing key — this covers today and any day the daily LAMP rebuild hasn't published yet. v2 still covers 2017-11-06 through 2019-08-31.
  - Also fixes an existing off-by-one: the old `WE_HAVE_V2_ALERTS_SINCE <= day <= WE_HAVE_V3_ALERTS_SINCE` check double-counted 2024-04-12 (both branches could fire); the boundary is now half-open.
- No changes to the `/api/alerts/{date}` response shape or the live `/api/alerts` endpoint — this is a read-side routing change only.

## Testing

- 16 new tests (`tests/test_s3_alerts.py`, `tests/test_data_funcs_alerts.py`) covering key construction, route filtering (including the null-route-key edge case), the v2/LAMP dispatch boundary, the v3 fallback on a missing LAMP key (and that it does *not* fall back on other S3 errors), and that LAMP-shaped alerts flatten identically to v3-shaped ones.
- `uv run pytest` — 54 passed. `uv run ruff check` / `ruff format --check` clean.
