### PR TITLE
Flag Mattapan as a terminus in stations.json

### DIFF
--- a/common/constants/stations.json
+++ b/common/constants/stations.json
@@ -1597,7 +1597,8 @@
           "0": ["70276"],
           "1": ["70275"]
         },
-        "accessible": true
+        "accessible": true,
+        "terminus": true
       }
     ]
   }


### PR DESCRIPTION
One-line data fix: the Mattapan line's outer terminus was the only terminus in `stations.json` without a `"terminus"` flag. Ashmont at the other end already has one.

## Why now

`slow-zones` forks this file. That repo is switching `is_terminus()` from a hardcoded list of terminus station **names** to this flag — see transitmatters/slow-zones#73 — because the hardcoded list was missing Riverside, which caused Riverside's terminal layover to be folded into the Riverside → Woodland travel time and produced a phantom **496-day, +416%** Green Line slow zone on the dashboard.

`Mattapan` is the one station where the hardcoded list was *ahead* of the JSON, so without this flag the switch would silently regress Mattapan → Capen Street. Fixing it here rather than only in the fork means a future re-copy of this file can't reintroduce the gap.

## Effect on the dashboard

One behavioral change: `TerminusNotice` now shows its "data collection issues at terminus stations" caveat for trips involving Mattapan, the same as it already does for Ashmont. That's correct — Mattapan has the same terminal data-collection problem.

`update_stations.py` only writes the `accessible` / `enclosed_bike_parking` / `pedal_park` fields, so this flag survives a re-run of it.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
